### PR TITLE
fix!: remove truncating `VariableList` conversions and migrate consumers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
+        run: rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
+        run: rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
@@ -50,9 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
-        with:
-          components: rustfmt
+        run: rustup show
 
       - name: Check Rust formatting
         run: cargo fmt --all --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,4 @@ jobs:
           persist-credentials: false
 
       - name: Upload binary to release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
-
-  # cratesio:
-  #   name: Publish Release to Crates.io
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-  #       with:
-  #         persist-credentials: false
-
-  #     - name: Install Rust toolchain
-  #       uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
-
-  #     - name: Publish to crates.io
-  #       run: cargo publish
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: gh release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@22a6a5b0f9f487c5f5587025ae9d4a1caf2a8a78 # clippy
+        run: rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
+        run: rustup show
 
       - name: Install latest cargo-nextest release
         uses: taiki-e/install-action@3216b6964cbfe053bb8b9a2ef245bd9300e2061d # v2.62.14
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4 # stable
+        run: rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "sizzle-parser"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "thiserror",
 ]
@@ -721,7 +721,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "ssz"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arbitrary",
  "hex",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_derive"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "darling",
  "quote",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_primitives"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -881,7 +881,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree_hash"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "digest",
  "rand 0.8.5",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "darling",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = [
   "Trey Del Bonis <trey@alpenlabs.io>",

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -2275,7 +2275,10 @@ impl ClassDef {
                             let inner = &**ty;
                             if matches!(inner.resolution, TypeResolutionKind::UInt(8)) {
                                 quote! {
-                                    #field_name: self.#field_name().expect("valid view").to_owned().into()
+                                    #field_name: ssz_types::VariableList::new(
+                                        self.#field_name().expect("valid view").to_owned(),
+                                    )
+                                    .expect("valid view")
                                 }
                             } else {
                                 quote! {
@@ -2288,7 +2291,7 @@ impl ClassDef {
                                             })
                                             .collect();
                                         let items = items.expect("valid view");
-                                        ssz_types::VariableList::from(items)
+                                        ssz_types::VariableList::new(items).expect("valid view")
                                     }
                                 }
                             }

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1488,7 +1488,10 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
@@ -2689,7 +2692,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -1102,7 +1102,14 @@ pub mod tests {
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
@@ -1151,7 +1158,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1273,7 +1286,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
@@ -1322,7 +1342,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1462,13 +1488,23 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
@@ -1524,7 +1560,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct GammaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1682,7 +1724,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
@@ -1724,7 +1773,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct DeltaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1824,7 +1879,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
@@ -1900,7 +1962,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EpsilonRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2122,7 +2190,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
                 pub u: Optional<FixedBytes<16usize>>,
@@ -2178,7 +2253,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ZetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2345,7 +2426,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
@@ -2412,7 +2500,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestTypeRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2598,14 +2692,21 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
@@ -2654,7 +2755,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EtaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2827,7 +2934,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
@@ -2876,7 +2990,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ThetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3041,7 +3161,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
@@ -3137,7 +3264,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct IotaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3432,7 +3565,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
@@ -3481,7 +3621,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct KappaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3644,7 +3790,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
@@ -3700,7 +3853,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct LambdaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3849,7 +4008,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
@@ -3891,7 +4057,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct MuRef<'a> {
                 bytes: &'a [u8],
             }
@@ -4034,7 +4206,14 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
@@ -4090,7 +4269,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct NuRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -1120,7 +1120,10 @@ pub mod tests {
                 pub fn to_owned(&self) -> InnerProfile2 {
                     InnerProfile2 {
                         x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view").to_owned().into(),
+                        y: ssz_types::VariableList::new(
+                                self.y().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         z: self.z().expect("valid view").to_owned(),
                     }
                 }
@@ -1715,7 +1718,10 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> InnerProfile4 {
                     InnerProfile4 {
-                        y: self.y().expect("valid view").to_owned().into(),
+                        y: ssz_types::VariableList::new(
+                                self.y().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         z: self.z().expect("valid view").to_owned(),
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 2usize)]
             pub struct Alpha {
                 pub a: Optional<u8>,
@@ -67,7 +74,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -225,7 +238,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 8usize)]
             pub struct InnerBase {
                 pub x: Optional<u8>,
@@ -301,7 +321,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerBaseRef<'a> {
                 bytes: &'a [u8],
             }
@@ -539,7 +565,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct InnerProfile1 {
                 pub x: u8,
@@ -611,7 +644,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerProfile1Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -845,7 +884,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct InnerProfile2 {
                 pub x: Optional<u8>,
@@ -903,7 +949,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerProfile2Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -1068,12 +1120,22 @@ pub mod tests {
                 pub fn to_owned(&self) -> InnerProfile2 {
                     InnerProfile2 {
                         x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view").to_owned().into(),
+                        y: ssz_types::VariableList::new(
+                                self.y().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         z: self.z().expect("valid view").to_owned(),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct AlphaProfile {
                 pub a: u8,
@@ -1125,7 +1187,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaProfileRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1274,7 +1342,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct InnerProfile3 {
                 pub w: AlphaProfile,
@@ -1316,7 +1391,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerProfile3Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -1440,7 +1521,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct InnerProfile4 {
                 pub y: VariableList<u8, 4usize>,
@@ -1488,7 +1576,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerProfile4Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -1624,12 +1718,22 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> InnerProfile4 {
                     InnerProfile4 {
-                        y: self.y().expect("valid view").to_owned().into(),
+                        y: ssz_types::VariableList::new(
+                                self.y().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         z: self.z().expect("valid view").to_owned(),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct InnerProfile5 {
                 pub x: u8,
@@ -1683,7 +1787,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct InnerProfile5Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -1847,7 +1957,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "profile")]
             pub struct ProfileProfile {
                 pub x: Optional<u8>,
@@ -1900,7 +2017,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ProfileProfileRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2052,7 +2175,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 8usize)]
             pub struct ContainerContainer {
                 pub x: Optional<u16>,
@@ -2169,7 +2299,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerContainerRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 9usize)]
             pub struct BitvectorLenTest {
                 pub a: Optional<u8>,
@@ -48,22 +55,11 @@ pub mod tests {
                     if let ssz_types::Optional::Some(ref inner) = self.a {
                         field_roots
                             .push(<_ as tree_hash::TreeHash<H>>::tree_hash_root(inner));
-                    } else {
-                        field_roots.push(H::get_zero_hash(0));
                     }
                     if let ssz_types::Optional::Some(ref inner) = self.b {
                         field_roots
                             .push(<_ as tree_hash::TreeHash<H>>::tree_hash_root(inner));
-                    } else {
-                        field_roots.push(H::get_zero_hash(0));
                     }
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
-                    field_roots.push(H::get_zero_hash(0));
                     let hash = tree_hash::merkleize_progressive_with_hasher::<
                         H,
                     >(&field_roots);
@@ -79,7 +75,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BitvectorLenTestRef<'a> {
                 bytes: &'a [u8],
             }
@@ -161,17 +163,10 @@ pub mod tests {
                     if let ssz_types::Optional::Some(ref inner) = a {
                         field_roots
                             .push(<_ as tree_hash::TreeHash<H>>::tree_hash_root(inner));
-                    } else {
-                        field_roots.push(H::get_zero_hash(0));
                     }
                     if let ssz_types::Optional::Some(ref inner) = b {
                         field_roots
                             .push(<_ as tree_hash::TreeHash<H>>::tree_hash_root(inner));
-                    } else {
-                        field_roots.push(H::get_zero_hash(0));
-                    }
-                    for _ in 2usize..9usize {
-                        field_roots.push(H::get_zero_hash(0));
                     }
                     let hash = tree_hash::merkleize_progressive_with_hasher::<
                         H,

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 9usize)]
             pub struct BitvectorLenTest {
                 pub a: Optional<u8>,
@@ -68,7 +75,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BitvectorLenTestRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -946,7 +946,14 @@ pub type AliasListAlias = VariableList<u8, 5usize>;
 pub type AliasNested = AliasUintAlias;
 pub type BitAlias = BitList<{ VAL_X as usize }>;
 pub type UnionE = UnionD;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Alpha {
     pub a: u8,
@@ -984,7 +991,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Alpha {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct AlphaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1097,7 +1110,14 @@ impl<'a> AlphaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Beta {
     pub d: AliasListAlias,
@@ -1135,7 +1155,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Beta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct BetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1263,13 +1289,21 @@ impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
         Beta {
-            d: self.d().expect("valid view").to_owned().into(),
+            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
+                .expect("valid view"),
             e: self.e().expect("valid view"),
             f: self.f().expect("valid view"),
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Gamma {
     pub g: Optional<u8>,
@@ -1317,7 +1351,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Gamma {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct GammaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1458,7 +1498,14 @@ impl<'a> GammaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Delta {
     pub z: bool,
@@ -1492,7 +1539,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Delta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct DeltaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1585,7 +1638,14 @@ impl<'a> DeltaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Epsilon {
     pub g: Optional<u8>,
@@ -1647,7 +1707,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Epsilon {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct EpsilonRef<'a> {
     bytes: &'a [u8],
 }
@@ -1846,7 +1912,14 @@ impl<'a> EpsilonRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
 pub struct Zeta {
     pub u: Optional<FixedBytes<16usize>>,
@@ -1894,7 +1967,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Zeta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ZetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2042,7 +2121,14 @@ impl<'a> ZetaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct TestType {
     pub ccc: u8,
@@ -2094,7 +2180,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for TestType {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct TestTypeRef<'a> {
     bytes: &'a [u8],
 }
@@ -2268,14 +2360,21 @@ impl<'a> TestTypeRef<'a> {
                     })
                     .collect();
                 let items = items.expect("valid view");
-                ssz_types::VariableList::from(items)
+                ssz_types::VariableList::new(items).expect("valid view")
             },
             large_int_128: self.large_int_128().expect("valid view"),
             large_int_256: self.large_int_256().expect("valid view"),
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Eta {
     pub l: Zeta,
@@ -2313,7 +2412,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Eta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct EtaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2474,7 +2579,14 @@ impl<'a> EtaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Theta {
     pub o: UnionB,
@@ -2512,7 +2624,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Theta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ThetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2663,7 +2781,14 @@ impl<'a> ThetaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Iota {
     pub g: Optional<u8>,
@@ -2739,7 +2864,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Iota {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct IotaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3003,7 +3134,14 @@ impl<'a> IotaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Kappa {
     pub t: Alpha,
@@ -3041,7 +3179,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Kappa {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct KappaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3192,7 +3336,14 @@ impl<'a> KappaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
 pub struct Lambda {
     pub w: Optional<u16>,
@@ -3240,7 +3391,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Lambda {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct LambdaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3374,7 +3531,14 @@ impl<'a> LambdaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Mu {
     pub y: Lambda,
@@ -3408,7 +3572,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Mu {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct MuRef<'a> {
     bytes: &'a [u8],
 }
@@ -3540,7 +3710,14 @@ impl<'a> MuRef<'a> {
     }
 }
 pub type AliasMu = Mu;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Nu {
     pub zz: AliasMu,
@@ -3582,7 +3759,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Nu {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct NuRef<'a> {
     bytes: &'a [u8],
 }

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -6,7 +6,14 @@ use ssz_derive::{Encode, Decode};
 use tree_hash::TreeHashDigest;
 use tree_hash_derive::TreeHash;
 use ssz::view::*;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ExportEntry {
     pub value: u64,
@@ -40,7 +47,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ExportEntry {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ExportEntryRef<'a> {
     bytes: &'a [u8],
 }
@@ -133,7 +146,14 @@ impl<'a> ExportEntryRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ExportContainer {
     pub entries: VariableList<ExportEntry, 4096usize>,
@@ -167,7 +187,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ExportContainer {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ExportContainerRef<'a> {
     bytes: &'a [u8],
 }
@@ -291,7 +317,7 @@ impl<'a> ExportContainerRef<'a> {
                     })
                     .collect();
                 let items = items.expect("valid view");
-                ssz_types::VariableList::from(items)
+                ssz_types::VariableList::new(items).expect("valid view")
             },
             name: self.name().expect("valid view"),
         }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -9,7 +9,14 @@ pub mod test_cross_entry_state {
     use ssz::view::*;
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     pub const MAX_VK_BYTES: u64 = 48u64;
-    #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+    #[derive(
+        std::clone::Clone,
+        std::fmt::Debug,
+        std::cmp::PartialEq,
+        std::cmp::Eq,
+        ssz_derive::Encode,
+        ssz_derive::Decode
+    )]
     #[ssz(struct_behaviour = "container")]
     pub struct State {
         pub data: FixedBytes<48usize>,
@@ -47,7 +54,13 @@ pub mod test_cross_entry_state {
     /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
     /// needed.
     #[allow(dead_code, reason = "generated code using ssz-gen")]
-    #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+    #[derive(
+        std::clone::Clone,
+        std::fmt::Debug,
+        std::cmp::PartialEq,
+        std::cmp::Eq,
+        std::marker::Copy
+    )]
     pub struct StateRef<'a> {
         bytes: &'a [u8],
     }
@@ -154,7 +167,14 @@ pub mod test_cross_entry_update {
     use ssz::view::*;
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     pub const MAX_UPDATES: u64 = 10u64;
-    #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+    #[derive(
+        std::clone::Clone,
+        std::fmt::Debug,
+        std::cmp::PartialEq,
+        std::cmp::Eq,
+        ssz_derive::Encode,
+        ssz_derive::Decode
+    )]
     #[ssz(struct_behaviour = "container")]
     pub struct Update {
         pub state: crate::tests::input::test_cross_entry_state::State,
@@ -199,7 +219,13 @@ pub mod test_cross_entry_update {
     /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
     /// needed.
     #[allow(dead_code, reason = "generated code using ssz-gen")]
-    #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+    #[derive(
+        std::clone::Clone,
+        std::fmt::Debug,
+        std::cmp::PartialEq,
+        std::cmp::Eq,
+        std::marker::Copy
+    )]
     pub struct UpdateRef<'a> {
         bytes: &'a [u8],
     }
@@ -351,7 +377,10 @@ pub mod test_cross_entry_update {
                     ssz_types::view::ToOwnedSsz::to_owned(&view)
                 },
                 timestamp: self.timestamp().expect("valid view"),
-                updates: self.updates().expect("valid view").to_owned().into(),
+                updates: ssz_types::VariableList::new(
+                        self.updates().expect("valid view").to_owned(),
+                    )
+                    .expect("valid view"),
             }
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct CommonTypeA {
                 pub value: u32,
@@ -46,7 +53,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct CommonTypeARef<'a> {
                 bytes: &'a [u8],
             }
@@ -128,7 +141,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct CommonTypeB {
                 pub value: u64,
@@ -163,7 +183,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct CommonTypeBRef<'a> {
                 bytes: &'a [u8],
             }
@@ -255,7 +281,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ContainerA {
                 pub field: crate::tests::input::test_cross_entry_common::CommonTypeA,
@@ -300,7 +333,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerARef<'a> {
                 bytes: &'a [u8],
             }
@@ -460,7 +499,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -13,7 +13,14 @@ pub mod tests {
             use ssz::view::*;
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const MAX_VK_BYTES: u64 = 48u64;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct State {
                 pub data: FixedBytes<48usize>,
@@ -55,7 +62,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct StateRef<'a> {
                 bytes: &'a [u8],
             }
@@ -173,7 +186,14 @@ pub mod tests {
             use ssz::view::*;
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const MAX_UPDATES: u64 = 10u64;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Update {
                 pub state: crate::tests::input::test_cross_entry_state::State,
@@ -224,7 +244,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct UpdateRef<'a> {
                 bytes: &'a [u8],
             }
@@ -385,7 +411,10 @@ pub mod tests {
                             ssz_types::view::ToOwnedSsz::to_owned(&view)
                         },
                         timestamp: self.timestamp().expect("valid view"),
-                        updates: self.updates().expect("valid view").to_owned().into(),
+                        updates: ssz_types::VariableList::new(
+                                self.updates().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                     }
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -8,7 +8,14 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_VK_BYTES: u64 = 48u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct State {
     pub data: FixedBytes<48usize>,
@@ -42,7 +49,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for State {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct StateRef<'a> {
     bytes: &'a [u8],
 }
@@ -139,7 +152,14 @@ impl<'a> StateRef<'a> {
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_UPDATES: u64 = 10u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Update {
     pub state: crate::tests::input::test_cross_entry_state::State,
@@ -179,7 +199,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Update {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct UpdateRef<'a> {
     bytes: &'a [u8],
 }
@@ -326,7 +352,10 @@ impl<'a> UpdateRef<'a> {
                 ssz_types::view::ToOwnedSsz::to_owned(&view)
             },
             timestamp: self.timestamp().expect("valid view"),
-            updates: self.updates().expect("valid view").to_owned().into(),
+            updates: ssz_types::VariableList::new(
+                    self.updates().expect("valid view").to_owned(),
+                )
+                .expect("valid view"),
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -1102,7 +1102,14 @@ pub mod tests {
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
@@ -1151,7 +1158,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1273,7 +1286,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
@@ -1322,7 +1342,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1462,13 +1488,23 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
@@ -1524,7 +1560,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct GammaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1682,7 +1724,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
@@ -1724,7 +1773,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct DeltaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1824,7 +1879,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
@@ -1900,7 +1962,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EpsilonRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2122,7 +2190,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
                 pub u: Optional<FixedBytes<16usize>>,
@@ -2178,7 +2253,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ZetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2345,7 +2426,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
@@ -2412,7 +2500,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestTypeRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2598,14 +2692,21 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
@@ -2654,7 +2755,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EtaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2827,7 +2934,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
@@ -2876,7 +2990,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ThetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3041,7 +3161,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
@@ -3137,7 +3264,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct IotaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3432,7 +3565,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
@@ -3481,7 +3621,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct KappaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3644,7 +3790,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
@@ -3700,7 +3853,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct LambdaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3849,7 +4008,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
@@ -3891,7 +4057,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct MuRef<'a> {
                 bytes: &'a [u8],
             }
@@ -4034,7 +4206,14 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
@@ -4090,7 +4269,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct NuRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -1102,7 +1102,14 @@ pub mod tests {
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
@@ -1151,7 +1158,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1273,7 +1286,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
@@ -1322,7 +1342,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1462,13 +1488,23 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
@@ -1524,7 +1560,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct GammaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1682,7 +1724,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
@@ -1724,7 +1773,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct DeltaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1824,7 +1879,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
@@ -1900,7 +1962,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EpsilonRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2122,7 +2190,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
                 pub u: Optional<FixedBytes<16usize>>,
@@ -2178,7 +2253,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ZetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2345,7 +2426,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
@@ -2412,7 +2500,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestTypeRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2598,14 +2692,21 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
@@ -2654,7 +2755,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EtaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2827,7 +2934,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
@@ -2876,7 +2990,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ThetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3041,7 +3161,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
@@ -3137,7 +3264,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct IotaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3432,7 +3565,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
@@ -3481,7 +3621,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct KappaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3644,7 +3790,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
@@ -3700,7 +3853,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct LambdaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3849,7 +4008,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
@@ -3891,7 +4057,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct MuRef<'a> {
                 bytes: &'a [u8],
             }
@@ -4034,7 +4206,14 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
@@ -4090,7 +4269,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct NuRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -1102,7 +1102,7 @@ pub mod tests {
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
-            #[derive(Eq, Clone, Encode, Decode)]
+            #[derive(Eq, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
@@ -1151,7 +1151,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Eq, Copy, Clone)]
+            #[derive(Eq, std::marker::Copy, std::clone::Clone)]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1273,7 +1273,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
@@ -1322,7 +1322,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct BetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1462,13 +1462,16 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
@@ -1524,7 +1527,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct GammaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1682,7 +1685,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
@@ -1724,7 +1727,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct DeltaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1824,7 +1827,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
@@ -1900,7 +1903,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct EpsilonRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2122,7 +2125,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
                 pub u: Optional<FixedBytes<16usize>>,
@@ -2178,7 +2181,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct ZetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2345,7 +2348,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
@@ -2412,7 +2415,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct TestTypeRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2598,14 +2601,14 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
@@ -2654,7 +2657,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct EtaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2827,7 +2830,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
@@ -2876,7 +2879,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct ThetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3041,7 +3044,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
@@ -3137,7 +3140,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct IotaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3432,7 +3435,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
@@ -3481,7 +3484,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct KappaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3644,7 +3647,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
@@ -3700,7 +3703,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct LambdaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3849,7 +3852,7 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
@@ -3891,7 +3894,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct MuRef<'a> {
                 bytes: &'a [u8],
             }
@@ -4034,7 +4037,7 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Debug, Clone, Encode, Decode)]
+            #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
             #[ssz(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
@@ -4090,7 +4093,7 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, std::marker::Copy, std::clone::Clone)]
             pub struct NuRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -12,7 +12,14 @@ pub mod tests {
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
             /// Type A that imports base
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TypeA {
                 pub base: crate::tests::input::test_multi_import_base::BaseType,
@@ -54,7 +61,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TypeARef<'a> {
                 bytes: &'a [u8],
             }
@@ -201,7 +214,14 @@ pub mod tests {
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
             /// Type B that imports both base and a
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TypeB {
                 pub base: crate::tests::input::test_multi_import_base::BaseType,
@@ -250,7 +270,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TypeBRef<'a> {
                 bytes: &'a [u8],
             }
@@ -432,7 +458,14 @@ pub mod tests {
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
             /// Base type shared by multiple importers
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct BaseType {
                 pub value: u64,
@@ -467,7 +500,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BaseTypeRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -946,7 +946,14 @@ pub type AliasListAlias = VariableList<u8, 5usize>;
 pub type AliasNested = AliasUintAlias;
 pub type BitAlias = BitList<{ VAL_X as usize }>;
 pub type UnionE = UnionD;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Alpha {
     pub a: u8,
@@ -984,7 +991,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Alpha {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct AlphaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1097,7 +1110,14 @@ impl<'a> AlphaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Beta {
     pub d: AliasListAlias,
@@ -1135,7 +1155,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Beta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct BetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1263,13 +1289,21 @@ impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
         Beta {
-            d: self.d().expect("valid view").to_owned().into(),
+            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
+                .expect("valid view"),
             e: self.e().expect("valid view"),
             f: self.f().expect("valid view"),
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Gamma {
     pub g: Optional<u8>,
@@ -1317,7 +1351,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Gamma {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct GammaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1458,7 +1498,14 @@ impl<'a> GammaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Delta {
     pub z: bool,
@@ -1492,7 +1539,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Delta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct DeltaRef<'a> {
     bytes: &'a [u8],
 }
@@ -1585,7 +1638,14 @@ impl<'a> DeltaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Epsilon {
     pub g: Optional<u8>,
@@ -1647,7 +1707,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Epsilon {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct EpsilonRef<'a> {
     bytes: &'a [u8],
 }
@@ -1846,7 +1912,14 @@ impl<'a> EpsilonRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
 pub struct Zeta {
     pub u: Optional<FixedBytes<16usize>>,
@@ -1894,7 +1967,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Zeta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ZetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2042,7 +2121,14 @@ impl<'a> ZetaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct TestType {
     pub ccc: u8,
@@ -2094,7 +2180,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for TestType {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct TestTypeRef<'a> {
     bytes: &'a [u8],
 }
@@ -2268,14 +2360,21 @@ impl<'a> TestTypeRef<'a> {
                     })
                     .collect();
                 let items = items.expect("valid view");
-                ssz_types::VariableList::from(items)
+                ssz_types::VariableList::new(items).expect("valid view")
             },
             large_int_128: self.large_int_128().expect("valid view"),
             large_int_256: self.large_int_256().expect("valid view"),
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Eta {
     pub l: Zeta,
@@ -2313,7 +2412,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Eta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct EtaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2474,7 +2579,14 @@ impl<'a> EtaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Theta {
     pub o: UnionB,
@@ -2512,7 +2624,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Theta {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ThetaRef<'a> {
     bytes: &'a [u8],
 }
@@ -2663,7 +2781,14 @@ impl<'a> ThetaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
 pub struct Iota {
     pub g: Optional<u8>,
@@ -2739,7 +2864,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Iota {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct IotaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3003,7 +3134,14 @@ impl<'a> IotaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Kappa {
     pub t: Alpha,
@@ -3041,7 +3179,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Kappa {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct KappaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3192,7 +3336,14 @@ impl<'a> KappaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
 pub struct Lambda {
     pub w: Optional<u16>,
@@ -3240,7 +3391,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Lambda {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct LambdaRef<'a> {
     bytes: &'a [u8],
 }
@@ -3374,7 +3531,14 @@ impl<'a> LambdaRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Mu {
     pub y: Lambda,
@@ -3408,7 +3572,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Mu {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct MuRef<'a> {
     bytes: &'a [u8],
 }
@@ -3540,7 +3710,14 @@ impl<'a> MuRef<'a> {
     }
 }
 pub type AliasMu = Mu;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Nu {
     pub zz: AliasMu,
@@ -3582,7 +3759,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Nu {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct NuRef<'a> {
     bytes: &'a [u8],
 }

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -22,7 +22,14 @@ pub mod tests {
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
             /// Test container that references types from an existing Rust module
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestExistingModule {
                 /// Field using type from existing module (no .ssz file)
@@ -69,7 +76,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestExistingModuleRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -1102,7 +1102,14 @@ pub mod tests {
             pub type AliasNested = AliasUintAlias;
             pub type BitAlias = BitList<{ VAL_X as usize }>;
             pub type UnionE = UnionD;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Alpha {
                 pub a: u8,
@@ -1151,7 +1158,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct AlphaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1273,7 +1286,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Beta {
                 pub d: AliasListAlias,
@@ -1322,7 +1342,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct BetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1462,13 +1488,23 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> Beta {
                     Beta {
-                        d: self.d().expect("valid view").to_owned().into(),
+                        d: ssz_types::VariableList::new(
+                                self.d().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         e: self.e().expect("valid view"),
                         f: self.f().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Gamma {
                 pub g: Optional<u8>,
@@ -1524,7 +1560,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct GammaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1682,7 +1724,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Delta {
                 pub z: bool,
@@ -1724,7 +1773,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct DeltaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1824,7 +1879,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Epsilon {
                 pub g: Optional<u8>,
@@ -1900,7 +1962,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EpsilonRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2122,7 +2190,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 128usize)]
             pub struct Zeta {
                 pub u: Optional<FixedBytes<16usize>>,
@@ -2178,7 +2253,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ZetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2345,7 +2426,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestType {
                 pub ccc: u8,
@@ -2412,7 +2500,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestTypeRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2598,14 +2692,21 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         large_int_128: self.large_int_128().expect("valid view"),
                         large_int_256: self.large_int_256().expect("valid view"),
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Eta {
                 pub l: Zeta,
@@ -2654,7 +2755,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct EtaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -2827,7 +2934,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Theta {
                 pub o: UnionB,
@@ -2876,7 +2990,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ThetaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3041,7 +3161,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 42usize)]
             pub struct Iota {
                 pub g: Optional<u8>,
@@ -3137,7 +3264,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct IotaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3432,7 +3565,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Kappa {
                 pub t: Alpha,
@@ -3481,7 +3621,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct KappaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3644,7 +3790,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "stable_container", max_fields = 4usize)]
             pub struct Lambda {
                 pub w: Optional<u16>,
@@ -3700,7 +3853,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct LambdaRef<'a> {
                 bytes: &'a [u8],
             }
@@ -3849,7 +4008,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Mu {
                 pub y: Lambda,
@@ -3891,7 +4057,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct MuRef<'a> {
                 bytes: &'a [u8],
             }
@@ -4034,7 +4206,14 @@ pub mod tests {
                 }
             }
             pub type AliasMu = Mu;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct Nu {
                 pub zz: AliasMu,
@@ -4090,7 +4269,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct NuRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -121,7 +121,14 @@ pub mod tests {
                 }
             }
             /// Container using the union
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestContainer {
                 /// Pending inputs
@@ -159,7 +166,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestContainerRef<'a> {
                 bytes: &'a [u8],
             }
@@ -281,7 +294,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -12,7 +12,14 @@ pub mod tests {
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
             /// Test external_kind pragma for container vs primitive external types
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ExternalPragmaTest {
                 /// External container type - needs Ref variant
@@ -85,7 +92,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ExternalPragmaTestRef<'a> {
                 bytes: &'a [u8],
             }
@@ -338,7 +351,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         account_ids: {
                             let view = self.account_ids().expect("valid view");
@@ -350,7 +363,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ContainerWithExternal {
                 pub payload: external_ssz::MsgPayload,
@@ -63,7 +70,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerWithExternalRef<'a> {
                 bytes: &'a [u8],
             }
@@ -249,7 +262,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1309,7 +1309,8 @@ pub mod test_1 {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Beta {
             Beta {
-                d: self.d().expect("valid view").to_owned().into(),
+                d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
+                    .expect("valid view"),
                 e: self.e().expect("valid view"),
                 f: self.f().expect("valid view"),
             }
@@ -2386,7 +2387,7 @@ pub mod test_1 {
                         })
                         .collect();
                     let items = items.expect("valid view");
-                    ssz_types::VariableList::from(items)
+                    ssz_types::VariableList::new(items).expect("valid view")
                 },
                 large_int_128: self.large_int_128().expect("valid view"),
                 large_int_256: self.large_int_256().expect("valid view"),

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -292,13 +292,19 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> NestedAliasContainer {
                     NestedAliasContainer {
-                        field1: self.field1().expect("valid view").to_owned().into(),
+                        field1: ssz_types::VariableList::new(
+                                self.field1().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         field2: self
                             .field2()
                             .expect("valid view")
                             .to_owned()
                             .expect("valid view"),
-                        field3: self.field3().expect("valid view").to_owned().into(),
+                        field3: ssz_types::VariableList::new(
+                                self.field3().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         field4: self
                             .field4()
                             .expect("valid view")

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -8,7 +8,14 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_VK_BYTES: u64 = 48u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct State {
     pub data: FixedBytes<48usize>,
@@ -42,7 +49,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for State {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct StateRef<'a> {
     bytes: &'a [u8],
 }
@@ -139,7 +152,14 @@ impl<'a> StateRef<'a> {
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_UPDATES: u64 = 10u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Update {
     pub state: crate::tests::input::test_cross_entry_state::State,
@@ -179,7 +199,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Update {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct UpdateRef<'a> {
     bytes: &'a [u8],
 }
@@ -326,7 +352,10 @@ impl<'a> UpdateRef<'a> {
                 ssz_types::view::ToOwnedSsz::to_owned(&view)
             },
             timestamp: self.timestamp().expect("valid view"),
-            updates: self.updates().expect("valid view").to_owned().into(),
+            updates: ssz_types::VariableList::new(
+                    self.updates().expect("valid view").to_owned(),
+                )
+                .expect("valid view"),
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -8,7 +8,14 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_VK_BYTES: u64 = 48u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct State {
     pub data: FixedBytes<48usize>,
@@ -42,7 +49,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for State {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct StateRef<'a> {
     bytes: &'a [u8],
 }
@@ -139,7 +152,14 @@ impl<'a> StateRef<'a> {
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const MAX_UPDATES: u64 = 10u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct Update {
     pub state: crate::tests::input::test_cross_entry_state::State,
@@ -179,7 +199,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for Update {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct UpdateRef<'a> {
     bytes: &'a [u8],
 }
@@ -326,7 +352,10 @@ impl<'a> UpdateRef<'a> {
                 ssz_types::view::ToOwnedSsz::to_owned(&view)
             },
             timestamp: self.timestamp().expect("valid view"),
-            updates: self.updates().expect("valid view").to_owned().into(),
+            updates: ssz_types::VariableList::new(
+                    self.updates().expect("valid view").to_owned(),
+                )
+                .expect("valid view"),
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1289,7 +1289,8 @@ impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
         Beta {
-            d: self.d().expect("valid view").to_owned().into(),
+            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
+                .expect("valid view"),
             e: self.e().expect("valid view"),
             f: self.f().expect("valid view"),
         }
@@ -2359,7 +2360,7 @@ impl<'a> TestTypeRef<'a> {
                     })
                     .collect();
                 let items = items.expect("valid view");
-                ssz_types::VariableList::from(items)
+                ssz_types::VariableList::new(items).expect("valid view")
             },
             large_int_128: self.large_int_128().expect("valid view"),
             large_int_256: self.large_int_256().expect("valid view"),

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -8,7 +8,14 @@ use tree_hash_derive::TreeHash;
 use ssz::view::*;
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const CONST_A: u64 = 100u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ContainerA {
     pub value: u8,
@@ -42,7 +49,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ContainerA {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ContainerARef<'a> {
     bytes: &'a [u8],
 }
@@ -168,7 +181,14 @@ impl<'a> ContainerARef<'a> {
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const CONST_B: u64 = 200u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ContainerB {
     pub value: u16,
@@ -202,7 +222,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ContainerB {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ContainerBRef<'a> {
     bytes: &'a [u8],
 }
@@ -328,7 +354,14 @@ impl<'a> ContainerBRef<'a> {
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 pub const CONST_C: u64 = 300u64;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ContainerC {
     pub value: u32,
@@ -358,7 +391,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ContainerC {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ContainerCRef<'a> {
     bytes: &'a [u8],
 }

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -146,7 +146,14 @@ pub mod tests {
             /// Test union with empty/unit variant
             ///
             /// Some container type for the union variant
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct DataVariant {
                 pub value: u64,
@@ -181,7 +188,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct DataVariantRef<'a> {
                 bytes: &'a [u8],
             }
@@ -264,7 +277,14 @@ pub mod tests {
                 }
             }
             /// Container using the union
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct TestContainer {
                 pub state: TestUnion,
@@ -299,7 +319,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct TestContainerRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -410,7 +410,14 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             pub const MAX_LIST_SIZE: u64 = 65536u64;
             /// Test Union[Type1, Type2] syntax in a List
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct UnionTypeAliasVariant1 {
                 pub value: u8,
@@ -446,7 +453,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct UnionTypeAliasVariant1Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -529,7 +542,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct UnionTypeAliasVariant2 {
                 pub value: u16,
@@ -565,7 +585,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct UnionTypeAliasVariant2Ref<'a> {
                 bytes: &'a [u8],
             }
@@ -649,7 +675,14 @@ pub mod tests {
                 }
             }
             /// Container using class Name(Union): syntax in a List
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ContainerWithUnionClass {
                 pub items: VariableList<UnionClass, 65536usize>,
@@ -685,7 +718,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerWithUnionClassRef<'a> {
                 bytes: &'a [u8],
             }
@@ -807,13 +846,20 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }
             }
             /// Container using class Name(Union): syntax with external in a List
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ContainerWithUnionClassExternal {
                 pub items: VariableList<UnionClassWithExternal, 65536usize>,
@@ -849,7 +895,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerWithUnionClassExternalRef<'a> {
                 bytes: &'a [u8],
             }
@@ -972,7 +1024,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }
@@ -980,7 +1032,14 @@ pub mod tests {
             pub type TypeAliasVariant1 = UnionTypeAliasVariant1;
             pub type TypeAliasVariant2 = UnionTypeAliasVariant2;
             /// Container using Union[Type1, Type2] syntax in a List
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ContainerWithUnionTypeAlias {
                 pub items: VariableList<UnionTypeAlias, 65536usize>,
@@ -1016,7 +1075,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ContainerWithUnionTypeAliasRef<'a> {
                 bytes: &'a [u8],
             }
@@ -1138,7 +1203,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                     }
                 }

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -118,7 +118,14 @@ pub mod tests {
                 }
             }
             /// Test type alias used in union
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct UnderlyingType {
                 pub value: u64,
@@ -154,7 +161,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct UnderlyingTypeRef<'a> {
                 bytes: &'a [u8],
             }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -6,7 +6,14 @@ use ssz_derive::{Encode, Decode};
 use tree_hash::TreeHashDigest;
 use tree_hash_derive::TreeHash;
 use ssz::view::*;
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ExportEntry {
     pub key: u32,
@@ -40,7 +47,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ExportEntry {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ExportEntryRef<'a> {
     bytes: &'a [u8],
 }
@@ -133,7 +146,14 @@ impl<'a> ExportEntryRef<'a> {
         }
     }
 }
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    ssz_derive::Encode,
+    ssz_derive::Decode
+)]
 #[ssz(struct_behaviour = "container")]
 pub struct ViewTypeTest {
     pub payload: VariableList<u8, 4096usize>,
@@ -171,7 +191,13 @@ impl<H: tree_hash::TreeHashDigest> tree_hash::TreeHash<H> for ViewTypeTest {
 /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
 /// needed.
 #[allow(dead_code, reason = "generated code using ssz-gen")]
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(
+    std::clone::Clone,
+    std::fmt::Debug,
+    std::cmp::PartialEq,
+    std::cmp::Eq,
+    std::marker::Copy
+)]
 pub struct ViewTypeTestRef<'a> {
     bytes: &'a [u8],
 }
@@ -312,7 +338,10 @@ impl<'a> ViewTypeTestRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ViewTypeTest {
         ViewTypeTest {
-            payload: self.payload().expect("valid view").to_owned().into(),
+            payload: ssz_types::VariableList::new(
+                    self.payload().expect("valid view").to_owned(),
+                )
+                .expect("valid view"),
             entries: {
                 let view = self.entries().expect("valid view");
                 let items: Result<Vec<_>, _> = view
@@ -323,7 +352,7 @@ impl<'a> ViewTypeTestRef<'a> {
                     })
                     .collect();
                 let items = items.expect("valid view");
-                ssz_types::VariableList::from(items)
+                ssz_types::VariableList::new(items).expect("valid view")
             },
             hash: ssz_types::FixedBytes(self.hash().expect("valid view").to_owned()),
         }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -11,7 +11,14 @@ pub mod tests {
             use tree_hash::TreeHashDigest;
             use tree_hash_derive::TreeHash;
             use ssz::view::*;
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ExportEntry {
                 pub key: u32,
@@ -53,7 +60,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ExportEntryRef<'a> {
                 bytes: &'a [u8],
             }
@@ -153,7 +166,14 @@ pub mod tests {
                     }
                 }
             }
-            #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
             #[ssz(struct_behaviour = "container")]
             pub struct ViewTypeTest {
                 pub payload: VariableList<u8, 4096usize>,
@@ -202,7 +222,13 @@ pub mod tests {
             /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
             /// needed.
             #[allow(dead_code, reason = "generated code using ssz-gen")]
-            #[derive(Clone, Debug, PartialEq, Eq, Copy)]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
             pub struct ViewTypeTestRef<'a> {
                 bytes: &'a [u8],
             }
@@ -362,7 +388,10 @@ pub mod tests {
                 )]
                 pub fn to_owned(&self) -> ViewTypeTest {
                     ViewTypeTest {
-                        payload: self.payload().expect("valid view").to_owned().into(),
+                        payload: ssz_types::VariableList::new(
+                                self.payload().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                         entries: {
                             let view = self.entries().expect("valid view");
                             let items: Result<Vec<_>, _> = view
@@ -373,7 +402,7 @@ pub mod tests {
                                 })
                                 .collect();
                             let items = items.expect("valid view");
-                            ssz_types::VariableList::from(items)
+                            ssz_types::VariableList::new(items).expect("valid view")
                         },
                         hash: ssz_types::FixedBytes(
                             self.hash().expect("valid view").to_owned(),

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -1032,7 +1032,7 @@ fn test_view_types_imports_and_to_owned() {
 
     // Verify that list to_owned conversion builds VariableList from items
     assert!(
-        generated.contains("VariableList::from(items)"),
+        generated.contains("VariableList::new(items).expect(\"valid view\")"),
         "ListRef to_owned conversion should build VariableList"
     );
 

--- a/crates/ssz_derive/tests/tests.rs
+++ b/crates/ssz_derive/tests/tests.rs
@@ -380,7 +380,7 @@ fn shape_2() {
 fn shape_3() {
     let shape = Shape3 {
         side: Optional::Some(0x42),
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::Some(0x42),
     };
     assert_encode_decode(
@@ -399,7 +399,7 @@ fn shape_3() {
 
     let shape = Shape3 {
         side: Optional::None,
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::None,
     };
     assert_encode_decode(&shape, &[0x02, 0x04, 0x00, 0x00, 0x00, 0x01, 0x02]);
@@ -413,7 +413,7 @@ fn shape_3() {
 
     let shape = Shape3 {
         side: Optional::None,
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::Some(0x42),
     };
     assert_encode_decode(

--- a/crates/ssz_types/benches/view_vs_owned.rs
+++ b/crates/ssz_types/benches/view_vs_owned.rs
@@ -44,7 +44,7 @@ fn bench_decode_variable_list_u64(c: &mut Criterion) {
 
     for size in [10, 100, 1000, 10000] {
         let data = generate_u64_vec(size);
-        let list: VariableList<u64, 16384> = data.into();
+        let list = VariableList::<u64, 16384>::try_from(data).unwrap();
         let encoded = list.as_ssz_bytes();
 
         group.throughput(Throughput::Elements(size as u64));
@@ -77,7 +77,7 @@ fn bench_decode_variable_list_bytes(c: &mut Criterion) {
 
     for size in [100, 1000, 10000, 100000] {
         let data = generate_byte_vec(size);
-        let list: VariableList<u8, 131072> = data.into();
+        let list = VariableList::<u8, 131072>::try_from(data).unwrap();
         let encoded = list.as_ssz_bytes();
 
         group.throughput(Throughput::Bytes(size as u64));
@@ -219,7 +219,7 @@ fn bench_tree_hash_variable_list_u64(c: &mut Criterion) {
 
     for size in [10, 100, 1000] {
         let data = generate_u64_vec(size);
-        let list: VariableList<u64, 16384> = data.into();
+        let list = VariableList::<u64, 16384>::try_from(data).unwrap();
         let encoded = list.as_ssz_bytes();
 
         group.throughput(Throughput::Elements(size as u64));
@@ -348,7 +348,7 @@ fn bench_iterate_variable_list_u64(c: &mut Criterion) {
 
     for size in [100, 1000, 10000] {
         let data = generate_u64_vec(size);
-        let list: VariableList<u64, 16384> = data.into();
+        let list = VariableList::<u64, 16384>::try_from(data).unwrap();
         let encoded = list.as_ssz_bytes();
 
         group.throughput(Throughput::Elements(size as u64));
@@ -381,7 +381,7 @@ fn bench_decode_and_hash_variable_list(c: &mut Criterion) {
 
     for size in [100, 1000] {
         let data = generate_u64_vec(size);
-        let list: VariableList<u64, 16384> = data.into();
+        let list = VariableList::<u64, 16384>::try_from(data).unwrap();
         let encoded = list.as_ssz_bytes();
 
         group.throughput(Throughput::Elements(size as u64));

--- a/crates/ssz_types/src/lib.rs
+++ b/crates/ssz_types/src/lib.rs
@@ -29,7 +29,7 @@
 //! let mut example = Example {
 //!     bit_vector: Bitfield::<length::Fixed<8>>::new(),
 //!     bit_list: Bitfield::<length::Variable<8>>::with_capacity(4).unwrap(),
-//!     variable_list: <_>::from(vec![0, 1]),
+//!     variable_list: VariableList::try_from(vec![0, 1]).unwrap(),
 //!     fixed_vector: <_>::from(vec![2, 3]),
 //! };
 //!

--- a/crates/ssz_types/src/serde_utils/quoted_u64_var_list.rs
+++ b/crates/ssz_types/src/serde_utils/quoted_u64_var_list.rs
@@ -3,7 +3,7 @@
 
 //! Formats `VariableList<u64,N>` and similar types using quotes.
 //!
-//! E.g., `VariableList::from(vec![0, 1, 2])` serializes as `["0", "1", "2"]`.
+//! E.g., `VariableList::try_from(vec![0, 1, 2]).unwrap()` serializes as `["0", "1", "2"]`.
 //!
 //! Quotes can be optional during decoding. If the length of the `Vec` is greater than `N`,
 //! deserialization fails.
@@ -84,21 +84,21 @@ mod test {
     #[test]
     fn quoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", "2", "3", "4"] }"#).unwrap();
-        let expected: VariableList<u64, 4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected = VariableList::<u64, 4>::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn unquoted_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": [1, 2, 3, 4] }"#).unwrap();
-        let expected: VariableList<u64, 4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected = VariableList::<u64, 4>::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
     #[test]
     fn mixed_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": ["1", 2, "3", "4"] }"#).unwrap();
-        let expected: VariableList<u64, 4> = VariableList::from(vec![1, 2, 3, 4]);
+        let expected = VariableList::<u64, 4>::try_from(vec![1, 2, 3, 4]).unwrap();
         assert_eq!(obj.values, expected);
     }
 
@@ -111,7 +111,7 @@ mod test {
     #[test]
     fn short_list_success() {
         let obj: Obj = serde_json::from_str(r#"{ "values": [1, 2] }"#).unwrap();
-        let expected: VariableList<u64, 4> = VariableList::from(vec![1, 2]);
+        let expected = VariableList::<u64, 4>::try_from(vec![1, 2]).unwrap();
         assert_eq!(obj.values, expected);
     }
 

--- a/crates/ssz_types/src/variable_list.rs
+++ b/crates/ssz_types/src/variable_list.rs
@@ -31,15 +31,14 @@ use crate::{Error, tree_hash::vec_tree_hash_root};
 /// let base: Vec<u64> = vec![1, 2, 3, 4];
 ///
 /// // Create a `VariableList` from a `Vec` that has the expected length.
-/// let exact: VariableList<_, 4> = VariableList::from(base.clone());
+/// let exact = VariableList::<_, 4>::try_from(base.clone()).unwrap();
 /// assert_eq!(&exact[..], &[1, 2, 3, 4]);
 ///
-/// // Create a `VariableList` from a `Vec` that is too long and the `Vec` is truncated.
-/// let short: VariableList<_, 3> = VariableList::from(base.clone());
-/// assert_eq!(&short[..], &[1, 2, 3]);
+/// // Creating a `VariableList` from a `Vec` that is too long returns an error.
+/// assert!(VariableList::<_, 3>::try_from(base.clone()).is_err());
 ///
 /// // Create a `VariableList` from a `Vec` that is shorter than the maximum.
-/// let mut long: VariableList<_, 5> = VariableList::from(base);
+/// let mut long = VariableList::<_, 5>::try_from(base).unwrap();
 /// assert_eq!(&long[..], &[1, 2, 3, 4]);
 ///
 /// // Push a value to if it does not exceed the maximum
@@ -127,11 +126,11 @@ impl<T, const N: usize> VariableList<T, N> {
     }
 }
 
-impl<T, const N: usize> From<Vec<T>> for VariableList<T, N> {
-    fn from(mut vec: Vec<T>) -> Self {
-        vec.truncate(N);
+impl<T, const N: usize> TryFrom<Vec<T>> for VariableList<T, N> {
+    type Error = Error;
 
-        Self { vec }
+    fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
+        Self::new(vec)
     }
 }
 
@@ -276,7 +275,7 @@ where
         let max_len = N;
 
         if bytes.is_empty() {
-            Ok(vec![].into())
+            Ok(Self::new(vec![]).expect("empty list fits within max length"))
         } else if T::is_ssz_fixed_len() {
             let num_items = bytes
                 .len()
@@ -295,10 +294,21 @@ where
                     vec.push(T::from_ssz_bytes(chunk)?);
                     Ok(vec)
                 })
-                .map(Into::into)
+                .and_then(|vec| {
+                    Self::new(vec).map_err(|e| {
+                        ssz::DecodeError::BytesInvalid(format!(
+                            "VariableList exceeds maximum length: {e}"
+                        ))
+                    })
+                })
         } else {
-            ssz::decode_list_of_variable_length_items(bytes, Some(max_len))
-                .map(|vec: Vec<_>| vec.into())
+            ssz::decode_list_of_variable_length_items(bytes, Some(max_len)).and_then(|vec| {
+                Self::new(vec).map_err(|e| {
+                    ssz::DecodeError::BytesInvalid(format!(
+                        "VariableList exceeds maximum length: {e}"
+                    ))
+                })
+            })
         }
     }
 }
@@ -370,7 +380,7 @@ mod test {
     fn indexing() {
         let vec = vec![1, 2];
 
-        let mut fixed: VariableList<u64, 8192> = vec.clone().into();
+        let mut fixed = VariableList::<u64, 8192>::try_from(vec.clone()).unwrap();
 
         assert_eq!(fixed[0], 1);
         assert_eq!(&fixed[0..1], &vec[0..1]);
@@ -383,23 +393,29 @@ mod test {
     #[test]
     fn length() {
         let vec = vec![42; 5];
-        let fixed: VariableList<u64, 4> = VariableList::from(vec.clone());
-        assert_eq!(&fixed[..], &vec[0..4]);
+        let fixed = VariableList::<u64, 4>::try_from(vec.clone());
+        assert_eq!(
+            fixed,
+            Err(Error::OutOfBounds {
+                i: vec.len(),
+                len: 4,
+            })
+        );
 
         let vec = vec![42; 3];
-        let fixed: VariableList<u64, 4> = VariableList::from(vec.clone());
+        let fixed = VariableList::<u64, 4>::try_from(vec.clone()).unwrap();
         assert_eq!(&fixed[0..3], &vec[..]);
         assert_eq!(&fixed[..], &vec![42, 42, 42][..]);
 
         let vec = vec![];
-        let fixed: VariableList<u64, 4> = VariableList::from(vec);
+        let fixed = VariableList::<u64, 4>::try_from(vec).unwrap();
         assert_eq!(&fixed[..], &[] as &[u64]);
     }
 
     #[test]
     fn deref() {
         let vec = vec![0, 2, 4, 6];
-        let fixed: VariableList<u64, 4> = VariableList::from(vec);
+        let fixed = VariableList::<u64, 4>::try_from(vec).unwrap();
 
         assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
@@ -408,7 +424,7 @@ mod test {
 
     #[test]
     fn encode() {
-        let vec: VariableList<u16, 2> = vec![0; 2].into();
+        let vec = VariableList::<u16, 2>::try_from(vec![0; 2]).unwrap();
         assert_eq!(vec.as_ssz_bytes(), vec![0, 0, 0, 0]);
         assert_eq!(<VariableList<u16, 2> as Encode>::ssz_fixed_len(), 4);
     }
@@ -421,8 +437,8 @@ mod test {
 
     #[test]
     fn u16_len_8() {
-        round_trip::<VariableList<u16, 8>>(vec![42; 8].into());
-        round_trip::<VariableList<u16, 8>>(vec![0; 8].into());
+        round_trip::<VariableList<u16, 8>>(VariableList::try_from(vec![42; 8]).unwrap());
+        round_trip::<VariableList<u16, 8>>(VariableList::try_from(vec![0; 8]).unwrap());
     }
 
     fn root_with_length(bytes: &[u8], len: usize) -> tree_hash::Hash256 {
@@ -432,14 +448,14 @@ mod test {
 
     #[test]
     fn tree_hash_u8() {
-        let fixed: VariableList<u8, 0> = VariableList::from(vec![]);
+        let fixed = VariableList::<u8, 0>::try_from(vec![]).unwrap();
         assert_eq!(
             <VariableList<u8, 0> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
             root_with_length(&[0; 8], 0)
         );
 
         for i in 0..=1 {
-            let fixed: VariableList<u8, 1> = VariableList::from(vec![0; i]);
+            let fixed = VariableList::<u8, 1>::try_from(vec![0; i]).unwrap();
             assert_eq!(
                 <VariableList<u8, 1> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 root_with_length(&vec![0; i], i)
@@ -447,7 +463,7 @@ mod test {
         }
 
         for i in 0..=8 {
-            let fixed: VariableList<u8, 8> = VariableList::from(vec![0; i]);
+            let fixed = VariableList::<u8, 8>::try_from(vec![0; i]).unwrap();
             assert_eq!(
                 <VariableList<u8, 8> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 root_with_length(&vec![0; i], i)
@@ -455,7 +471,7 @@ mod test {
         }
 
         for i in 0..=13 {
-            let fixed: VariableList<u8, 13> = VariableList::from(vec![0; i]);
+            let fixed = VariableList::<u8, 13>::try_from(vec![0; i]).unwrap();
             assert_eq!(
                 <VariableList<u8, 13> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 root_with_length(&vec![0; i], i)
@@ -463,7 +479,7 @@ mod test {
         }
 
         for i in 0..=16 {
-            let fixed: VariableList<u8, 16> = VariableList::from(vec![0; i]);
+            let fixed = VariableList::<u8, 16>::try_from(vec![0; i]).unwrap();
             assert_eq!(
                 <VariableList<u8, 16> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 root_with_length(&vec![0; i], i)
@@ -471,7 +487,7 @@ mod test {
         }
 
         let source: Vec<u8> = (0..16).collect();
-        let fixed: VariableList<u8, 16> = VariableList::from(source.clone());
+        let fixed = VariableList::<u8, 16>::try_from(source.clone()).unwrap();
         assert_eq!(
             <VariableList<u8, 16> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
             root_with_length(&source, 16)
@@ -504,14 +520,14 @@ mod test {
     fn tree_hash_composite() {
         let a = A { a: 0, b: 1 };
 
-        let fixed: VariableList<A, 0> = VariableList::from(vec![]);
+        let fixed = VariableList::<A, 0>::try_from(vec![]).unwrap();
         assert_eq!(
             <VariableList<A, 0> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
             padded_root_with_length(&[0; 32], 0, 0),
         );
 
         for i in 0..=1 {
-            let fixed: VariableList<A, 1> = VariableList::from(vec![a; i]);
+            let fixed = VariableList::<A, 1>::try_from(vec![a; i]).unwrap();
             assert_eq!(
                 <VariableList<A, 1> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 1),
@@ -520,7 +536,7 @@ mod test {
         }
 
         for i in 0..=8 {
-            let fixed: VariableList<A, 8> = VariableList::from(vec![a; i]);
+            let fixed = VariableList::<A, 8>::try_from(vec![a; i]).unwrap();
             assert_eq!(
                 <VariableList<A, 8> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 8),
@@ -529,7 +545,7 @@ mod test {
         }
 
         for i in 0..=13 {
-            let fixed: VariableList<A, 13> = VariableList::from(vec![a; i]);
+            let fixed = VariableList::<A, 13>::try_from(vec![a; i]).unwrap();
             assert_eq!(
                 <VariableList<A, 13> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 13),
@@ -538,7 +554,7 @@ mod test {
         }
 
         for i in 0..=16 {
-            let fixed: VariableList<A, 16> = VariableList::from(vec![a; i]);
+            let fixed = VariableList::<A, 16>::try_from(vec![a; i]).unwrap();
             assert_eq!(
                 <VariableList<A, 16> as TreeHash<tree_hash::Sha256Hasher>>::tree_hash_root(&fixed),
                 padded_root_with_length(&repeat(a.tree_hash_root().as_slice(), i), i, 16),
@@ -589,8 +605,8 @@ mod test {
 
     #[test]
     fn std_hash() {
-        let x: VariableList<u32, 16> = VariableList::from(vec![3; 16]);
-        let y: VariableList<u32, 16> = VariableList::from(vec![4; 16]);
+        let x = VariableList::<u32, 16>::try_from(vec![3; 16]).unwrap();
+        let y = VariableList::<u32, 16>::try_from(vec![4; 16]).unwrap();
         let mut hashset = HashSet::new();
 
         for value in [x.clone(), y.clone()] {

--- a/crates/ssz_types/src/view.rs
+++ b/crates/ssz_types/src/view.rs
@@ -46,7 +46,7 @@ use crate::{Error, FixedVector, VariableList};
 /// use ssz_types::{VariableList, view::VariableListRef};
 ///
 /// // Encode a variable list
-/// let list: VariableList<u64, 10> = vec![1, 2, 3].into();
+/// let list = VariableList::<u64, 10>::try_from(vec![1, 2, 3]).unwrap();
 /// let encoded = list.as_ssz_bytes();
 ///
 /// // Create a zero-copy view
@@ -191,7 +191,7 @@ impl<'a, const N: usize> ToOwnedSsz<FixedBytes<N>> for ssz::view::FixedBytesRef<
 
 impl<'a, const N: usize> ToOwnedSsz<VariableList<u8, N>> for ssz::view::BytesRef<'a, N> {
     fn to_owned(&self) -> VariableList<u8, N> {
-        VariableList::from(self.to_owned())
+        VariableList::new(self.to_owned()).expect("valid view")
     }
 }
 
@@ -207,7 +207,7 @@ where
                 ToOwnedSsz::to_owned(&item)
             })
             .collect();
-        VariableList::from(items)
+        VariableList::new(items).expect("valid view")
     }
 }
 
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn variable_list_ref_to_owned() {
         let values = vec![1u64, 2, 3];
-        let list: VariableList<u64, 10> = values.clone().into();
+        let list = VariableList::<u64, 10>::try_from(values.clone()).unwrap();
         let encoded = list.as_ssz_bytes();
 
         let view = VariableListRef::<u64, 10>::from_ssz_bytes(&encoded).unwrap();
@@ -521,7 +521,7 @@ mod tests {
     #[test]
     fn round_trip_variable_list() {
         // Test that view decoding matches owned decoding
-        let original: VariableList<u64, 10> = vec![1, 2, 3, 4, 5].into();
+        let original = VariableList::<u64, 10>::try_from(vec![1, 2, 3, 4, 5]).unwrap();
         let encoded = original.as_ssz_bytes();
 
         let view = VariableListRef::<u64, 10>::from_ssz_bytes(&encoded).unwrap();
@@ -546,7 +546,7 @@ mod tests {
     fn variable_list_ref_u8() {
         // Test with u8 (byte list)
         let values = vec![0x01u8, 0x02, 0x03, 0x04];
-        let list: VariableList<u8, 10> = values.clone().into();
+        let list = VariableList::<u8, 10>::try_from(values.clone()).unwrap();
         let encoded = list.as_ssz_bytes();
 
         let view = VariableListRef::<u8, 10>::from_ssz_bytes(&encoded).unwrap();
@@ -572,7 +572,7 @@ mod tests {
 
         // Test that tree hash of view matches tree hash of owned
         let values = vec![1u64, 2, 3, 4, 5];
-        let list: VariableList<u64, 10> = values.into();
+        let list = VariableList::<u64, 10>::try_from(values).unwrap();
         let encoded = list.as_ssz_bytes();
 
         let view = VariableListRef::<u64, 10>::from_ssz_bytes(&encoded).unwrap();
@@ -591,7 +591,7 @@ mod tests {
         // An empty `VariableList<u8, 64>` must merkleize with `limit = ceil(64 / 32) = 2` chunks,
         // then mix in length (0). Historically some view hashing paths behaved like `limit = 0`,
         // producing a different root.
-        let owned: VariableList<u8, 64> = vec![].into();
+        let owned = VariableList::<u8, 64>::try_from(vec![]).unwrap();
         let bytes = owned.as_ssz_bytes();
         let view = VariableListRef::<u8, 64>::from_ssz_bytes(&bytes).unwrap();
 
@@ -630,7 +630,7 @@ mod tests {
     fn tree_hash_empty_variable_list() {
         use tree_hash::{Sha256Hasher, TreeHash};
 
-        let list: VariableList<u64, 10> = vec![].into();
+        let list = VariableList::<u64, 10>::try_from(vec![]).unwrap();
         let encoded = list.as_ssz_bytes();
 
         let view = VariableListRef::<u64, 10>::from_ssz_bytes(&encoded).unwrap();
@@ -647,7 +647,7 @@ mod tests {
         // Test various list sizes and verify view produces same results as owned
         for size in [0, 1, 2, 5, 10, 15, 20] {
             let values: Vec<u64> = (0..size).collect();
-            let list: VariableList<u64, 32> = values.clone().into();
+            let list = VariableList::<u64, 32>::try_from(values.clone()).unwrap();
             let encoded = list.as_ssz_bytes();
 
             // Decode as owned
@@ -697,7 +697,7 @@ mod tests {
         // Property: tree hash of view must equal tree hash of owned for all inputs
         for size in [0, 1, 5, 10, 20] {
             let values: Vec<u32> = (0..size).map(|i| i * 7).collect();
-            let list: VariableList<u32, 32> = values.into();
+            let list = VariableList::<u32, 32>::try_from(values).unwrap();
             let encoded = list.as_ssz_bytes();
 
             let view = VariableListRef::<u32, 32>::from_ssz_bytes(&encoded).unwrap();
@@ -719,7 +719,7 @@ mod tests {
 
         for size in [0, 1, 2, 31, 32, 33, 63, 64] {
             let values: Vec<u8> = (0..size).map(|i| i as u8).collect();
-            let list: VariableList<u8, 64> = values.clone().into();
+            let list = VariableList::<u8, 64>::try_from(values.clone()).unwrap();
             let encoded = list.as_ssz_bytes();
 
             let view = VariableListRef::<u8, 64>::from_ssz_bytes(&encoded).unwrap();
@@ -761,7 +761,7 @@ mod tests {
     fn property_variable_list_length_validation() {
         // Property: decoding should fail when list exceeds maximum length
         let values: Vec<u64> = (0..10).collect();
-        let list: VariableList<u64, 20> = values.into();
+        let list = VariableList::<u64, 20>::try_from(values).unwrap();
         let encoded = list.as_ssz_bytes();
 
         // Should succeed with sufficient max
@@ -793,7 +793,7 @@ mod tests {
         use tree_hash::{Sha256Hasher, TreeHash};
 
         // Test with u8
-        let list_u8: VariableList<u8, 10> = vec![1u8, 2, 3].into();
+        let list_u8 = VariableList::<u8, 10>::try_from(vec![1u8, 2, 3]).unwrap();
         let encoded_u8 = list_u8.as_ssz_bytes();
         let view_u8 = VariableListRef::<u8, 10>::from_ssz_bytes(&encoded_u8).unwrap();
         assert_eq!(
@@ -802,7 +802,7 @@ mod tests {
         );
 
         // Test with u16
-        let list_u16: VariableList<u16, 10> = vec![100u16, 200, 300].into();
+        let list_u16 = VariableList::<u16, 10>::try_from(vec![100u16, 200, 300]).unwrap();
         let encoded_u16 = list_u16.as_ssz_bytes();
         let view_u16 = VariableListRef::<u16, 10>::from_ssz_bytes(&encoded_u16).unwrap();
         assert_eq!(
@@ -811,7 +811,7 @@ mod tests {
         );
 
         // Test with u32
-        let list_u32: VariableList<u32, 10> = vec![1000u32, 2000, 3000].into();
+        let list_u32 = VariableList::<u32, 10>::try_from(vec![1000u32, 2000, 3000]).unwrap();
         let encoded_u32 = list_u32.as_ssz_bytes();
         let view_u32 = VariableListRef::<u32, 10>::from_ssz_bytes(&encoded_u32).unwrap();
         assert_eq!(
@@ -820,7 +820,7 @@ mod tests {
         );
 
         // Test with u64
-        let list_u64: VariableList<u64, 10> = vec![10000u64, 20000, 30000].into();
+        let list_u64 = VariableList::<u64, 10>::try_from(vec![10000u64, 20000, 30000]).unwrap();
         let encoded_u64 = list_u64.as_ssz_bytes();
         let view_u64 = VariableListRef::<u64, 10>::from_ssz_bytes(&encoded_u64).unwrap();
         assert_eq!(

--- a/crates/ssz_types/tests/lazy_view_integration.rs
+++ b/crates/ssz_types/tests/lazy_view_integration.rs
@@ -16,7 +16,7 @@ use tree_hash::{Sha256Hasher, TreeHash};
 fn test_variable_list_lazy_decode() {
     // Create and encode a variable list
     let values = vec![1u64, 2, 3, 4, 5];
-    let owned: VariableList<u64, 10> = values.clone().into();
+    let owned = VariableList::<u64, 10>::try_from(values.clone()).unwrap();
     let encoded = owned.as_ssz_bytes();
 
     // Decode as view (lazy)
@@ -64,7 +64,7 @@ fn test_fixed_vector_lazy_decode() {
 fn test_no_allocations_on_decode() {
     // This test demonstrates that view decoding doesn't allocate
     let values = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let owned: VariableList<u64, 20> = values.into();
+    let owned = VariableList::<u64, 20>::try_from(values).unwrap();
     let encoded = owned.as_ssz_bytes();
 
     // Decode as view - this should not allocate
@@ -83,7 +83,7 @@ fn test_no_allocations_on_decode() {
 fn test_nested_views_share_lifetime() {
     // Test that nested views all borrow from the same original buffer
     let inner_values = vec![100u16, 200, 300];
-    let inner: VariableList<u16, 10> = inner_values.into();
+    let inner = VariableList::<u16, 10>::try_from(inner_values).unwrap();
     let inner_encoded = inner.as_ssz_bytes();
 
     // Create a view over the inner list
@@ -100,7 +100,7 @@ fn test_nested_views_share_lifetime() {
 fn test_lazy_access_on_large_list() {
     // For large lists, lazy access means we don't decode everything
     let values: Vec<u64> = (0..1000).collect();
-    let owned: VariableList<u64, 1024> = values.into();
+    let owned = VariableList::<u64, 1024>::try_from(values).unwrap();
     let encoded = owned.as_ssz_bytes();
 
     // Decode as view

--- a/crates/tree_hash/tests/test_vectors.rs
+++ b/crates/tree_hash/tests/test_vectors.rs
@@ -633,7 +633,7 @@ fn test_variable_list_tree_hash() {
     );
 
     // List with values: List[uint64, 8](1, 2, 3, 4)
-    let with_values: VariableList<u64, 8> = VariableList::from(vec![1u64, 2, 3, 4]);
+    let with_values = VariableList::<u64, 8>::try_from(vec![1u64, 2, 3, 4]).unwrap();
     assert_eq!(
         <VariableList<u64, 8> as TreeHash<Sha256Hasher>>::tree_hash_root(&with_values),
         Hash256::from_slice(&HASH_LIST_U64_1234),

--- a/crates/tree_hash/tests/tests.rs
+++ b/crates/tree_hash/tests/tests.rs
@@ -65,7 +65,7 @@ impl tree_hash::TreeHash<tree_hash::Sha256Hasher> for HashVec {
 
 #[test]
 fn macro_list_tree_hash_matches_variable_list() {
-    let list: VariableList<u8, 64> = vec![0x42].into();
+    let list = VariableList::<u8, 64>::try_from(vec![0x42]).unwrap();
     let macro_list = MacroList(list.clone());
 
     let list_root = TreeHash::<Sha256Hasher>::tree_hash_root(&list);
@@ -406,7 +406,7 @@ fn shape_2() {
 fn shape_3() {
     let shape_3 = Shape3 {
         side: Optional::Some(0x42),
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::Some(0x42),
     };
 
@@ -436,7 +436,7 @@ fn shape_3() {
 
     let shape_3 = Shape3 {
         side: Optional::None,
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::None,
     };
 
@@ -466,7 +466,7 @@ fn shape_3() {
 
     let shape_3 = Shape3 {
         side: Optional::None,
-        colors: Optional::Some(VariableList::from(vec![1, 2])),
+        colors: Optional::Some(VariableList::try_from(vec![1, 2]).unwrap()),
         radius: Optional::Some(0x42),
     };
 

--- a/crates/tree_hash/tests/view_parity.rs
+++ b/crates/tree_hash/tests/view_parity.rs
@@ -43,7 +43,7 @@ fn bitlistref_tree_hash_matches_owned_large_capacity() {
 
 #[test]
 fn bytesref_tree_hash_matches_owned_empty() {
-    let owned: VariableList<u8, 64> = vec![].into();
+    let owned = VariableList::<u8, 64>::try_from(vec![]).unwrap();
     let bytes = owned.as_ssz_bytes();
     let view = BytesRef::<64>::from_ssz_bytes(&bytes).unwrap();
 
@@ -55,7 +55,7 @@ fn bytesref_tree_hash_matches_owned_empty() {
 
 #[test]
 fn bytesref_tree_hash_matches_owned_short() {
-    let owned: VariableList<u8, 64> = vec![0x42].into();
+    let owned = VariableList::<u8, 64>::try_from(vec![0x42]).unwrap();
     let bytes = owned.as_ssz_bytes();
     let view = BytesRef::<64>::from_ssz_bytes(&bytes).unwrap();
 
@@ -67,7 +67,7 @@ fn bytesref_tree_hash_matches_owned_short() {
 
 #[test]
 fn listref_tree_hash_matches_owned_empty_basic() {
-    let owned: VariableList<u16, 17> = vec![].into();
+    let owned = VariableList::<u16, 17>::try_from(vec![]).unwrap();
     let bytes = owned.as_ssz_bytes();
     let view = ListRef::<u16, 17>::from_ssz_bytes(&bytes).unwrap();
 
@@ -79,7 +79,7 @@ fn listref_tree_hash_matches_owned_empty_basic() {
 
 #[test]
 fn listref_tree_hash_matches_owned_empty_composite() {
-    let owned: VariableList<VariableList<u8, 4>, 2> = vec![].into();
+    let owned = VariableList::<VariableList<u8, 4>, 2>::try_from(vec![]).unwrap();
     let bytes = owned.as_ssz_bytes();
     let view = ListRef::<BytesRef<'_, 4>, 2>::from_ssz_bytes(&bytes).unwrap();
 


### PR DESCRIPTION
## Description

- remove `From<Vec<T>> for VariableList<T, N>` because it silently truncated oversized inputs
- add `TryFrom<Vec<T>> for VariableList<T, N>` backed by `VariableList::new(...)`
- update `ssz_types` decode/docs/tests to use checked construction
- migrate repo-local consumers, benches, and generated code to checked `VariableList` construction
- refresh `ssz_codegen` expected outputs to match the new generated code
- preserve infallible view/codegen-owned conversion APIs where length is already validated, using checked construction internally with `expect("valid view")`

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This is breaking, that's why the last commit bumps the version to `0.15.0`

- The main behavioral change is that oversized `Vec<T>` values can no longer be converted into `VariableList<T, N>` by truncation.
- Repo-local consumers were migrated to `VariableList::try_from(...)` or `VariableList::new(...).expect("valid view")` depending on whether the path is externally fallible or already protected by SSZ/view invariants.
- `ssz_codegen` generated output changed in many snapshot files because list-to-owned conversion now uses checked construction.
- This is split into two commits:
  - fix(ssz_types): remove truncating VariableList conversion
  - fix(codegen): migrate VariableList consumers to checked constructors

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-2856 and subtasks from it: STR-2857 and STR-2858
