### PR TITLE
dependabot: increase cooldown to 2 weeks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: "00:00"
     # Cooldown
     cooldown:
-      default-days: 5
+      default-days: 14
     # Group all updates into a single PR
     groups:
       all-dependencies:
@@ -32,7 +32,7 @@ updates:
       time: "00:00"
     # Cooldown
     cooldown:
-      default-days: 5
+      default-days: 14
     # Group non-security updates
     groups:
       rust-dependencies:


### PR DESCRIPTION
## Description

Increases dependabot cooldown to a more conservative 2 weeks.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Discussed with the security team at Alpen Labs.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-1827

