### PR TITLE
fix!: feature-gate serde

### DIFF
--- a/crates/ssz/Cargo.toml
+++ b/crates/ssz/Cargo.toml
@@ -22,14 +22,17 @@ name = "ssz"
 ssz_derive.workspace = true
 serde_json.workspace = true
 ssz_primitives = { workspace = true, features = ["rand"] }
+serde.workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-hex.workspace = true
+hex = { workspace = true, optional = true }
 itertools.workspace = true
-serde.workspace = true
+serde = { workspace = true, optional = true }
 smallvec.workspace = true
 ssz_primitives.workspace = true
 
 [features]
+default = []
 arbitrary = ["dep:arbitrary"]
+serde = ["dep:serde", "dep:hex"]

--- a/crates/ssz/src/bitfield.rs
+++ b/crates/ssz/src/bitfield.rs
@@ -3,10 +3,13 @@
 
 //! Bitfield implementation
 
+#[cfg(feature = "serde")]
 use crate::serde_utils::hex::{PrefixedHexVisitor, encode as hex_encode};
 use crate::{Decode, DecodeError, Encode};
 use core::marker::PhantomData;
+#[cfg(feature = "serde")]
 use serde::de::{Deserialize, Deserializer};
+#[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
 use smallvec::{SmallVec, ToSmallVec, smallvec};
 
@@ -642,6 +645,7 @@ impl<const N: usize> Decode for Bitfield<Fixed<N>> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<const N: usize> Serialize for Bitfield<Variable<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -652,6 +656,7 @@ impl<const N: usize> Serialize for Bitfield<Variable<N>> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, const N: usize> Deserialize<'de> for Bitfield<Variable<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -664,6 +669,7 @@ impl<'de, const N: usize> Deserialize<'de> for Bitfield<Variable<N>> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<const N: usize> Serialize for Bitfield<Fixed<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -674,6 +680,7 @@ impl<const N: usize> Serialize for Bitfield<Fixed<N>> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, const N: usize> Deserialize<'de> for Bitfield<Fixed<N>> {
     /// Serde serialization is compliant with the Ethereum YAML test format.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/ssz/src/bitfield/bitvector_dynamic.rs
+++ b/crates/ssz/src/bitfield/bitvector_dynamic.rs
@@ -3,13 +3,16 @@
 
 //! Provides `Bitfield<Dynamic>` (BitVectorDynamic)
 /// for encoding and decoding bitvectors that have a dynamic length.
+#[cfg(feature = "serde")]
 use crate::serde_utils::hex::{PrefixedHexVisitor, encode as hex_encode};
 use crate::{
     Decode, DecodeError, Encode,
     bitfield::{Bitfield, BitfieldBehaviour, Error, SMALLVEC_LEN, bytes_for_bit_len},
 };
 use core::marker::PhantomData;
+#[cfg(feature = "serde")]
 use serde::de::{Deserialize, Deserializer};
+#[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
 use smallvec::{SmallVec, ToSmallVec, smallvec};
 
@@ -121,6 +124,7 @@ impl Decode for Bitfield<Dynamic> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for Bitfield<Dynamic> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -130,6 +134,7 @@ impl Serialize for Bitfield<Dynamic> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Bitfield<Dynamic> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -485,6 +490,7 @@ mod roundtrip_tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_serde_roundtrip() -> Result<(), Error> {
         use serde_json::de::Deserializer as json_deserializer;
         use serde_json::ser::Serializer as json_serializer;

--- a/crates/ssz/src/lib.rs
+++ b/crates/ssz/src/lib.rs
@@ -42,6 +42,7 @@ pub mod decode;
 pub mod encode;
 pub mod legacy;
 /// Serde utilities for SSZ types.
+#[cfg(feature = "serde")]
 pub mod serde_utils;
 mod union_selector;
 

--- a/crates/ssz_types/Cargo.toml
+++ b/crates/ssz_types/Cargo.toml
@@ -17,9 +17,9 @@ workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-itertools.workspace = true
-serde.workspace = true
-serde_derive.workspace = true
+itertools = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 ssz.workspace = true
 ssz_primitives.workspace = true
 tree_hash.workspace = true
@@ -27,3 +27,8 @@ tree_hash.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 tree_hash_derive.workspace = true
+ssz = { workspace = true, features = ["serde"] }
+
+[features]
+default = []
+serde = ["dep:serde", "dep:serde_derive", "dep:itertools", "ssz/serde"]

--- a/crates/ssz_types/src/fixed_vector.rs
+++ b/crates/ssz_types/src/fixed_vector.rs
@@ -3,7 +3,9 @@
 
 use crate::Error;
 use crate::tree_hash::vec_tree_hash_root;
+#[cfg(feature = "serde")]
 use serde::Deserialize;
+#[cfg(feature = "serde")]
 use serde_derive::Serialize;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::slice::SliceIndex;
@@ -42,8 +44,9 @@ use std::slice::SliceIndex;
 /// let long: FixedVector<_, 5> = FixedVector::from(base);
 /// assert_eq!(&long[..], &[1, 2, 3, 4, 0]);
 /// ```
-#[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct FixedVector<T, const N: usize> {
     vec: Vec<T>,
 }
@@ -338,6 +341,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T, const N: usize> Deserialize<'de> for FixedVector<T, N>
 where
     T: Deserialize<'de>,
@@ -575,7 +579,10 @@ mod test {
         assert_eq!(hashset.len(), 2);
     }
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_invalid_length() {
+        use serde_json;
+
         let json = serde_json::json!([1, 2, 3, 4, 5]);
         let result: Result<FixedVector<u64, 4>, _> = serde_json::from_value(json);
         assert!(result.is_err());

--- a/crates/ssz_types/src/lib.rs
+++ b/crates/ssz_types/src/lib.rs
@@ -43,9 +43,13 @@
 #[macro_use]
 mod fixed_vector;
 mod optional;
+#[cfg(feature = "serde")]
 pub mod serde_utils;
 mod tree_hash;
 mod variable_list;
+
+#[cfg(any(test, doctest))]
+use serde_json as _;
 
 pub use fixed_vector::FixedVector;
 pub use optional::Optional;

--- a/crates/ssz_types/src/optional.rs
+++ b/crates/ssz_types/src/optional.rs
@@ -1,6 +1,7 @@
 // Modified in 2025 from the original version
 // Original source licensed under the Apache License 2.0
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use tree_hash::Hash256;
 
@@ -164,6 +165,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T> Serialize for Optional<T>
 where
     T: Serialize,
@@ -179,6 +181,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Optional<T>
 where
     T: Deserialize<'de>,
@@ -245,7 +248,10 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde() {
+        use serde_json;
+
         let json = serde_json::json!(null);
         let result: Result<Optional<u64>, _> = serde_json::from_value(json);
         assert!(result.is_ok());

--- a/crates/ssz_types/src/variable_list.rs
+++ b/crates/ssz_types/src/variable_list.rs
@@ -3,7 +3,9 @@
 
 use crate::Error;
 use crate::tree_hash::vec_tree_hash_root;
+#[cfg(feature = "serde")]
 use serde::Deserialize;
+#[cfg(feature = "serde")]
 use serde_derive::Serialize;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::slice::SliceIndex;
@@ -44,8 +46,9 @@ use std::slice::SliceIndex;
 /// // Push a value to if it _does_ exceed the maximum.
 /// assert!(long.push(6).is_err());
 /// ```
-#[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct VariableList<T, const N: usize> {
     vec: Vec<T>,
 }
@@ -297,6 +300,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T, const N: usize> Deserialize<'de> for VariableList<T, N>
 where
     T: Deserialize<'de>,
@@ -593,7 +597,10 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_invalid_length() {
+        use serde_json;
+
         let json = serde_json::json!([1, 2, 3, 4, 5]);
         let result: Result<VariableList<u64, 4>, _> = serde_json::from_value(json);
         assert!(result.is_err());


### PR DESCRIPTION
## Description

`serde` is used for debug/API purposes, not in-protocol serialization.

We should feature-gate it in `ssz-gen`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1604
