### PR TITLE
fix: external import resolution and path generation

### DIFF
--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -193,7 +193,7 @@ fn test_external_type_ref_variants() {
     // Test that external container types use Ref variants in view getters,
     // while primitive-like types use the type itself
     build_ssz_files(
-        &["test_external.ssz"],
+        &["test_external_ref_variants.ssz"],
         "tests/input",
         &["external_ssz"],
         "tests/output/test_external_ref_variants.rs",
@@ -204,12 +204,21 @@ fn test_external_type_ref_variants() {
     let output = fs::read_to_string("tests/output/test_external_ref_variants.rs")
         .expect("Failed to read output");
 
-    // Verify that ExternalContainerRef uses Ref variants for external types
-    // The exact pattern depends on what external_ssz types are, but we should
-    // see that view getters return Result<external_ssz::..., DecodeError>
+    // Verify that container types use Ref variants
     assert!(
-        output.contains("Result<external_ssz::") || output.contains("external_ssz::"),
-        "External types should be referenced correctly in view getters"
+        output.contains("MsgPayloadRef") || output.contains("Result<external_ssz::MsgPayloadRef"),
+        "Container type MsgPayload should use Ref variant in view getters"
+    );
+    assert!(
+        output.contains("MessagePayloadRef")
+            || output.contains("Result<external_ssz::MessagePayloadRef"),
+        "Container type MessagePayload in List should use Ref variant"
+    );
+
+    // Verify that primitive-like types use the type itself, not Ref variant
+    assert!(
+        output.contains("Result<external_ssz::AccountId") && !output.contains("AccountIdRef"),
+        "Primitive-like type AccountId should use the type itself, not Ref variant"
     );
 }
 


### PR DESCRIPTION
## Description

Fix: External Import Resolution and Path Generation

This PR fixes several issues related to external module imports and path 
generation in SSZ code generation:

1. **Pre-register external modules** - Fixes UnknownImport errors by 
   registering external modules in cross_module_types before schema conversion
   occurs, ensuring external types are available when needed.

2. **Fix external crate path construction** - Uses PathBuf::from() directly 
   for external crates instead of PathBuf::new().join(), ensuring correct 
   path construction (e.g., "external_ssz" instead of "./external_ssz").

3. **Fix local type path generation** - Converts crate::ssz:: paths to 
   super:: for locally generated types in both to_view_type_inner() and 
   unwrap_type(), ensuring generated code correctly references sibling 
   modules within the ssz module.

4. **External type Ref variant heuristic** - Uses heuristic to determine 
   when external types need Ref variants: container types (ending with 
   "Payload", "Message", "State", "Proof", "Claim") use Ref variants, 
   while primitive-like types use the type itself.

These fixes resolve issues encountered when generating SSZ types for 
snark-acct-types that imports types from strata_acct_types.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
