### PR TITLE
feat: preserve constant names in generated type parameters

### DIFF
--- a/crates/sizzle-parser/src/schema.rs
+++ b/crates/sizzle-parser/src/schema.rs
@@ -266,6 +266,17 @@ pub(crate) fn conv_module_to_schema<'a>(
                             value: v,
                         })
                     }
+                    TyExpr::ConstRef(_id, value) => {
+                        // Resolve constant reference to its concrete value
+                        let const_value = ConstValue::Int(value);
+                        resolver.decl_const(name.clone(), const_value.clone())?;
+
+                        idents.insert(name.clone(), IdentTarget::Const(const_value.clone()));
+                        constants.push(ConstDef {
+                            name: name.clone(),
+                            value: const_value,
+                        })
+                    }
                     TyExpr::None => panic!("schema: assignment to None"),
                 },
 
@@ -277,6 +288,9 @@ pub(crate) fn conv_module_to_schema<'a>(
                         TyExpr::Ty(ty) => ty,
                         TyExpr::Int(_) => {
                             panic!("schema: resolver generated int for complex tyspec")
+                        }
+                        TyExpr::ConstRef(_, _) => {
+                            panic!("schema: resolver generated const ref for complex tyspec")
                         }
                         TyExpr::None => {
                             panic!("schema: resolver generated None for complex tyspec")

--- a/crates/sizzle-parser/src/tysys.rs
+++ b/crates/sizzle-parser/src/tysys.rs
@@ -17,11 +17,18 @@ pub enum TyExpr {
     /// A type.
     Ty(Ty),
 
-    /// A value, possibly resolved from a const.
+    /// A concrete value expression.
     ///
     /// This isn't a normal type, but it's valid and we can resolve to it from
     /// things that look like types and then would proceed to error from that.
     Int(ConstValue),
+
+    /// A reference to a named constant.
+    ///
+    /// This preserves the constant identifier for codegen purposes while also
+    /// storing the evaluated value. The identifier is kept as an unresolved
+    /// reference that codegen can resolve to the appropriate constant name.
+    ConstRef(Identifier, u64),
 }
 
 impl TyExpr {
@@ -40,6 +47,7 @@ impl TyExpr {
         // FIXME I couldn't figure out how to make this no-alloc.
         let idents = match self {
             TyExpr::Ty(t) => t.iter_idents().collect::<Vec<_>>(),
+            TyExpr::ConstRef(id, _) => vec![id],
             TyExpr::Int(_) | TyExpr::None => Vec::new(),
         };
 

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1004,7 +1004,7 @@ pub mod tests {
             pub type AliasVecB = AliasVecA;
             pub type AliasListAlias = VariableList<u8, 5usize>;
             pub type AliasNested = AliasUintAlias;
-            pub type BitAlias = BitList<42usize>;
+            pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
             #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -18,12 +18,12 @@ pub mod tests {
             pub const LARGE_SIZE: u64 = 256u64;
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const POWER_OF_TWO: u64 = 128u64;
-            pub type TinyBitlist = BitList<1usize>;
-            pub type StandardBitlist = BitList<64usize>;
-            pub type LargeBitlist = BitList<256usize>;
-            pub type TinyBitvector = BitVector<1usize>;
-            pub type StandardBitvector = BitVector<64usize>;
-            pub type LargeBitvector = BitVector<128usize>;
+            pub type TinyBitlist = BitList<{ SMALL_SIZE as usize }>;
+            pub type StandardBitlist = BitList<{ MEDIUM_SIZE as usize }>;
+            pub type LargeBitlist = BitList<{ LARGE_SIZE as usize }>;
+            pub type TinyBitvector = BitVector<{ SMALL_SIZE as usize }>;
+            pub type StandardBitvector = BitVector<{ MEDIUM_SIZE as usize }>;
+            pub type LargeBitvector = BitVector<{ POWER_OF_TWO as usize }>;
             #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct BitfieldContainer {

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -866,7 +866,7 @@ pub mod test_1 {
     pub type AliasVecB = AliasVecA;
     pub type AliasListAlias = VariableList<u8, 5usize>;
     pub type AliasNested = AliasUintAlias;
-    pub type BitAlias = BitList<42usize>;
+    pub type BitAlias = BitList<{ VAL_X as usize }>;
     pub type UnionE = UnionD;
     #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
     #[ssz(struct_behaviour = "container")]

--- a/crates/ssz_codegen/tests/expected_output/test_import.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_import.rs
@@ -507,7 +507,7 @@ pub mod tests {
             >;
             pub type AliasListImportedConstant = VariableList<
                 crate::tests::input::test_common::AliasUint8,
-                5usize,
+                { CONSTANT_VALUE_IMPORTED as usize },
             >;
             pub type AliasClassStableContainer = crate::tests::input::test_common::StableContainerClass;
             pub type AliasUint8 = crate::tests::input::test_common::AliasUint8;

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -21,8 +21,11 @@ pub mod tests {
             pub type C = B;
             pub type D = VariableList<C, 10usize>;
             pub type E = FixedVector<D, 5usize>;
-            pub type F = VariableList<A, 10usize>;
-            pub type G = FixedVector<F, 10usize>;
+            pub type F = VariableList<A, { SIZE_3 as usize }>;
+            pub type G = FixedVector<
+                VariableList<A, { SIZE_3 as usize }>,
+                { SIZE_1 as usize },
+            >;
             #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct NestedAliasContainer {

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -849,7 +849,7 @@ pub type AliasVecA = FixedBytes<10usize>;
 pub type AliasVecB = AliasVecA;
 pub type AliasListAlias = VariableList<u8, 5usize>;
 pub type AliasNested = AliasUintAlias;
-pub type BitAlias = BitList<42usize>;
+pub type BitAlias = BitList<{ VAL_X as usize }>;
 pub type UnionE = UnionD;
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 #[ssz(struct_behaviour = "container")]


### PR DESCRIPTION
## Description

### Problem
SSZ schemas using constants as type parameters lost semantic meaning in generated Rust code:
```
// Input: Vector[uint8, MAX_VK_BYTES] where MAX_VK_BYTES = 48
pub data: FixedVector<u8, 48usize>,  // ❌ Lost constant name
```

### Solution
Preserve constant names in generated code:
```
pub const MAX_VK_BYTES: u64 = 48u64;
pub data: FixedVector<u8, { MAX_VK_BYTES as usize }>,  // ✅ Preserves meaning
```

### Implementation:
Extended parser to track constant references (`TyExpr::ConstRef`)
Added `SizeExpr` enum to store literal or constant reference
Modified `TypeResolver` to preserve constant info via original_args
Added `unwrap_type_preserving_const_names()` for codegen
Applies to: `Vector, List, Bitvector, Bitlist`

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers


## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
