### PR TITLE
feat(parser): accept tokens up to end and handle final newline cases

### DIFF
--- a/crates/sizzle-parser/src/gobbler.rs
+++ b/crates/sizzle-parser/src/gobbler.rs
@@ -99,6 +99,8 @@ impl<'b, T> Gobbler<'b, T> {
     /// The returned slice does not contain the entry that satisfied the
     /// condition.  The `.get()` entry will be the entry that satisfied the
     /// condition.
+    #[deprecated(note = "use gobble_slice_up_to_or_end instead")]
+    #[expect(dead_code, reason = "deprecated")]
     pub(crate) fn gobble_slice_up_to(&mut self, cond: impl Fn(&T) -> bool) -> Option<&[T]> {
         let start = self.at;
 
@@ -114,6 +116,31 @@ impl<'b, T> Gobbler<'b, T> {
 
         self.at = start;
         None
+    }
+
+    /// Scans forwards until finding an entry satisfying a condition. Gobbles
+    /// those entries and returns a slice over those entries. If we reach the
+    /// end of the entries without finding a satisfying entry, returns all
+    /// remaining entries from the start position to the end.
+    ///
+    /// The returned slice does not contain the entry that satisfied the
+    /// condition (if found).  The `.get()` entry will be the entry that satisfied
+    /// the condition, or `None` if we reached the end.
+    pub(crate) fn gobble_slice_up_to_or_end(&mut self, cond: impl Fn(&T) -> bool) -> &[T] {
+        let start = self.at;
+
+        while self.has_entry() {
+            let e = self.get_expect();
+
+            if cond(e) {
+                return &self.buf[start..self.at];
+            }
+
+            self.gobble_one();
+        }
+
+        // Reached the end without finding the condition - return all remaining
+        &self.buf[start..self.at]
     }
 
     /// Gets the item we're currently at.

--- a/crates/sizzle-parser/src/pipeline.rs
+++ b/crates/sizzle-parser/src/pipeline.rs
@@ -269,4 +269,68 @@ TestB = mod_b.TypeB
             "External crate paths should be constructed correctly and not cause UnknownImport"
         );
     }
+
+    #[test]
+    fn test_schema_without_trailing_newline() {
+        // Test that parsing works when the file doesn't end with a newline
+        // This was causing an infinite loop in parse_class_body
+        const SCHEMA: &str = "class Point2d(Container):\n  x_coord: uint32\n  y_coord: uint32";
+
+        let files = HashMap::from([(Path::new("test.ssz").to_path_buf(), SCHEMA.to_string())]);
+
+        let result = parse_str_schema(&files, &[]);
+        assert!(
+            result.is_ok(),
+            "Schema without trailing newline should parse successfully"
+        );
+    }
+
+    #[test]
+    fn test_assignment_without_trailing_newline() {
+        // Test that parsing works when an assignment doesn't end with a newline
+        const SCHEMA: &str = "MyAlias = uint32";
+
+        let files = HashMap::from([(Path::new("test.ssz").to_path_buf(), SCHEMA.to_string())]);
+
+        let result = parse_str_schema(&files, &[]);
+        assert!(
+            result.is_ok(),
+            "Assignment without trailing newline should parse successfully"
+        );
+    }
+
+    #[test]
+    fn test_import_without_trailing_newline() {
+        // Test that parsing works when an import doesn't end with a newline
+        const SCHEMA: &str = "import ssz_external";
+
+        let files = HashMap::from([(Path::new("test.ssz").to_path_buf(), SCHEMA.to_string())]);
+
+        let result = parse_str_schema(&files, &["ssz_external"]);
+        assert!(
+            result.is_ok(),
+            "Import without trailing newline should parse successfully"
+        );
+    }
+
+    #[test]
+    fn test_complex_schema_without_trailing_newline() {
+        // Test a more complex schema without trailing newline
+        const SCHEMA: &str = r"
+Epoch = uint32
+SomeVec = List[Epoch, 1337]
+
+class Header(Container):
+    slot: uint64
+    epoch: Epoch
+    vec: SomeVec";
+
+        let files = HashMap::from([(Path::new("test.ssz").to_path_buf(), SCHEMA.to_string())]);
+
+        let result = parse_str_schema(&files, &[]);
+        assert!(
+            result.is_ok(),
+            "Complex schema without trailing newline should parse successfully"
+        );
+    }
 }

--- a/crates/sizzle-parser/src/token.rs
+++ b/crates/sizzle-parser/src/token.rs
@@ -610,4 +610,17 @@ mod tests {
 
         eprintln!("{toks:#?}");
     }
+
+    #[test]
+    fn test_parse_without_trailing_newline() {
+        // Test that parsing works when file doesn't end with newline
+        let s = "class Point(Container):\n  x_pos: int32\n  y_pos: int32";
+
+        let chars = s.chars().collect::<Vec<_>>();
+
+        let toks =
+            parse_char_array_to_tokens(&chars).expect("test: invoke parse_char_array_to_tokens");
+
+        eprintln!("{toks:#?}");
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-09-01"
+channel = "nightly-2025-11-01"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
## Description

Change gobbler behavior to use `gobble_slice_up_to_or_end` so parsing does not fail when a file ends without a trailing newline.

Replace patterns matching `Some([...])` with direct slice patterns `[...]` and handle empty slices (`[]`) as end-of-input or consecutive newlines. Remove explicit `gobble_until` calls were unnecessary. Fixes cases where:

- assignment expressions at EOF previously returned `UnexpectedEnd`;
- docstring and field parsing failed when the last line lacked a  newline; - unexpected token handling at end-of-file was noisy.
- Add a test program (`test_no_newline.rs`) that parses a schema with and without a trailing newline to verify the fixes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Also bumps the nightly version to match `alpen` and other `alpenlabs` repos.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #41.
