### PR TITLE
fix: prevent duplicate definitions when entry points import each other

### DIFF
--- a/crates/sizzle-parser/src/pipeline.rs
+++ b/crates/sizzle-parser/src/pipeline.rs
@@ -51,8 +51,11 @@ pub fn parse_str_schema(
 
         // TODO: Inserts at positon 0 in Vec, it's ok for now since we don't expect too many imports
         // but if it becomes a bottleneck we can fix it.
-        module_manager.add_module_to_front(path.clone());
-        ast::parse_module_from_toktrs(&toktrs, path, &mut module_manager)?;
+        // Only parse if the module hasn't been added yet (e.g., by an import from another entry
+        // point)
+        if module_manager.add_module_to_front(path.clone()) {
+            ast::parse_module_from_toktrs(&toktrs, path, &mut module_manager)?;
+        }
     }
 
     let mut schema_map = HashMap::new();

--- a/crates/ssz_codegen/tests/input/test_circular_a.ssz
+++ b/crates/ssz_codegen/tests/input/test_circular_a.ssz
@@ -1,0 +1,8 @@
+import test_circular_b as b
+
+CONST_A = 10
+
+class ContainerA(Container):
+    value: uint8
+    b_ref: b.ContainerB
+

--- a/crates/ssz_codegen/tests/input/test_circular_b.ssz
+++ b/crates/ssz_codegen/tests/input/test_circular_b.ssz
@@ -1,0 +1,8 @@
+import test_circular_a as a
+
+CONST_B = 20
+
+class ContainerB(Container):
+    value: uint16
+    a_ref: a.ContainerA
+

--- a/crates/ssz_codegen/tests/input/test_cross_entry_state.ssz
+++ b/crates/ssz_codegen/tests/input/test_cross_entry_state.ssz
@@ -1,0 +1,6 @@
+MAX_VK_BYTES = 48
+
+class State(Container):
+    data: Vector[uint8, MAX_VK_BYTES]
+    counter: uint64
+

--- a/crates/ssz_codegen/tests/input/test_cross_entry_update.ssz
+++ b/crates/ssz_codegen/tests/input/test_cross_entry_update.ssz
@@ -1,0 +1,9 @@
+import test_cross_entry_state as state
+
+MAX_UPDATES = 10
+
+class Update(Container):
+    state: state.State
+    timestamp: uint64
+    updates: List[uint8, MAX_UPDATES]
+

--- a/crates/ssz_codegen/tests/input/test_three_way_a.ssz
+++ b/crates/ssz_codegen/tests/input/test_three_way_a.ssz
@@ -1,0 +1,8 @@
+import test_three_way_b as b
+
+CONST_A = 100
+
+class ContainerA(Container):
+    value: uint8
+    b_ref: b.ContainerB
+

--- a/crates/ssz_codegen/tests/input/test_three_way_b.ssz
+++ b/crates/ssz_codegen/tests/input/test_three_way_b.ssz
@@ -1,0 +1,8 @@
+import test_three_way_c as c
+
+CONST_B = 200
+
+class ContainerB(Container):
+    value: uint16
+    c_ref: c.ContainerC
+

--- a/crates/ssz_codegen/tests/input/test_three_way_c.ssz
+++ b/crates/ssz_codegen/tests/input/test_three_way_c.ssz
@@ -1,0 +1,5 @@
+CONST_C = 300
+
+class ContainerC(Container):
+    value: uint32
+


### PR DESCRIPTION
## Description

When an entry point SSZ file imports another entry point, the imported
module was being parsed twice, causing duplicate constant and type
definitions. Now checks if a module is already parsed before adding it.

- Skip re-parsing already-added modules in sizzle-parser pipeline
- Track entry points vs dependencies in codegen for proper filtering
- Add tests for cross-module dependencies in all generation modes


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues


