### PR TITLE
fix: to_owned() generation for Vector[byte, N] types

### DIFF
--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -896,7 +896,9 @@ pub mod tests {
                     Alpha {
                         a: self.a().expect("valid view"),
                         b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view").to_owned().expect("valid view"),
+                        c: ssz_types::FixedBytes(
+                            self.c().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
@@ -2541,7 +2543,9 @@ pub mod tests {
                     Theta {
                         o: self.o().expect("valid view").to_owned(),
                         p: self.p().expect("valid view").to_owned(),
-                        q: self.q().expect("valid view").to_owned().expect("valid view"),
+                        q: ssz_types::FixedBytes(
+                            self.q().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -7,7 +7,6 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[ssz(struct_behaviour = "container")]
-#[tree_hash(struct_behaviour = "container")]
 pub struct ExportEntry {
     pub value: u64,
     pub data: u32,
@@ -135,7 +134,6 @@ impl<'a> ExportEntryRef<'a> {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[ssz(struct_behaviour = "container")]
-#[tree_hash(struct_behaviour = "container")]
 pub struct ExportContainer {
     pub entries: VariableList<ExportEntry, 4096usize>,
     pub name: u32,

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -725,19 +725,54 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const SIZE_ALIAS: u64 = 64u64;
             pub type AliasUintAlias = u16;
-            pub type AliasVecA = FixedVector<u8, 10usize>;
+            pub type AliasVecA = FixedBytes<10usize>;
             pub type AliasVecB = AliasVecA;
             pub type AliasListAlias = VariableList<u8, 5usize>;
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<42usize>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
                 pub b: u16,
                 pub c: AliasVecB,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Alpha {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.a)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.b)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.c)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Alpha`].
             ///
@@ -775,9 +810,7 @@ pub mod tests {
                     let bytes = &self.bytes[offset..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn c(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 3usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -863,17 +896,54 @@ pub mod tests {
                     Alpha {
                         a: self.a().expect("valid view"),
                         b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view").to_owned().expect("valid view"),
+                        c: ssz_types::FixedBytes(
+                            self.c().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
                 pub e: u8,
                 pub f: AliasUintAlias,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Beta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.d)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.e)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.f)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Beta`].
             ///
@@ -1027,12 +1097,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Gamma {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Gamma`].
             ///
@@ -1173,12 +1298,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
                 pub w: u8,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Delta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.w)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Delta`].
             ///
@@ -1286,14 +1440,101 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
                 pub i: Optional<u8>,
                 pub j: Optional<AliasNested>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Epsilon {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Epsilon`].
             ///
@@ -1488,12 +1729,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
-                pub u: Optional<FixedVector<u8, 16usize>>,
+                pub u: Optional<FixedBytes<16usize>>,
                 pub v: Optional<AliasListAlias>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Zeta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<128u64>::new();
+                    if self.u.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.v.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(128usize);
+                    if let Some(ref u) = self.u {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(u).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref v) = self.v {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(v).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Zeta`].
             ///
@@ -1509,10 +1805,7 @@ pub mod tests {
             impl<'a> ZetaRef<'a> {
                 pub fn u(
                     &self,
-                ) -> Result<
-                    Optional<FixedVectorRef<'a, u8, 16usize>>,
-                    ssz::DecodeError,
-                > {
+                ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
                     let bitvector_offset = 1usize;
                     let container_bytes = &self.bytes[bitvector_offset..];
                     let start = ssz::layout::read_variable_offset(
@@ -1634,13 +1927,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
                 pub ddd: u8,
                 pub eee: VariableList<u16, 3usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for TestType {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ccc)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ddd)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.eee)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`TestType`].
             ///
@@ -1800,13 +2128,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
                 pub m: TestType,
                 pub n: FirstUnion,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Eta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.l)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.m)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.n)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Eta`].
             ///
@@ -1978,13 +2341,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
                 pub p: UnionC,
                 pub q: AliasVecA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Theta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.o)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.p)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.q)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Theta`].
             ///
@@ -2036,9 +2434,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn q(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 8usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -2147,13 +2543,14 @@ pub mod tests {
                     Theta {
                         o: self.o().expect("valid view").to_owned(),
                         p: self.p().expect("valid view").to_owned(),
-                        q: self.q().expect("valid view").to_owned().expect("valid view"),
+                        q: ssz_types::FixedBytes(
+                            self.q().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
@@ -2161,6 +2558,126 @@ pub mod tests {
                 pub j: Optional<AliasNested>,
                 pub r: Optional<VariableList<AliasNested, 2usize>>,
                 pub s: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Iota {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.r.is_some() {
+                        active_fields
+                            .set(4usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.s.is_some() {
+                        active_fields
+                            .set(5usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref r) = self.r {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(r).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref s) = self.s {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(s).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Iota`].
             ///
@@ -2414,13 +2931,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
                 pub u: Beta,
                 pub v: BitVector<64usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Kappa {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.t)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.u)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.v)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Kappa`].
             ///
@@ -2585,12 +3137,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
                 pub x: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Lambda {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<4u64>::new();
+                    if self.w.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.x.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    if let Some(ref w) = self.w {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(w).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref x) = self.x {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(x).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Lambda`].
             ///
@@ -2726,12 +3333,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
                 pub z: UnionA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Mu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.y)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Mu`].
             ///
@@ -2876,14 +3512,55 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
                 pub aaa: FixedVector<bool, 4usize>,
                 pub bbb: BitAlias,
                 pub test: Option<AliasMu>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Nu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.zz)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.aaa)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.bbb)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.test)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Nu`].
             ///
@@ -2897,7 +3574,7 @@ pub mod tests {
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
-                pub fn zz(&self) -> Result<MuRef<'a>, ssz::DecodeError> {
+                pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,
@@ -2949,7 +3626,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn test(&self) -> Result<Option<MuRef<'a>>, ssz::DecodeError> {
+                pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -725,19 +725,54 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const SIZE_ALIAS: u64 = 64u64;
             pub type AliasUintAlias = u16;
-            pub type AliasVecA = FixedVector<u8, 10usize>;
+            pub type AliasVecA = FixedBytes<10usize>;
             pub type AliasVecB = AliasVecA;
             pub type AliasListAlias = VariableList<u8, 5usize>;
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<42usize>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
                 pub b: u16,
                 pub c: AliasVecB,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Alpha {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.a)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.b)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.c)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Alpha`].
             ///
@@ -775,9 +810,7 @@ pub mod tests {
                     let bytes = &self.bytes[offset..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn c(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 3usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -863,17 +896,54 @@ pub mod tests {
                     Alpha {
                         a: self.a().expect("valid view"),
                         b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view").to_owned().expect("valid view"),
+                        c: ssz_types::FixedBytes(
+                            self.c().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
                 pub e: u8,
                 pub f: AliasUintAlias,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Beta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.d)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.e)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.f)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Beta`].
             ///
@@ -1027,12 +1097,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Gamma {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Gamma`].
             ///
@@ -1173,12 +1298,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
                 pub w: u8,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Delta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.w)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Delta`].
             ///
@@ -1286,14 +1440,101 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
                 pub i: Optional<u8>,
                 pub j: Optional<AliasNested>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Epsilon {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Epsilon`].
             ///
@@ -1488,12 +1729,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
-                pub u: Optional<FixedVector<u8, 16usize>>,
+                pub u: Optional<FixedBytes<16usize>>,
                 pub v: Optional<AliasListAlias>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Zeta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<128u64>::new();
+                    if self.u.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.v.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(128usize);
+                    if let Some(ref u) = self.u {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(u).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref v) = self.v {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(v).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Zeta`].
             ///
@@ -1509,10 +1805,7 @@ pub mod tests {
             impl<'a> ZetaRef<'a> {
                 pub fn u(
                     &self,
-                ) -> Result<
-                    Optional<FixedVectorRef<'a, u8, 16usize>>,
-                    ssz::DecodeError,
-                > {
+                ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
                     let bitvector_offset = 1usize;
                     let container_bytes = &self.bytes[bitvector_offset..];
                     let start = ssz::layout::read_variable_offset(
@@ -1634,13 +1927,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
                 pub ddd: u8,
                 pub eee: VariableList<u16, 3usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for TestType {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ccc)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ddd)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.eee)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`TestType`].
             ///
@@ -1800,13 +2128,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
                 pub m: TestType,
                 pub n: FirstUnion,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Eta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.l)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.m)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.n)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Eta`].
             ///
@@ -1978,13 +2341,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
                 pub p: UnionC,
                 pub q: AliasVecA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Theta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.o)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.p)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.q)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Theta`].
             ///
@@ -2036,9 +2434,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn q(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 8usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -2147,13 +2543,14 @@ pub mod tests {
                     Theta {
                         o: self.o().expect("valid view").to_owned(),
                         p: self.p().expect("valid view").to_owned(),
-                        q: self.q().expect("valid view").to_owned().expect("valid view"),
+                        q: ssz_types::FixedBytes(
+                            self.q().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
@@ -2161,6 +2558,126 @@ pub mod tests {
                 pub j: Optional<AliasNested>,
                 pub r: Optional<VariableList<AliasNested, 2usize>>,
                 pub s: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Iota {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.r.is_some() {
+                        active_fields
+                            .set(4usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.s.is_some() {
+                        active_fields
+                            .set(5usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref r) = self.r {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(r).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref s) = self.s {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(s).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Iota`].
             ///
@@ -2414,13 +2931,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
                 pub u: Beta,
                 pub v: BitVector<64usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Kappa {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.t)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.u)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.v)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Kappa`].
             ///
@@ -2585,12 +3137,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
                 pub x: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Lambda {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<4u64>::new();
+                    if self.w.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.x.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    if let Some(ref w) = self.w {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(w).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref x) = self.x {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(x).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Lambda`].
             ///
@@ -2726,12 +3333,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
                 pub z: UnionA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Mu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.y)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Mu`].
             ///
@@ -2876,14 +3512,55 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
                 pub aaa: FixedVector<bool, 4usize>,
                 pub bbb: BitAlias,
                 pub test: Option<AliasMu>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Nu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.zz)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.aaa)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.bbb)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.test)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Nu`].
             ///
@@ -2897,7 +3574,7 @@ pub mod tests {
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
-                pub fn zz(&self) -> Result<MuRef<'a>, ssz::DecodeError> {
+                pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,
@@ -2949,7 +3626,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn test(&self) -> Result<Option<MuRef<'a>>, ssz::DecodeError> {
+                pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -725,19 +725,54 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const SIZE_ALIAS: u64 = 64u64;
             pub type AliasUintAlias = u16;
-            pub type AliasVecA = FixedVector<u8, 10usize>;
+            pub type AliasVecA = FixedBytes<10usize>;
             pub type AliasVecB = AliasVecA;
             pub type AliasListAlias = VariableList<u8, 5usize>;
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<42usize>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
                 pub b: u16,
                 pub c: AliasVecB,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Alpha {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.a)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.b)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.c)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Alpha`].
             ///
@@ -775,9 +810,7 @@ pub mod tests {
                     let bytes = &self.bytes[offset..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn c(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 3usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -863,17 +896,54 @@ pub mod tests {
                     Alpha {
                         a: self.a().expect("valid view"),
                         b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view").to_owned().expect("valid view"),
+                        c: ssz_types::FixedBytes(
+                            self.c().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
                 pub e: u8,
                 pub f: AliasUintAlias,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Beta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.d)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.e)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.f)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Beta`].
             ///
@@ -1027,12 +1097,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Gamma {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Gamma`].
             ///
@@ -1173,12 +1298,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
                 pub w: u8,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Delta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.w)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Delta`].
             ///
@@ -1286,14 +1440,101 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
                 pub i: Optional<u8>,
                 pub j: Optional<AliasNested>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Epsilon {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Epsilon`].
             ///
@@ -1488,12 +1729,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
-                pub u: Optional<FixedVector<u8, 16usize>>,
+                pub u: Optional<FixedBytes<16usize>>,
                 pub v: Optional<AliasListAlias>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Zeta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<128u64>::new();
+                    if self.u.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.v.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(128usize);
+                    if let Some(ref u) = self.u {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(u).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref v) = self.v {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(v).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Zeta`].
             ///
@@ -1509,10 +1805,7 @@ pub mod tests {
             impl<'a> ZetaRef<'a> {
                 pub fn u(
                     &self,
-                ) -> Result<
-                    Optional<FixedVectorRef<'a, u8, 16usize>>,
-                    ssz::DecodeError,
-                > {
+                ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
                     let bitvector_offset = 1usize;
                     let container_bytes = &self.bytes[bitvector_offset..];
                     let start = ssz::layout::read_variable_offset(
@@ -1634,13 +1927,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
                 pub ddd: u8,
                 pub eee: VariableList<u16, 3usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for TestType {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ccc)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.ddd)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.eee)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`TestType`].
             ///
@@ -1800,13 +2128,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
                 pub m: TestType,
                 pub n: FirstUnion,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Eta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.l)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.m)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.n)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Eta`].
             ///
@@ -1978,13 +2341,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
                 pub p: UnionC,
                 pub q: AliasVecA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Theta {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.o)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.p)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.q)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Theta`].
             ///
@@ -2036,9 +2434,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn q(
-                    &self,
-                ) -> Result<FixedVectorRef<'a, u8, 10usize>, ssz::DecodeError> {
+                pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let offset = 8usize;
                     let end = offset + 10usize;
                     if end > self.bytes.len() {
@@ -2147,13 +2543,14 @@ pub mod tests {
                     Theta {
                         o: self.o().expect("valid view").to_owned(),
                         p: self.p().expect("valid view").to_owned(),
-                        q: self.q().expect("valid view").to_owned().expect("valid view"),
+                        q: ssz_types::FixedBytes(
+                            self.q().expect("valid view").to_owned(),
+                        ),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
                 pub h: Optional<VariableList<AliasUintAlias, 8usize>>,
@@ -2161,6 +2558,126 @@ pub mod tests {
                 pub j: Optional<AliasNested>,
                 pub r: Optional<VariableList<AliasNested, 2usize>>,
                 pub s: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Iota {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<42u64>::new();
+                    if self.g.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.h.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.i.is_some() {
+                        active_fields
+                            .set(2usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.j.is_some() {
+                        active_fields
+                            .set(3usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.r.is_some() {
+                        active_fields
+                            .set(4usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.s.is_some() {
+                        active_fields
+                            .set(5usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(42usize);
+                    if let Some(ref g) = self.g {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(g).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref h) = self.h {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(h).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref i) = self.i {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(i).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref j) = self.j {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(j).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref r) = self.r {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(r).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref s) = self.s {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(s).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Iota`].
             ///
@@ -2414,13 +2931,48 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
                 pub u: Beta,
                 pub v: BitVector<64usize>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Kappa {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.t)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.u)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.v)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Kappa`].
             ///
@@ -2585,12 +3137,67 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
-            #[tree_hash(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
                 pub x: Optional<u8>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Lambda {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("StableContainer/Profile should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    use ssz_types::BitVector;
+                    let mut active_fields = BitVector::<4u64>::new();
+                    if self.w.is_some() {
+                        active_fields
+                            .set(0usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    if self.x.is_some() {
+                        active_fields
+                            .set(1usize, true)
+                            .expect("Should not be out of bounds");
+                    }
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    if let Some(ref w) = self.w {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(w).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    if let Some(ref x) = self.x {
+                        hasher
+                            .write(
+                                <_ as tree_hash::TreeHash<H>>::tree_hash_root(x).as_ref(),
+                            )
+                            .expect("tree hash derive should not apply too many leaves");
+                    } else {
+                        hasher
+                            .write(H::get_zero_hash_slice(0))
+                            .expect("tree hash derive should not apply too many leaves");
+                    }
+                    let hash = hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer");
+                    let active_fields_hash = <_ as tree_hash::TreeHash<
+                        H,
+                    >>::tree_hash_root(&active_fields);
+                    H::hash32_concat(hash.as_ref(), active_fields_hash.as_ref())
+                }
             }
             /// Zero-copy view over [`Lambda`].
             ///
@@ -2726,12 +3333,41 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
                 pub z: UnionA,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Mu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.y)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.z)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Mu`].
             ///
@@ -2876,14 +3512,55 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TreeHash)]
+            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
-            #[tree_hash(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
                 pub aaa: FixedVector<bool, 4usize>,
                 pub bbb: BitAlias,
                 pub test: Option<AliasMu>,
+            }
+            impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Nu {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.zz)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.aaa)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.bbb)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash<H>>::tree_hash_root(&self.test)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
             }
             /// Zero-copy view over [`Nu`].
             ///
@@ -2897,7 +3574,7 @@ pub mod tests {
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
-                pub fn zz(&self) -> Result<MuRef<'a>, ssz::DecodeError> {
+                pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,
@@ -2949,7 +3626,7 @@ pub mod tests {
                     let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
-                pub fn test(&self) -> Result<Option<MuRef<'a>>, ssz::DecodeError> {
+                pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let start = ssz::layout::read_variable_offset(
                         self.bytes,
                         16usize,

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -818,7 +818,7 @@ pub mod test_1 {
             Alpha {
                 a: self.a().expect("valid view"),
                 b: self.b().expect("valid view"),
-                c: self.c().expect("valid view").to_owned().expect("valid view"),
+                c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
             }
         }
     }
@@ -2311,7 +2311,7 @@ pub mod test_1 {
             Theta {
                 o: self.o().expect("valid view").to_owned(),
                 p: self.p().expect("valid view").to_owned(),
-                q: self.q().expect("valid view").to_owned().expect("valid view"),
+                q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
             }
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -777,7 +777,7 @@ impl<'a> AlphaRef<'a> {
         Alpha {
             a: self.a().expect("valid view"),
             b: self.b().expect("valid view"),
-            c: self.c().expect("valid view").to_owned().expect("valid view"),
+            c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
         }
     }
 }
@@ -2248,7 +2248,7 @@ impl<'a> ThetaRef<'a> {
         Theta {
             o: self.o().expect("valid view").to_owned(),
             p: self.p().expect("valid view").to_owned(),
-            q: self.q().expect("valid view").to_owned().expect("valid view"),
+            q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -7,7 +7,6 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[ssz(struct_behaviour = "container")]
-#[tree_hash(struct_behaviour = "container")]
 pub struct ExportEntry {
     pub key: u32,
     pub value: u64,
@@ -135,11 +134,10 @@ impl<'a> ExportEntryRef<'a> {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[ssz(struct_behaviour = "container")]
-#[tree_hash(struct_behaviour = "container")]
 pub struct ViewTypeTest {
     pub payload: VariableList<u8, 4096usize>,
     pub entries: VariableList<ExportEntry, 256usize>,
-    pub hash: FixedVector<u8, 32usize>,
+    pub hash: FixedBytes<32usize>,
 }
 impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ViewTypeTest {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -218,7 +216,7 @@ impl<'a> ViewTypeTestRef<'a> {
         let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
-    pub fn hash(&self) -> Result<FixedVectorRef<'a, u8, 32usize>, ssz::DecodeError> {
+    pub fn hash(&self) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
         let offset = 8usize;
         let end = offset + 32usize;
         if end > self.bytes.len() {
@@ -315,7 +313,7 @@ impl<'a> ViewTypeTestRef<'a> {
         ViewTypeTest {
             payload: self.payload().expect("valid view").to_owned().into(),
             entries: self.entries().expect("valid view").to_owned().expect("valid view"),
-            hash: self.hash().expect("valid view").to_owned().expect("valid view"),
+            hash: ssz_types::FixedBytes(self.hash().expect("valid view").to_owned()),
         }
     }
 }


### PR DESCRIPTION
## Description

**Problem**
When generating `to_owned()` methods for container types containing `Vector[byte, N]` fields (which map to `FixedBytesRef`), the generated code was calling `.to_owned()` directly on the result. However, `FixedBytesRef::to_owned()` returns `[u8; N]`, while the struct field expects `FixedBytes<N>` (a newtype wrapper).
This caused compilation errors like:
```
error[E0308]: mismatched types
   expected `FixedBytes<32>`, found `[u8; 32]`
```

**Solution**
Updated the code generation logic in `to_view_to_owned_impl()` to detect `Vector[byte, N]` types and wrap the result in `ssz_types::FixedBytes(self.#field_name().expect("valid view").to_owned())`
This ensures the generated code correctly converts `FixedBytesRef` to the expected `FixedBytes<N>` type.

This PR was created with help from Cursor AI.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
