### PR TITLE
ci: pin nextest version to 0.9.98

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install latest cargo-nextest release
         uses: taiki-e/install-action@92f69c195229fe62d58b4d697ab4bc75def98e76 # v2.52.7
         with:
-          tool: nextest
+          tool: nextest@0.9.98
 
       - name: Rust cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2


### PR DESCRIPTION
See https://github.com/alpenlabs/alpen/pull/892
