### PR TITLE
feat(ssz-derive): auto-detect newtype structs as transparent

### DIFF
--- a/crates/ssz_derive/tests/tests.rs
+++ b/crates/ssz_derive/tests/tests.rs
@@ -470,3 +470,38 @@ fn optional_option_u64() {
         &[1, 4, 0, 0, 0, 1, 2],
     );
 }
+
+// Test auto-detection of newtype pattern (single-field tuple struct)
+#[derive(PartialEq, Debug, Encode, Decode)]
+struct AutoDetectedNewtype(Vec<u8>);
+
+#[test]
+fn auto_detected_newtype() {
+    // Should work without explicit #[ssz(struct_behaviour = "transparent")]
+    assert_encode_decode(
+        &AutoDetectedNewtype(vec![42_u8]),
+        &vec![42_u8].as_ssz_bytes(),
+    );
+}
+
+#[derive(PartialEq, Debug, Encode, Decode)]
+struct AutoDetectedNewtypeFixed(u8);
+
+#[test]
+fn auto_detected_newtype_fixed() {
+    // Should work for fixed-size types too
+    assert_encode_decode(&AutoDetectedNewtypeFixed(42), &[42]);
+}
+
+#[derive(PartialEq, Debug, Encode, Decode)]
+#[ssz(struct_behaviour = "transparent")]
+struct ExplicitTransparentNewtype(Vec<u8>);
+
+#[test]
+fn explicit_transparent_newtype() {
+    // Explicit transparent should still work
+    assert_encode_decode(
+        &ExplicitTransparentNewtype(vec![42_u8]),
+        &vec![42_u8].as_ssz_bytes(),
+    );
+}


### PR DESCRIPTION
## Description

Detect single-field tuple structs (newtype pattern) as transparent by default when no explicit `#[ssz(struct_behaviour = "...")]` is provided.
Previously, absence of the attribute defaulted all structs to "container".
Now, when a struct has exactly one unnamed field, the derive will treat it as `StructBehaviour::Transparent` automatically.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Added tests covering:

- automatic detection for variable-length newtypes (`Vec<u8>`),
- automatic detection for fixed-size newtypes (`u8`),
- explicit transparent attribute still behaving as before.

Update crate documentation to clarify that transparent behaviour is applied automatically to newtypes and that the attribute is optional for single-field tuple structs.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes #44.
