### PR TITLE
Array Conversion for `FixedVector` and Module Structure Painpoints

### DIFF
--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1,0 +1,182 @@
+pub mod test_1 {
+    use ssz_types::*;
+    use ssz_derive::{Encode, Decode};
+    use tree_hash::TreeHashDigest;
+    use tree_hash_derive::TreeHash;
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum AliasOptionUnion {
+        Selector0(u8),
+        Selector1(Option<u16>),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum FirstUnion {
+        Selector0(u8),
+        Selector1(u16),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum TestUnion {
+        Selector0,
+        Selector1(u8),
+        Selector2(u16),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum UnionA {
+        Selector0(u8),
+        Selector1(u8),
+        Selector2(u16),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum UnionB {
+        Selector0(u8),
+        Selector1(UnionA),
+        Selector2(u32),
+        Selector3(VariableList<u8, 12usize>),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum UnionC {
+        Selector0(AliasUintAlias),
+        Selector1(AliasUintAlias),
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(enum_behaviour = "union")]
+    #[tree_hash(enum_behaviour = "union")]
+    pub enum UnionD {
+        Selector0(AliasUintAlias),
+        Selector1(AliasUintAlias),
+    }
+    pub const VAL_X: u64 = 42u64;
+    pub const VAL_Y: u64 = 64u64;
+    pub const SIZE_ALIAS: u64 = 64u64;
+    pub type AliasUintAlias = u16;
+    pub type AliasVecA = FixedVector<u8, 10usize>;
+    pub type AliasVecB = AliasVecA;
+    pub type AliasListAlias = VariableList<u8, 5usize>;
+    pub type AliasNested = AliasUintAlias;
+    pub type BitAlias = BitList<42usize>;
+    pub type UnionE = UnionD;
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Alpha {
+        pub a: u8,
+        pub b: u16,
+        pub c: AliasVecB,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Beta {
+        pub d: AliasListAlias,
+        pub e: u8,
+        pub f: AliasUintAlias,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+    #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+    pub struct Gamma {
+        pub g: Optional<u8>,
+        pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Delta {
+        pub z: bool,
+        pub w: u8,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+    #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+    pub struct Epsilon {
+        pub g: Optional<u8>,
+        pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+        pub i: Optional<u8>,
+        pub j: Optional<AliasNested>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
+    #[tree_hash(struct_behaviour = "stable_container", max_fields = 128usize)]
+    pub struct Zeta {
+        pub u: Optional<FixedVector<u8, 16usize>>,
+        pub v: Optional<AliasListAlias>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct TestType {
+        pub ccc: u8,
+        pub ddd: u8,
+        pub eee: VariableList<u16, 3usize>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Eta {
+        pub l: Zeta,
+        pub m: TestType,
+        pub n: FirstUnion,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Theta {
+        pub o: UnionB,
+        pub p: UnionC,
+        pub q: AliasVecA,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+    #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+    pub struct Iota {
+        pub g: Optional<u8>,
+        pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+        pub i: Optional<u8>,
+        pub j: Optional<AliasNested>,
+        pub r: Optional<VariableList<AliasNested, 2usize>>,
+        pub s: Optional<u8>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Kappa {
+        pub t: Alpha,
+        pub u: Beta,
+        pub v: BitVector<64usize>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
+    #[tree_hash(struct_behaviour = "stable_container", max_fields = 4usize)]
+    pub struct Lambda {
+        pub w: Optional<u16>,
+        pub x: Optional<u8>,
+    }
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Mu {
+        pub y: Lambda,
+        pub z: UnionA,
+    }
+    pub type AliasMu = Mu;
+    #[derive(Encode, Decode, TreeHash)]
+    #[ssz(struct_behaviour = "container")]
+    #[tree_hash(struct_behaviour = "container")]
+    pub struct Nu {
+        pub zz: AliasMu,
+        pub aaa: FixedVector<bool, 4usize>,
+        pub bbb: BitAlias,
+        pub test: Option<AliasMu>,
+    }
+}

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1,0 +1,180 @@
+use ssz_types::*;
+use ssz_derive::{Encode, Decode};
+use tree_hash::TreeHashDigest;
+use tree_hash_derive::TreeHash;
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum AliasOptionUnion {
+    Selector0(u8),
+    Selector1(Option<u16>),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum FirstUnion {
+    Selector0(u8),
+    Selector1(u16),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum TestUnion {
+    Selector0,
+    Selector1(u8),
+    Selector2(u16),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum UnionA {
+    Selector0(u8),
+    Selector1(u8),
+    Selector2(u16),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum UnionB {
+    Selector0(u8),
+    Selector1(UnionA),
+    Selector2(u32),
+    Selector3(VariableList<u8, 12usize>),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum UnionC {
+    Selector0(AliasUintAlias),
+    Selector1(AliasUintAlias),
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(enum_behaviour = "union")]
+#[tree_hash(enum_behaviour = "union")]
+pub enum UnionD {
+    Selector0(AliasUintAlias),
+    Selector1(AliasUintAlias),
+}
+pub const VAL_X: u64 = 42u64;
+pub const VAL_Y: u64 = 64u64;
+pub const SIZE_ALIAS: u64 = 64u64;
+pub type AliasUintAlias = u16;
+pub type AliasVecA = FixedVector<u8, 10usize>;
+pub type AliasVecB = AliasVecA;
+pub type AliasListAlias = VariableList<u8, 5usize>;
+pub type AliasNested = AliasUintAlias;
+pub type BitAlias = BitList<42usize>;
+pub type UnionE = UnionD;
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Alpha {
+    pub a: u8,
+    pub b: u16,
+    pub c: AliasVecB,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Beta {
+    pub d: AliasListAlias,
+    pub e: u8,
+    pub f: AliasUintAlias,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+#[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+pub struct Gamma {
+    pub g: Optional<u8>,
+    pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Delta {
+    pub z: bool,
+    pub w: u8,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+#[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+pub struct Epsilon {
+    pub g: Optional<u8>,
+    pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+    pub i: Optional<u8>,
+    pub j: Optional<AliasNested>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
+#[tree_hash(struct_behaviour = "stable_container", max_fields = 128usize)]
+pub struct Zeta {
+    pub u: Optional<FixedVector<u8, 16usize>>,
+    pub v: Optional<AliasListAlias>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct TestType {
+    pub ccc: u8,
+    pub ddd: u8,
+    pub eee: VariableList<u16, 3usize>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Eta {
+    pub l: Zeta,
+    pub m: TestType,
+    pub n: FirstUnion,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Theta {
+    pub o: UnionB,
+    pub p: UnionC,
+    pub q: AliasVecA,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
+#[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
+pub struct Iota {
+    pub g: Optional<u8>,
+    pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+    pub i: Optional<u8>,
+    pub j: Optional<AliasNested>,
+    pub r: Optional<VariableList<AliasNested, 2usize>>,
+    pub s: Optional<u8>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Kappa {
+    pub t: Alpha,
+    pub u: Beta,
+    pub v: BitVector<64usize>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
+#[tree_hash(struct_behaviour = "stable_container", max_fields = 4usize)]
+pub struct Lambda {
+    pub w: Optional<u16>,
+    pub x: Optional<u8>,
+}
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Mu {
+    pub y: Lambda,
+    pub z: UnionA,
+}
+pub type AliasMu = Mu;
+#[derive(Encode, Decode, TreeHash)]
+#[ssz(struct_behaviour = "container")]
+#[tree_hash(struct_behaviour = "container")]
+pub struct Nu {
+    pub zz: AliasMu,
+    pub aaa: FixedVector<bool, 4usize>,
+    pub bbb: BitAlias,
+    pub test: Option<AliasMu>,
+}

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -11,7 +11,7 @@ use syn as _;
 use tree_hash as _;
 use tree_hash_derive as _;
 
-use ssz_codegen::build_ssz_files;
+use ssz_codegen::{ModuleGeneration, build_ssz_files};
 use std::fs;
 
 #[test]
@@ -286,4 +286,72 @@ fn test_profile_field_order() {
         None,
     )
     .expect("This should panic due to field order in profile");
+}
+
+#[test]
+fn test_single_module_generation() {
+    build_ssz_files(
+        &["test_1.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_single_module.rs",
+        Some(ModuleGeneration::SingleModule),
+    )
+    .expect("Failed to generate SSZ types with SingleModule");
+
+    let expected_output = fs::read_to_string("tests/expected_output/test_single_module.rs")
+        .expect("Failed to read expected single module output");
+    let actual_output = fs::read_to_string("tests/output/test_single_module.rs")
+        .expect("Failed to read actual single module output");
+
+    assert_eq!(expected_output.trim(), actual_output.trim());
+}
+
+#[test]
+fn test_flat_modules_generation() {
+    build_ssz_files(
+        &["test_1.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_flat_modules.rs",
+        Some(ModuleGeneration::FlatModules),
+    )
+    .expect("Failed to generate SSZ types with FlatModules");
+
+    let expected_output = fs::read_to_string("tests/expected_output/test_flat_modules.rs")
+        .expect("Failed to read expected flat modules output");
+    let actual_output = fs::read_to_string("tests/output/test_flat_modules.rs")
+        .expect("Failed to read actual flat modules output");
+
+    assert_eq!(expected_output.trim(), actual_output.trim());
+}
+
+#[test]
+fn test_nested_modules_is_default() {
+    // Test that None defaults to NestedModules
+    build_ssz_files(
+        &["test_1.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_default_nested.rs",
+        None,
+    )
+    .expect("Failed to generate SSZ types with default");
+
+    build_ssz_files(
+        &["test_1.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_explicit_nested.rs",
+        Some(ModuleGeneration::NestedModules),
+    )
+    .expect("Failed to generate SSZ types with explicit NestedModules");
+
+    let default_output = fs::read_to_string("tests/output/test_default_nested.rs")
+        .expect("Failed to read default output");
+    let explicit_output = fs::read_to_string("tests/output/test_explicit_nested.rs")
+        .expect("Failed to read explicit nested output");
+
+    // They should be identical
+    assert_eq!(default_output.trim(), explicit_output.trim());
 }

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -21,6 +21,7 @@ fn test_basic_codegen() {
         "tests/input",
         &[],
         "tests/output/test_1.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -38,6 +39,7 @@ fn test_profile() {
         "tests/input",
         &[],
         "tests/output/test_2.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -55,6 +57,7 @@ fn test_imports() {
         "tests/input",
         &[],
         "tests/output/test_import.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -72,6 +75,7 @@ fn test_large_unions() {
         "tests/input",
         &[],
         "tests/output/test_large_unions.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -89,6 +93,7 @@ fn test_nested_aliases() {
         "tests/input",
         &[],
         "tests/output/test_nested_aliases.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -106,6 +111,7 @@ fn test_bitfields() {
         "tests/input",
         &[],
         "tests/output/test_bitfields.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -123,6 +129,7 @@ fn test_union_edge_cases() {
         "tests/input",
         &[],
         "tests/output/test_union_edge_cases.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -140,6 +147,7 @@ fn test_external_import() {
         "tests/input",
         &["external_ssz"],
         "tests/output/test_external.rs",
+        None,
     )
     .expect("Failed to generate SSZ types");
 
@@ -158,6 +166,7 @@ fn test_circular_dep() {
         "tests/input",
         &[],
         "tests/output/test_circular_dep.rs",
+        None,
     )
     .expect("This should panic due to circular dependency");
 }
@@ -170,6 +179,7 @@ fn test_unknown_import_item() {
         "tests/input",
         &[],
         "tests/output/test_unknown_import_item.rs",
+        None,
     )
     .expect("This should panic due to unknown import item");
 }
@@ -182,6 +192,7 @@ fn test_duplicate_field_name() {
         "tests/input",
         &[],
         "tests/output/test_duplicate_field_name.rs",
+        None,
     )
     .expect("This should panic due to duplicate field name");
 }
@@ -194,6 +205,7 @@ fn test_duplicate_item_name() {
         "tests/input",
         &[],
         "tests/output/test_duplicate_item_name.rs",
+        None,
     )
     .expect("This should panic due to duplicate item name");
 }
@@ -206,6 +218,7 @@ fn test_optional_field_container() {
         "tests/input",
         &[],
         "tests/output/test_optional_field_container.rs",
+        None,
     )
     .expect("This should panic due to optional field in container");
 }
@@ -218,6 +231,7 @@ fn test_stable_container_without_optional() {
         "tests/input",
         &[],
         "tests/output/test_stable_container_without_optional.rs",
+        None,
     )
     .expect("This should panic due to stable container without optional");
 }
@@ -230,6 +244,7 @@ fn test_union_null_position() {
         "tests/input",
         &[],
         "tests/output/test_union_null_position.rs",
+        None,
     )
     .expect("This should panic due to none not being first in union");
 }
@@ -242,6 +257,7 @@ fn test_anon_union() {
         "tests/input",
         &[],
         "tests/output/test_anon_union.rs",
+        None,
     )
     .expect("This should panic due to anonymous union");
 }
@@ -254,6 +270,7 @@ fn test_profile_new_fields() {
         "tests/input",
         &[],
         "tests/output/test_profile_new_fields.rs",
+        None,
     )
     .expect("This should panic due to new fields in profile");
 }
@@ -266,6 +283,7 @@ fn test_profile_field_order() {
         "tests/input",
         &[],
         "tests/output/test_profile_field_order.rs",
+        None,
     )
     .expect("This should panic due to field order in profile");
 }

--- a/crates/ssz_types/src/fixed_vector.rs
+++ b/crates/ssz_types/src/fixed_vector.rs
@@ -109,6 +109,20 @@ impl<T: Default, const N: usize> From<Vec<T>> for FixedVector<T, N> {
     }
 }
 
+impl<T, const N: usize> From<[T; N]> for FixedVector<T, N> {
+    fn from(array: [T; N]) -> Self {
+        Self { vec: array.into() }
+    }
+}
+
+impl<T: Clone, const N: usize> From<&[T; N]> for FixedVector<T, N> {
+    fn from(array: &[T; N]) -> Self {
+        Self {
+            vec: array.to_vec(),
+        }
+    }
+}
+
 impl<T, const N: usize> From<FixedVector<T, N>> for Vec<T> {
     fn from(vector: FixedVector<T, N>) -> Vec<T> {
         vector.vec
@@ -573,5 +587,27 @@ mod test {
         let json = serde_json::json!([1, 2, 3, 4]);
         let result: Result<FixedVector<u64, 4>, _> = serde_json::from_value(json);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn from_array() {
+        let array = [1u64, 2, 3, 4];
+        let fixed: FixedVector<u64, 4> = FixedVector::from(array);
+        assert_eq!(&fixed[..], &[1, 2, 3, 4]);
+
+        let array = [42u64; 8];
+        let fixed: FixedVector<u64, 8> = FixedVector::from(array);
+        assert_eq!(&fixed[..], &[42; 8]);
+    }
+
+    #[test]
+    fn from_array_ref() {
+        let array = &[1u64, 2, 3, 4];
+        let fixed: FixedVector<u64, 4> = FixedVector::from(array);
+        assert_eq!(&fixed[..], &[1, 2, 3, 4]);
+
+        let array = &[42u64; 8];
+        let fixed: FixedVector<u64, 8> = FixedVector::from(array);
+        assert_eq!(&fixed[..], &[42; 8]);
     }
 }


### PR DESCRIPTION
## Description

Addresses module structure painpoints and adds missing array conversion for `FixedVector`.

- **Removed deep module nesting**: Added `ModuleGeneration` enum with `SingleModule`, `FlatModules`, and `NestedModules` options
- **Added flexible module generation**: Extended `build_ssz_files()` to accept optional generation mode
- **Implemented `From<[T; N]>`**: Added convenient array conversion for `FixedVector<T, N>`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

All changes maintain backward compatibility. Default behavior is preserved (`NestedModules`). New functionality is opt-in via optional parameter.

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

STR-1725.
