### PR TITLE
fix(codegen): make container views agree with the owned encoding

### DIFF
--- a/crates/ssz/src/layout.rs
+++ b/crates/ssz/src/layout.rs
@@ -260,6 +260,71 @@ pub fn read_variable_offset_or_end(
     }
 }
 
+/// Slices a single container field out of `bytes`.
+///
+/// For a fixed-size field the slice sits inline in the fixed portion at
+/// `fixed_offset` with length `fixed_len`; for a variable-size field the
+/// bounds come from the offset table entry at `variable_index`.
+///
+/// All layout parameters are expected to be derived from the field types'
+/// [`Encode`](crate::Encode) impls (`ssz_fixed_len()` is
+/// `BYTES_PER_LENGTH_OFFSET` for variable-size types, i.e. exactly the offset
+/// slot the field occupies in the fixed portion), which keeps view layouts in
+/// agreement with the owned encoding by construction.
+///
+/// # Arguments
+///
+/// * `bytes` - The complete container bytes
+/// * `is_fixed` - Whether the field is fixed-size
+/// * `fixed_offset` - Byte offset of the field within the fixed portion
+/// * `fixed_len` - Byte length of the field (fixed-size fields only)
+/// * `fixed_portion_size` - The size of the fixed portion
+/// * `num_variable_fields` - Total number of variable-size fields
+/// * `variable_index` - Index of the field's offset-table entry (variable-size fields only)
+///
+/// # Returns
+///
+/// The field's byte slice, or an error if out of bounds.
+pub fn read_field_bytes(
+    bytes: &[u8],
+    is_fixed: bool,
+    fixed_offset: usize,
+    fixed_len: usize,
+    fixed_portion_size: usize,
+    num_variable_fields: usize,
+    variable_index: usize,
+) -> Result<&[u8], DecodeError> {
+    if is_fixed {
+        let end = fixed_offset
+            .checked_add(fixed_len)
+            .ok_or(DecodeError::OutOfBoundsByte { i: fixed_offset })?;
+        if end > bytes.len() {
+            return Err(DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: end,
+            });
+        }
+        Ok(&bytes[fixed_offset..end])
+    } else {
+        let start = read_variable_offset(
+            bytes,
+            fixed_portion_size,
+            num_variable_fields,
+            variable_index,
+        )?;
+        let end = read_variable_offset_or_end(
+            bytes,
+            fixed_portion_size,
+            num_variable_fields,
+            variable_index + 1,
+        )?;
+        if start > end || end > bytes.len() {
+            return Err(DecodeError::OffsetsAreDecreasing(end));
+        }
+        Ok(&bytes[start..end])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -400,5 +465,37 @@ mod tests {
         assert_eq!(read_variable_offset_or_end(&bytes, 8, 2, 1).unwrap(), 10);
         assert_eq!(read_variable_offset_or_end(&bytes, 8, 2, 2).unwrap(), 11); // End of container
         assert!(read_variable_offset_or_end(&bytes, 8, 2, 3).is_err());
+    }
+
+    #[test]
+    fn read_field_bytes_fixed() {
+        // Container: [u8][u16] -> 3 fixed bytes, no variable fields
+        let bytes = vec![0xAA, 0xBB, 0xCC];
+
+        assert_eq!(
+            read_field_bytes(&bytes, true, 0, 1, 3, 0, 0).unwrap(),
+            &[0xAA]
+        );
+        assert_eq!(
+            read_field_bytes(&bytes, true, 1, 2, 3, 0, 0).unwrap(),
+            &[0xBB, 0xCC]
+        );
+        // Fixed slice past the end of the container
+        assert!(read_field_bytes(&bytes, true, 2, 2, 3, 0, 0).is_err());
+    }
+
+    #[test]
+    fn read_field_bytes_variable() {
+        // Container: [u8][list] -> fixed portion = 1 + 4 (offset), list at 5..7
+        let bytes = vec![
+            0xAA, // u8 field
+            0x05, 0x00, 0x00, 0x00, // offset 0 = 5
+            0xBB, 0xCC, // list contents
+        ];
+
+        assert_eq!(
+            read_field_bytes(&bytes, false, 0, 0, 5, 1, 0).unwrap(),
+            &[0xBB, 0xCC]
+        );
     }
 }

--- a/crates/ssz/src/layout.rs
+++ b/crates/ssz/src/layout.rs
@@ -128,6 +128,10 @@ impl ContainerLayout {
 
 /// Validates the offset table for a variable-length container.
 ///
+/// Like [`read_variable_offset`], this assumes the offset entries are packed
+/// at the end of the fixed portion; see [`validate_container`] for the
+/// canonical interleaved layout.
+///
 /// # Arguments
 ///
 /// * `bytes` - The complete container bytes
@@ -199,6 +203,16 @@ fn validate_offset_table(
 
 /// Helper to read an offset from the offset table.
 ///
+/// Assumes the offset entries form a contiguous table at the end of the
+/// fixed portion, which holds only when no fixed-size field follows a
+/// variable-size one (e.g. all-`Optional` StableContainers). In canonical
+/// SSZ each offset entry sits at its field's own position in the fixed
+/// portion; use [`read_field_bytes`] with a field table for such layouts.
+///
+/// FIXME: the StableContainer/Profile codegen path still relies on this
+/// end-packed assumption, which is wrong for Profiles that mix required
+/// fixed-size fields after variable-size ones (pre-existing).
+///
 /// # Arguments
 ///
 /// * `bytes` - The complete container bytes
@@ -260,69 +274,163 @@ pub fn read_variable_offset_or_end(
     }
 }
 
-/// Slices a single container field out of `bytes`.
+/// Owned-encoding layout facts for one container field: `(is_fixed, fixed_len)`.
 ///
-/// For a fixed-size field the slice sits inline in the fixed portion at
-/// `fixed_offset` with length `fixed_len`; for a variable-size field the
-/// bounds come from the offset table entry at `variable_index`.
+/// `fixed_len` is the field's `ssz_fixed_len()`; for variable-size fields the
+/// [`Encode`](crate::Encode) contract makes this `BYTES_PER_LENGTH_OFFSET` —
+/// the size of the offset slot the field occupies in the fixed portion — so
+/// summing `fixed_len` over a prefix of fields yields the next field's
+/// position in the fixed portion.
+pub type FieldInfo = (bool, usize);
+
+/// Reads a 4-byte little-endian offset at `pos`.
+fn read_offset_at(bytes: &[u8], pos: usize) -> Result<usize, DecodeError> {
+    let end = pos
+        .checked_add(BYTES_PER_LENGTH_OFFSET)
+        .ok_or(DecodeError::OutOfBoundsByte { i: pos })?;
+    if end > bytes.len() {
+        return Err(DecodeError::InvalidByteLength {
+            len: bytes.len(),
+            expected: end,
+        });
+    }
+    let offset_bytes = &bytes[pos..end];
+    Ok(u32::from_le_bytes([
+        offset_bytes[0],
+        offset_bytes[1],
+        offset_bytes[2],
+        offset_bytes[3],
+    ]) as usize)
+}
+
+/// Slices the field at `index` out of `bytes` given the container's per-field
+/// layout facts.
 ///
-/// All layout parameters are expected to be derived from the field types'
-/// [`Encode`](crate::Encode) impls (`ssz_fixed_len()` is
-/// `BYTES_PER_LENGTH_OFFSET` for variable-size types, i.e. exactly the offset
-/// slot the field occupies in the fixed portion), which keeps view layouts in
-/// agreement with the owned encoding by construction.
+/// A fixed-size field sits inline in the fixed portion; a variable-size field
+/// occupies a `BYTES_PER_LENGTH_OFFSET`-sized offset slot **at its own
+/// position** in the fixed portion (offset entries are interleaved with fixed
+/// fields in field order, not packed at the end). The field's end is the
+/// offset of the next variable-size field, or the container end if there is
+/// none.
+///
+/// `fields` entries are expected to be derived from the field types' owned
+/// encoding ([`Encode`](crate::Encode) impls, or the `#[ssz(with = ...)]`
+/// module when overridden), which keeps view layouts in agreement with the
+/// owned encoding by construction.
 ///
 /// # Arguments
 ///
 /// * `bytes` - The complete container bytes
-/// * `is_fixed` - Whether the field is fixed-size
-/// * `fixed_offset` - Byte offset of the field within the fixed portion
-/// * `fixed_len` - Byte length of the field (fixed-size fields only)
-/// * `fixed_portion_size` - The size of the fixed portion
-/// * `num_variable_fields` - Total number of variable-size fields
-/// * `variable_index` - Index of the field's offset-table entry (variable-size fields only)
+/// * `fields` - Per-field layout facts, in field order
+/// * `index` - The index of the field to slice
 ///
 /// # Returns
 ///
 /// The field's byte slice, or an error if out of bounds.
-pub fn read_field_bytes(
-    bytes: &[u8],
-    is_fixed: bool,
-    fixed_offset: usize,
-    fixed_len: usize,
-    fixed_portion_size: usize,
-    num_variable_fields: usize,
-    variable_index: usize,
-) -> Result<&[u8], DecodeError> {
+pub fn read_field_bytes<'a>(
+    bytes: &'a [u8],
+    fields: &[FieldInfo],
+    index: usize,
+) -> Result<&'a [u8], DecodeError> {
+    let &(is_fixed, fixed_len) = fields
+        .get(index)
+        .ok_or(DecodeError::OutOfBoundsByte { i: index })?;
+    let pos: usize = fields[..index].iter().map(|&(_, len)| len).sum();
+
     if is_fixed {
-        let end = fixed_offset
+        let end = pos
             .checked_add(fixed_len)
-            .ok_or(DecodeError::OutOfBoundsByte { i: fixed_offset })?;
+            .ok_or(DecodeError::OutOfBoundsByte { i: pos })?;
         if end > bytes.len() {
             return Err(DecodeError::InvalidByteLength {
                 len: bytes.len(),
                 expected: end,
             });
         }
-        Ok(&bytes[fixed_offset..end])
+        Ok(&bytes[pos..end])
     } else {
-        let start = read_variable_offset(
-            bytes,
-            fixed_portion_size,
-            num_variable_fields,
-            variable_index,
-        )?;
-        let end = read_variable_offset_or_end(
-            bytes,
-            fixed_portion_size,
-            num_variable_fields,
-            variable_index + 1,
-        )?;
+        let start = read_offset_at(bytes, pos)?;
+
+        // The field ends where the next variable-size field begins, whose
+        // offset entry sits after the intervening fixed-size fields.
+        let mut next_pos = pos + BYTES_PER_LENGTH_OFFSET;
+        let mut end = bytes.len();
+        for &(next_is_fixed, next_len) in &fields[index + 1..] {
+            if next_is_fixed {
+                next_pos += next_len;
+            } else {
+                end = read_offset_at(bytes, next_pos)?;
+                break;
+            }
+        }
+
         if start > end || end > bytes.len() {
             return Err(DecodeError::OffsetsAreDecreasing(end));
         }
         Ok(&bytes[start..end])
     }
+}
+
+/// Validates container `bytes` against the per-field layout facts.
+///
+/// For an all-fixed container this checks the exact byte length; otherwise it
+/// walks the fixed portion reading each variable-size field's offset entry at
+/// its interleaved position, checking that the first offset points to the end
+/// of the fixed portion, offsets do not decrease, and none exceeds the
+/// container length.
+///
+/// # Arguments
+///
+/// * `bytes` - The complete container bytes
+/// * `fields` - Per-field layout facts, in field order
+pub fn validate_container(bytes: &[u8], fields: &[FieldInfo]) -> Result<(), DecodeError> {
+    let fixed_portion_size: usize = fields.iter().map(|&(_, len)| len).sum();
+    let num_variable_fields = fields.iter().filter(|&&(is_fixed, _)| !is_fixed).count();
+
+    if num_variable_fields == 0 {
+        if bytes.len() != fixed_portion_size {
+            return Err(DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: fixed_portion_size,
+            });
+        }
+        return Ok(());
+    }
+
+    if bytes.len() < fixed_portion_size {
+        return Err(DecodeError::InvalidByteLength {
+            len: bytes.len(),
+            expected: fixed_portion_size,
+        });
+    }
+
+    let mut pos = 0usize;
+    let mut prev_offset: Option<usize> = None;
+    for &(is_fixed, fixed_len) in fields {
+        if !is_fixed {
+            let offset = read_offset_at(bytes, pos)?;
+
+            match prev_offset {
+                // First offset must point to the start of the variable portion
+                None if offset != fixed_portion_size => {
+                    return Err(DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                Some(prev) if offset < prev => {
+                    return Err(DecodeError::OffsetsAreDecreasing(offset));
+                }
+                _ => {}
+            }
+
+            if offset > bytes.len() {
+                return Err(DecodeError::OffsetOutOfBounds(offset));
+            }
+
+            prev_offset = Some(offset);
+        }
+        pos += fixed_len;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -470,32 +578,113 @@ mod tests {
     #[test]
     fn read_field_bytes_fixed() {
         // Container: [u8][u16] -> 3 fixed bytes, no variable fields
+        let fields: &[FieldInfo] = &[(true, 1), (true, 2)];
         let bytes = vec![0xAA, 0xBB, 0xCC];
 
-        assert_eq!(
-            read_field_bytes(&bytes, true, 0, 1, 3, 0, 0).unwrap(),
-            &[0xAA]
-        );
-        assert_eq!(
-            read_field_bytes(&bytes, true, 1, 2, 3, 0, 0).unwrap(),
-            &[0xBB, 0xCC]
-        );
+        assert_eq!(read_field_bytes(&bytes, fields, 0).unwrap(), &[0xAA]);
+        assert_eq!(read_field_bytes(&bytes, fields, 1).unwrap(), &[0xBB, 0xCC]);
         // Fixed slice past the end of the container
-        assert!(read_field_bytes(&bytes, true, 2, 2, 3, 0, 0).is_err());
+        assert!(read_field_bytes(&bytes[..2], fields, 1).is_err());
     }
 
     #[test]
     fn read_field_bytes_variable() {
         // Container: [u8][list] -> fixed portion = 1 + 4 (offset), list at 5..7
+        let fields: &[FieldInfo] = &[(true, 1), (false, BYTES_PER_LENGTH_OFFSET)];
         let bytes = vec![
             0xAA, // u8 field
             0x05, 0x00, 0x00, 0x00, // offset 0 = 5
             0xBB, 0xCC, // list contents
         ];
 
+        assert_eq!(read_field_bytes(&bytes, fields, 0).unwrap(), &[0xAA]);
+        assert_eq!(read_field_bytes(&bytes, fields, 1).unwrap(), &[0xBB, 0xCC]);
+    }
+
+    #[test]
+    fn read_field_bytes_variable_before_fixed() {
+        // Container: [list][u32] -> the offset entry sits at position 0 (the
+        // list field's own slot), NOT at the end of the fixed portion.
+        let fields: &[FieldInfo] = &[(false, BYTES_PER_LENGTH_OFFSET), (true, 4)];
+        let bytes = vec![
+            0x08, 0x00, 0x00, 0x00, // offset 0 = 8 (list field's slot)
+            0xDE, 0xAD, 0xBE, 0xEF, // u32 field
+            0xBB, 0xCC, // list contents
+        ];
+
+        assert_eq!(read_field_bytes(&bytes, fields, 0).unwrap(), &[0xBB, 0xCC]);
         assert_eq!(
-            read_field_bytes(&bytes, false, 0, 0, 5, 1, 0).unwrap(),
-            &[0xBB, 0xCC]
+            read_field_bytes(&bytes, fields, 1).unwrap(),
+            &[0xDE, 0xAD, 0xBE, 0xEF]
         );
+    }
+
+    #[test]
+    fn read_field_bytes_interleaved() {
+        // Container: [list][u8][list] -> slots at 0 and 5, u8 at 4.
+        let fields: &[FieldInfo] = &[
+            (false, BYTES_PER_LENGTH_OFFSET),
+            (true, 1),
+            (false, BYTES_PER_LENGTH_OFFSET),
+        ];
+        let bytes = vec![
+            0x09, 0x00, 0x00, 0x00, // offset for field 0 = 9
+            0xAA, // u8 field
+            0x0B, 0x00, 0x00, 0x00, // offset for field 2 = 11
+            0xBB, 0xCC, // field 0 contents
+            0xDD, // field 2 contents
+        ];
+
+        assert_eq!(read_field_bytes(&bytes, fields, 0).unwrap(), &[0xBB, 0xCC]);
+        assert_eq!(read_field_bytes(&bytes, fields, 1).unwrap(), &[0xAA]);
+        assert_eq!(read_field_bytes(&bytes, fields, 2).unwrap(), &[0xDD]);
+    }
+
+    #[test]
+    fn validate_container_fixed() {
+        let fields: &[FieldInfo] = &[(true, 1), (true, 2)];
+
+        assert!(validate_container(&[0x01, 0x02, 0x03], fields).is_ok());
+        assert!(validate_container(&[0x01, 0x02], fields).is_err());
+        assert!(validate_container(&[0x01, 0x02, 0x03, 0x04], fields).is_err());
+    }
+
+    #[test]
+    fn validate_container_variable_before_fixed() {
+        let fields: &[FieldInfo] = &[(false, BYTES_PER_LENGTH_OFFSET), (true, 4)];
+
+        // Valid: offset entry at position 0 points to the end of the fixed
+        // portion (8), u32 field at 4..8.
+        let valid = vec![
+            0x08, 0x00, 0x00, 0x00, // offset = 8
+            0xDE, 0xAD, 0xBE, 0xEF, // u32 field
+            0xBB, 0xCC, // list contents
+        ];
+        assert!(validate_container(&valid, fields).is_ok());
+
+        // Invalid: the offset entry does not point to the variable portion.
+        // An end-packed reading would instead interpret the u32 field's bytes
+        // as the offset and reject valid encodings like the one above.
+        let invalid = vec![
+            0x04, 0x00, 0x00, 0x00, // offset = 4 (into fixed portion)
+            0xDE, 0xAD, 0xBE, 0xEF, //
+            0xBB, 0xCC,
+        ];
+        assert!(validate_container(&invalid, fields).is_err());
+    }
+
+    #[test]
+    fn validate_container_offsets_decreasing() {
+        let fields: &[FieldInfo] = &[
+            (false, BYTES_PER_LENGTH_OFFSET),
+            (false, BYTES_PER_LENGTH_OFFSET),
+        ];
+
+        let invalid = vec![
+            0x08, 0x00, 0x00, 0x00, // offset 0 = 8
+            0x07, 0x00, 0x00, 0x00, // offset 1 = 7 (< 8)
+            0xAA,
+        ];
+        assert!(validate_container(&invalid, fields).is_err());
     }
 }

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1724,10 +1724,24 @@ impl ClassDef {
     /// overridden), so the accessor agrees with the owned `ssz_derive`
     /// encoding by construction.
     ///
+    /// `#[ssz(with = ...)]` fields have a module-defined encoding with no
+    /// view-side counterpart, so their getter decodes the slice to the owned
+    /// field type through `module::decode`, mirroring the `ssz_derive`
+    /// `Decode` impl.
     fn container_view_getter(&self, idx: usize, field: &ClassFieldDef) -> TokenStream {
         let field_name = Ident::new(&field.name, Span::call_site());
         let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);
         let field_bytes = self.field_bytes_expr(idx);
+
+        if let Some(module) = field.ssz_with_module() {
+            let owned_ty = field.ty.unwrap_type();
+            return quote! {
+                pub fn #field_name(&self) -> Result<#owned_ty, ssz::DecodeError> {
+                    let bytes = #field_bytes;
+                    #module::decode::from_ssz_bytes(bytes)
+                }
+            };
+        }
 
         // Special handling for Option types (from Union[null, T]): encoded as
         // a union with a selector byte.
@@ -2378,6 +2392,14 @@ impl ClassDef {
             .map(|field| {
                 let field_name = Ident::new(&field.name, Span::call_site());
                 let is_optional = matches!(field.ty.resolution, TypeResolutionKind::Optional(_));
+
+                // Plain-container `#[ssz(with = ...)]` getters already decode
+                // to the owned field type, so no view conversion is needed.
+                if !is_stable_container && field.ssz_with_module().is_some() {
+                    return quote! {
+                        #field_name: self.#field_name().expect("valid view")
+                    };
+                }
 
                 // For StableContainer, fields are wrapped in ssz_types::Optional<T>
                 // Getter returns Result<Optional<TRef>, Error>

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Ident, Path, Type, TypePath, parse_quote};
+use syn::{Attribute, Ident, LitStr, Path, Type, TypePath, parse::Parser, parse_quote};
 
-use crate::{derive_config::DeriveConfig, types::resolver::TypeResolver};
+use crate::{derive_config::DeriveConfig, pragma::ParsedPragma, types::resolver::TypeResolver};
 pub mod resolver;
 
 /// Represents a size expression for type parameters
@@ -831,6 +831,66 @@ pub struct ClassFieldDef {
     pub doc_comment: Option<String>,
 }
 
+impl ClassFieldDef {
+    /// Module named by a `#[ssz(with = "module")]` field-attribute pragma, if
+    /// any.
+    ///
+    /// `ssz_derive` encodes such fields through `module::encode::*` instead of
+    /// the field type's `Encode` impl, so view layout expressions must call
+    /// the same functions to agree with the owned encoding.
+    fn ssz_with_module(&self) -> Option<Ident> {
+        let field_attrs = ParsedPragma::parse(&self.pragmas).field_attrs;
+        field_attrs.iter().find_map(|tokens| {
+            let attrs = Attribute::parse_outer.parse2(tokens.clone()).ok()?;
+            attrs
+                .into_iter()
+                .filter(|attr| attr.path().is_ident("ssz"))
+                .find_map(|attr| {
+                    let mut module = None;
+                    // A meta the closure can't handle aborts the walk, but a
+                    // `with` seen before that point is kept.
+                    let _ = attr.parse_nested_meta(|meta| {
+                        if meta.path.is_ident("with") {
+                            let value = meta.value()?;
+                            // ssz_derive documents `with = "module"`; also
+                            // accept a bare `with = module`.
+                            module = Some(match value.parse::<LitStr>() {
+                                Ok(lit) => lit.parse::<Ident>()?,
+                                Err(_) => value.parse::<Ident>()?,
+                            });
+                        }
+                        Ok(())
+                    });
+                    module
+                })
+        })
+    }
+
+    /// Expression for whether this field's owned encoding is fixed-size,
+    /// honoring `#[ssz(with = ...)]` overrides.
+    fn is_ssz_fixed_len_expr(&self) -> TokenStream {
+        match self.ssz_with_module() {
+            Some(module) => quote! { #module::encode::is_ssz_fixed_len() },
+            None => {
+                let ty = self.ty.unwrap_type();
+                quote! { <#ty as ssz::Encode>::is_ssz_fixed_len() }
+            }
+        }
+    }
+
+    /// Expression for this field's owned `ssz_fixed_len`, honoring
+    /// `#[ssz(with = ...)]` overrides.
+    fn ssz_fixed_len_expr(&self) -> TokenStream {
+        match self.ssz_with_module() {
+            Some(module) => quote! { #module::encode::ssz_fixed_len() },
+            None => {
+                let ty = self.ty.unwrap_type();
+                quote! { <#ty as ssz::Encode>::ssz_fixed_len() }
+            }
+        }
+    }
+}
+
 /// Definition of a class with its base type and fields
 #[derive(Clone, Debug)]
 pub struct ClassDef {
@@ -1053,17 +1113,6 @@ impl ClassDef {
         (fixed_offset, fixed_size, num_variable_fields)
     }
 
-    /// Owned Rust type tokens for each field, exactly as emitted in the
-    /// generated struct.
-    ///
-    /// Used to build layout expressions over the field types' `ssz::Encode`
-    /// impls, so that view layouts agree with the owned encoding even for
-    /// class or external field types whose fixedness is unknowable at codegen
-    /// time.
-    fn field_owned_types(&self) -> Vec<Type> {
-        self.fields.iter().map(|f| f.ty.unwrap_type()).collect()
-    }
-
     /// Sums a list of `usize` expressions, or `0usize` when empty.
     fn sum_expr(terms: &[TokenStream]) -> TokenStream {
         if terms.is_empty() {
@@ -1073,28 +1122,32 @@ impl ClassDef {
         }
     }
 
-    /// Expression computing the container's fixed-portion size from the field
-    /// types' `ssz::Encode` impls.
+    /// Expression computing the container's fixed-portion size from the
+    /// fields' owned encoding (their `ssz::Encode` impls, or the
+    /// `#[ssz(with = ...)]` module when overridden).
     ///
     /// `ssz_fixed_len()` returns `BYTES_PER_LENGTH_OFFSET` for variable-size
     /// types — exactly the offset slot such a field occupies in the fixed
     /// portion — so a plain sum over all fields yields the fixed-portion size.
     fn fixed_portion_size_expr(&self) -> TokenStream {
         let terms: Vec<TokenStream> = self
-            .field_owned_types()
+            .fields
             .iter()
-            .map(|ty| quote! { <#ty as ssz::Encode>::ssz_fixed_len() })
+            .map(ClassFieldDef::ssz_fixed_len_expr)
             .collect();
         Self::sum_expr(&terms)
     }
 
-    /// Expression computing the number of variable-size fields from the field
-    /// types' `ssz::Encode` impls.
+    /// Expression computing the number of variable-size fields from the
+    /// fields' owned encoding.
     fn num_variable_fields_expr(&self) -> TokenStream {
         let terms: Vec<TokenStream> = self
-            .field_owned_types()
+            .fields
             .iter()
-            .map(|ty| quote! { usize::from(!<#ty as ssz::Encode>::is_ssz_fixed_len()) })
+            .map(|f| {
+                let is_fixed = f.is_ssz_fixed_len_expr();
+                quote! { usize::from(!#is_fixed) }
+            })
             .collect();
         Self::sum_expr(&terms)
     }
@@ -1104,10 +1157,7 @@ impl ClassDef {
     fn field_fixed_offset_expr(&self, field_index: usize) -> TokenStream {
         let terms: Vec<TokenStream> = self.fields[..field_index]
             .iter()
-            .map(|f| {
-                let ty = f.ty.unwrap_type();
-                quote! { <#ty as ssz::Encode>::ssz_fixed_len() }
-            })
+            .map(ClassFieldDef::ssz_fixed_len_expr)
             .collect();
         Self::sum_expr(&terms)
     }
@@ -1118,18 +1168,20 @@ impl ClassDef {
         let terms: Vec<TokenStream> = self.fields[..field_index]
             .iter()
             .map(|f| {
-                let ty = f.ty.unwrap_type();
-                quote! { usize::from(!<#ty as ssz::Encode>::is_ssz_fixed_len()) }
+                let is_fixed = f.is_ssz_fixed_len_expr();
+                quote! { usize::from(!#is_fixed) }
             })
             .collect();
         Self::sum_expr(&terms)
     }
 
     /// Expression slicing field `field_index`'s bytes out of `self.bytes`,
-    /// deciding fixed-vs-variable from the field type's `ssz::Encode` impl at
-    /// runtime (const-foldable) rather than at codegen time.
+    /// deciding fixed-vs-variable from the field's owned encoding at runtime
+    /// (const-foldable) rather than at codegen time.
     fn field_bytes_expr(&self, field_index: usize) -> TokenStream {
-        let owned_ty = self.fields[field_index].ty.unwrap_type();
+        let field = &self.fields[field_index];
+        let is_fixed_expr = field.is_ssz_fixed_len_expr();
+        let fixed_len_expr = field.ssz_fixed_len_expr();
         let offset_expr = self.field_fixed_offset_expr(field_index);
         let variable_index_expr = self.field_variable_index_expr(field_index);
         let fixed_portion_expr = self.fixed_portion_size_expr();
@@ -1138,9 +1190,9 @@ impl ClassDef {
         quote! {
             ssz::layout::read_field_bytes(
                 self.bytes,
-                <#owned_ty as ssz::Encode>::is_ssz_fixed_len(),
+                #is_fixed_expr,
                 #offset_expr,
-                <#owned_ty as ssz::Encode>::ssz_fixed_len(),
+                #fixed_len_expr,
                 #fixed_portion_expr,
                 #num_variable_expr,
                 #variable_index_expr,
@@ -1678,8 +1730,16 @@ impl ClassDef {
     /// Generates a single view getter for a plain-container field.
     ///
     /// The field slice is obtained via [`ssz::layout::read_field_bytes`] with
-    /// the layout derived from the field types' `ssz::Encode` impls, so the
-    /// accessor agrees with the owned `ssz_derive` encoding by construction.
+    /// the layout derived from the fields' owned encoding (their
+    /// `ssz::Encode` impls, or the `#[ssz(with = ...)]` module when
+    /// overridden), so the accessor agrees with the owned `ssz_derive`
+    /// encoding by construction.
+    ///
+    /// TODO: for `#[ssz(with = ...)]` fields only the slicing honors the
+    /// override; the getter still interprets the slice through the bare field
+    /// type's `DecodeView` impl. Decoding such fields faithfully needs a
+    /// view-side counterpart of the `with` module (ssz_derive only supports
+    /// owned `encode`/`decode` fns).
     fn container_view_getter(&self, idx: usize, field: &ClassFieldDef) -> TokenStream {
         let field_name = Ident::new(&field.name, Span::call_site());
         let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1152,55 +1152,44 @@ impl ClassDef {
         Self::sum_expr(&terms)
     }
 
-    /// Expression computing the fixed-portion byte offset of field
-    /// `field_index` (meaningful for fixed-size fields).
-    fn field_fixed_offset_expr(&self, field_index: usize) -> TokenStream {
-        let terms: Vec<TokenStream> = self.fields[..field_index]
-            .iter()
-            .map(ClassFieldDef::ssz_fixed_len_expr)
-            .collect();
-        Self::sum_expr(&terms)
-    }
-
-    /// Expression computing the offset-table index of field `field_index`
-    /// (meaningful for variable-size fields).
-    fn field_variable_index_expr(&self, field_index: usize) -> TokenStream {
-        let terms: Vec<TokenStream> = self.fields[..field_index]
+    /// Expression building the container's per-field layout table
+    /// (`&[(is_fixed, ssz_fixed_len)]`, see [`ssz::layout::FieldInfo`]) from
+    /// the fields' owned encoding.
+    fn field_layout_table_expr(&self) -> TokenStream {
+        let entries: Vec<TokenStream> = self
+            .fields
             .iter()
             .map(|f| {
                 let is_fixed = f.is_ssz_fixed_len_expr();
-                quote! { usize::from(!#is_fixed) }
+                let fixed_len = f.ssz_fixed_len_expr();
+                quote! { (#is_fixed, #fixed_len) }
             })
             .collect();
-        Self::sum_expr(&terms)
+        quote! { &[ #(#entries),* ] }
     }
 
     /// Expression slicing field `field_index`'s bytes out of `self.bytes`,
-    /// deciding fixed-vs-variable from the field's owned encoding at runtime
-    /// (const-foldable) rather than at codegen time.
+    /// deciding fixed-vs-variable and offset-slot positions from the fields'
+    /// owned encoding at runtime rather than at codegen time.
     fn field_bytes_expr(&self, field_index: usize) -> TokenStream {
-        let field = &self.fields[field_index];
-        let is_fixed_expr = field.is_ssz_fixed_len_expr();
-        let fixed_len_expr = field.ssz_fixed_len_expr();
-        let offset_expr = self.field_fixed_offset_expr(field_index);
-        let variable_index_expr = self.field_variable_index_expr(field_index);
-        let fixed_portion_expr = self.fixed_portion_size_expr();
-        let num_variable_expr = self.num_variable_fields_expr();
-
+        let table = self.field_layout_table_expr();
         quote! {
-            ssz::layout::read_field_bytes(
-                self.bytes,
-                #is_fixed_expr,
-                #offset_expr,
-                #fixed_len_expr,
-                #fixed_portion_expr,
-                #num_variable_expr,
-                #variable_index_expr,
-            )?
+            ssz::layout::read_field_bytes(self.bytes, #table, #field_index)?
         }
     }
 
     /// Generates field layout information for a given field index.
+    ///
+    /// Only used for StableContainer/Profile views; plain containers use
+    /// [`Self::field_bytes_expr`].
+    ///
+    /// FIXME: this path still computes the layout at codegen time and reads
+    /// variable offsets via the end-packed [`ssz::layout::read_variable_offset`],
+    /// which is correct for all-`Optional` StableContainers (every field is
+    /// variable) but wrong for Profiles mixing required fixed-size fields
+    /// after variable-size ones; it also ignores `#[ssz(with = ...)]`
+    /// overrides. Migrating it to the per-field layout table used by plain
+    /// containers would fix both.
     ///
     /// Returns (offset_expr, is_fixed, size_expr) where:
     /// - offset_expr: TokenStream to compute the field's byte offset
@@ -1735,11 +1724,6 @@ impl ClassDef {
     /// overridden), so the accessor agrees with the owned `ssz_derive`
     /// encoding by construction.
     ///
-    /// TODO: for `#[ssz(with = ...)]` fields only the slicing honors the
-    /// override; the getter still interprets the slice through the bare field
-    /// type's `DecodeView` impl. Decoding such fields faithfully needs a
-    /// view-side counterpart of the `with` module (ssz_derive only supports
-    /// owned `encode`/`decode` fns).
     fn container_view_getter(&self, idx: usize, field: &ClassFieldDef) -> TokenStream {
         let field_name = Ident::new(&field.name, Span::call_site());
         let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);
@@ -2135,63 +2119,15 @@ impl ClassDef {
 
         match self.base {
             BaseClass::Container => {
-                // Layout is computed from the field types' `Encode` impls at
-                // runtime (const-foldable), so validation agrees with the
-                // owned encoding even for class or external field types.
-                let fixed_portion_expr = self.fixed_portion_size_expr();
-                let num_variable_expr = self.num_variable_fields_expr();
+                // Layout is computed from the fields' owned encoding at
+                // runtime, so validation agrees with the owned `ssz_derive`
+                // encoding even for class or external field types.
+                let table = self.field_layout_table_expr();
 
                 quote! {
                     impl<'a> ssz::view::DecodeView<'a> for #ref_ident<'a> {
                         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                            let fixed_portion_size = #fixed_portion_expr;
-                            let num_variable_fields = #num_variable_expr;
-
-                            if num_variable_fields == 0 {
-                                // Fixed-size container: just check length
-                                if bytes.len() != fixed_portion_size {
-                                    return Err(ssz::DecodeError::InvalidByteLength {
-                                        len: bytes.len(),
-                                        expected: fixed_portion_size,
-                                    });
-                                }
-                            } else {
-                                if bytes.len() < fixed_portion_size {
-                                    return Err(ssz::DecodeError::InvalidByteLength {
-                                        len: bytes.len(),
-                                        expected: fixed_portion_size,
-                                    });
-                                }
-
-                                // Validate offset table
-                                let mut prev_offset: Option<usize> = None;
-                                for i in 0..num_variable_fields {
-                                    let offset = ssz::layout::read_variable_offset(
-                                        bytes,
-                                        fixed_portion_size,
-                                        num_variable_fields,
-                                        i
-                                    )?;
-
-                                    // First offset should point to start of variable portion
-                                    if i == 0 && offset != fixed_portion_size {
-                                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                                    }
-
-                                    // Offsets must not decrease
-                                    if let Some(prev) = prev_offset && offset < prev {
-                                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                                    }
-
-                                    // Offset must not exceed container length
-                                    if offset > bytes.len() {
-                                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                                    }
-
-                                    prev_offset = Some(offset);
-                                }
-                            }
-
+                            ssz::layout::validate_container(bytes, #table)?;
                             Ok(Self { bytes })
                         }
                     }

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1053,6 +1053,101 @@ impl ClassDef {
         (fixed_offset, fixed_size, num_variable_fields)
     }
 
+    /// Owned Rust type tokens for each field, exactly as emitted in the
+    /// generated struct.
+    ///
+    /// Used to build layout expressions over the field types' `ssz::Encode`
+    /// impls, so that view layouts agree with the owned encoding even for
+    /// class or external field types whose fixedness is unknowable at codegen
+    /// time.
+    fn field_owned_types(&self) -> Vec<Type> {
+        self.fields.iter().map(|f| f.ty.unwrap_type()).collect()
+    }
+
+    /// Sums a list of `usize` expressions, or `0usize` when empty.
+    fn sum_expr(terms: &[TokenStream]) -> TokenStream {
+        if terms.is_empty() {
+            quote! { 0usize }
+        } else {
+            quote! { #(#terms)+* }
+        }
+    }
+
+    /// Expression computing the container's fixed-portion size from the field
+    /// types' `ssz::Encode` impls.
+    ///
+    /// `ssz_fixed_len()` returns `BYTES_PER_LENGTH_OFFSET` for variable-size
+    /// types — exactly the offset slot such a field occupies in the fixed
+    /// portion — so a plain sum over all fields yields the fixed-portion size.
+    fn fixed_portion_size_expr(&self) -> TokenStream {
+        let terms: Vec<TokenStream> = self
+            .field_owned_types()
+            .iter()
+            .map(|ty| quote! { <#ty as ssz::Encode>::ssz_fixed_len() })
+            .collect();
+        Self::sum_expr(&terms)
+    }
+
+    /// Expression computing the number of variable-size fields from the field
+    /// types' `ssz::Encode` impls.
+    fn num_variable_fields_expr(&self) -> TokenStream {
+        let terms: Vec<TokenStream> = self
+            .field_owned_types()
+            .iter()
+            .map(|ty| quote! { usize::from(!<#ty as ssz::Encode>::is_ssz_fixed_len()) })
+            .collect();
+        Self::sum_expr(&terms)
+    }
+
+    /// Expression computing the fixed-portion byte offset of field
+    /// `field_index` (meaningful for fixed-size fields).
+    fn field_fixed_offset_expr(&self, field_index: usize) -> TokenStream {
+        let terms: Vec<TokenStream> = self.fields[..field_index]
+            .iter()
+            .map(|f| {
+                let ty = f.ty.unwrap_type();
+                quote! { <#ty as ssz::Encode>::ssz_fixed_len() }
+            })
+            .collect();
+        Self::sum_expr(&terms)
+    }
+
+    /// Expression computing the offset-table index of field `field_index`
+    /// (meaningful for variable-size fields).
+    fn field_variable_index_expr(&self, field_index: usize) -> TokenStream {
+        let terms: Vec<TokenStream> = self.fields[..field_index]
+            .iter()
+            .map(|f| {
+                let ty = f.ty.unwrap_type();
+                quote! { usize::from(!<#ty as ssz::Encode>::is_ssz_fixed_len()) }
+            })
+            .collect();
+        Self::sum_expr(&terms)
+    }
+
+    /// Expression slicing field `field_index`'s bytes out of `self.bytes`,
+    /// deciding fixed-vs-variable from the field type's `ssz::Encode` impl at
+    /// runtime (const-foldable) rather than at codegen time.
+    fn field_bytes_expr(&self, field_index: usize) -> TokenStream {
+        let owned_ty = self.fields[field_index].ty.unwrap_type();
+        let offset_expr = self.field_fixed_offset_expr(field_index);
+        let variable_index_expr = self.field_variable_index_expr(field_index);
+        let fixed_portion_expr = self.fixed_portion_size_expr();
+        let num_variable_expr = self.num_variable_fields_expr();
+
+        quote! {
+            ssz::layout::read_field_bytes(
+                self.bytes,
+                <#owned_ty as ssz::Encode>::is_ssz_fixed_len(),
+                #offset_expr,
+                <#owned_ty as ssz::Encode>::ssz_fixed_len(),
+                #fixed_portion_expr,
+                #num_variable_expr,
+                #variable_index_expr,
+            )?
+        }
+    }
+
     /// Generates field layout information for a given field index.
     ///
     /// Returns (offset_expr, is_fixed, size_expr) where:
@@ -1238,39 +1333,22 @@ impl ClassDef {
 
         match self.base {
             BaseClass::Container => {
-                // Generate optimized tree hashing that uses bytes directly for basic types
+                // Each field contributes exactly one (padded) leaf, matching
+                // the owned TreeHash impl which writes every field's
+                // `tree_hash_root`. Writing raw basic-field bytes instead
+                // would misalign the `MerkleHasher` leaf stream (it only
+                // forms a leaf per HASH_SIZE bytes), so all fields go through
+                // their getters.
                 let hash_operations: Vec<TokenStream> = self
                     .fields
                     .iter()
-                    .enumerate()
-                    .map(|(idx, field)| {
+                    .map(|field| {
                         let field_name = Ident::new(&field.name, Span::call_site());
-                        let (offset_expr, is_fixed, size_expr) = self.generate_field_layout(idx);
-
-                        // Check if this is a basic packable type
-                        let is_basic = matches!(
-                            field.ty.resolution,
-                            TypeResolutionKind::Boolean | TypeResolutionKind::UInt(_)
-                        );
-
-                        if is_basic && is_fixed {
-                            // Optimize: hash bytes directly for basic types
-                            let size = size_expr.unwrap();
-                            quote! {
-                                {
-                                    let offset = #offset_expr;
-                                    let field_bytes = &self.bytes[offset..offset + #size];
-                                    hasher.write(field_bytes).expect("write field");
-                                }
-                            }
-                        } else {
-                            // For composite types, use getter and hash the result
-                            quote! {
-                                {
-                                    let #field_name = self.#field_name().expect("valid view");
-                                    let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&#field_name);
-                                    hasher.write(root.as_ref()).expect("write field");
-                                }
+                        quote! {
+                            {
+                                let #field_name = self.#field_name().expect("valid view");
+                                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&#field_name);
+                                hasher.write(root.as_ref()).expect("write field");
                             }
                         }
                     })
@@ -1597,6 +1675,52 @@ impl ClassDef {
         }
     }
 
+    /// Generates a single view getter for a plain-container field.
+    ///
+    /// The field slice is obtained via [`ssz::layout::read_field_bytes`] with
+    /// the layout derived from the field types' `ssz::Encode` impls, so the
+    /// accessor agrees with the owned `ssz_derive` encoding by construction.
+    fn container_view_getter(&self, idx: usize, field: &ClassFieldDef) -> TokenStream {
+        let field_name = Ident::new(&field.name, Span::call_site());
+        let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);
+        let field_bytes = self.field_bytes_expr(idx);
+
+        // Special handling for Option types (from Union[null, T]): encoded as
+        // a union with a selector byte.
+        if let TypeResolutionKind::Option(inner_ty) = &field.ty.resolution {
+            let inner_view_ty = inner_ty.to_view_type_with_pragmas(&field.pragmas);
+            return quote! {
+                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
+                    let bytes = #field_bytes;
+                    if bytes.is_empty() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: 0,
+                            expected: 1,
+                        });
+                    }
+                    let selector = bytes[0];
+                    match selector {
+                        0 => Ok(None),
+                        1 => {
+                            let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
+                            Ok(Some(inner))
+                        }
+                        _ => Err(ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector for Option: {}", selector)
+                        ))
+                    }
+                }
+            };
+        }
+
+        quote! {
+            pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
+                let bytes = #field_bytes;
+                ssz::view::DecodeView::from_ssz_bytes(bytes)
+            }
+        }
+    }
+
     /// Generates getter methods for view struct fields.
     ///
     /// Each field gets a method that computes its position and decodes on-demand.
@@ -1611,6 +1735,26 @@ impl ClassDef {
     /// A [`TokenStream`] containing the impl block with getter methods.
     pub fn to_view_getters(&self, ident: &Ident) -> TokenStream {
         let ref_ident = Ident::new(&format!("{}Ref", ident), Span::call_site());
+
+        // Plain containers derive their layout from the field types' `Encode`
+        // impls at runtime (const-foldable), so views stay in agreement with
+        // the owned encoding even for class or external field types.
+        if matches!(self.base, BaseClass::Container) {
+            let getters: Vec<TokenStream> = self
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(idx, field)| self.container_view_getter(idx, field))
+                .collect();
+
+            return quote! {
+                #[allow(dead_code, reason = "generated code using ssz-gen")]
+                impl<'a> #ref_ident<'a> {
+                    #(#getters)*
+                }
+            };
+        }
+
         let (fixed_portion_size, _, num_variable_fields) = self.compute_layout();
 
         // Check if we need to account for bitvector (StableContainer/Profile with Optional fields)
@@ -1928,65 +2072,66 @@ impl ClassDef {
     /// A [`TokenStream`] containing the [`DecodeView`](ssz::view::DecodeView) implementation
     pub fn to_view_decode_impl(&self, ident: &Ident) -> TokenStream {
         let ref_ident = Ident::new(&format!("{}Ref", ident), Span::call_site());
-        let (fixed_portion_size, fixed_size, num_variable_fields) = self.compute_layout();
 
         match self.base {
             BaseClass::Container => {
-                // Generate validation code based on whether container is fixed or variable size
-                let validation = if let Some(expected_size) = fixed_size {
-                    // Fixed-size container: just check length
-                    quote! {
-                        if bytes.len() != #expected_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: #expected_size,
-                            });
-                        }
-                    }
-                } else {
-                    // Variable-size container: validate offset table
-                    quote! {
-                        if bytes.len() < #fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: #fixed_portion_size,
-                            });
-                        }
-
-                        // Validate offset table
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..#num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                #fixed_portion_size,
-                                #num_variable_fields,
-                                i
-                            )?;
-
-                            // First offset should point to start of variable portion
-                            if i == 0 && offset != #fixed_portion_size {
-                                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                            }
-
-                            // Offsets must not decrease
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-
-                            // Offset must not exceed container length
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-
-                            prev_offset = Some(offset);
-                        }
-                    }
-                };
+                // Layout is computed from the field types' `Encode` impls at
+                // runtime (const-foldable), so validation agrees with the
+                // owned encoding even for class or external field types.
+                let fixed_portion_expr = self.fixed_portion_size_expr();
+                let num_variable_expr = self.num_variable_fields_expr();
 
                 quote! {
                     impl<'a> ssz::view::DecodeView<'a> for #ref_ident<'a> {
                         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                            #validation
+                            let fixed_portion_size = #fixed_portion_expr;
+                            let num_variable_fields = #num_variable_expr;
+
+                            if num_variable_fields == 0 {
+                                // Fixed-size container: just check length
+                                if bytes.len() != fixed_portion_size {
+                                    return Err(ssz::DecodeError::InvalidByteLength {
+                                        len: bytes.len(),
+                                        expected: fixed_portion_size,
+                                    });
+                                }
+                            } else {
+                                if bytes.len() < fixed_portion_size {
+                                    return Err(ssz::DecodeError::InvalidByteLength {
+                                        len: bytes.len(),
+                                        expected: fixed_portion_size,
+                                    });
+                                }
+
+                                // Validate offset table
+                                let mut prev_offset: Option<usize> = None;
+                                for i in 0..num_variable_fields {
+                                    let offset = ssz::layout::read_variable_offset(
+                                        bytes,
+                                        fixed_portion_size,
+                                        num_variable_fields,
+                                        i
+                                    )?;
+
+                                    // First offset should point to start of variable portion
+                                    if i == 0 && offset != fixed_portion_size {
+                                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                                    }
+
+                                    // Offsets must not decrease
+                                    if let Some(prev) = prev_offset && offset < prev {
+                                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                                    }
+
+                                    // Offset must not exceed container length
+                                    if offset > bytes.len() {
+                                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                                    }
+
+                                    prev_offset = Some(offset);
+                                }
+                            }
+
                             Ok(Self { bytes })
                         }
                     }
@@ -2123,6 +2268,31 @@ impl ClassDef {
     /// A [`TokenStream`] containing the [`SszTypeInfo`](ssz::view::SszTypeInfo) implementation.
     pub fn to_view_ssz_type_info_impl(&self, ident: &Ident) -> TokenStream {
         let ref_ident = Ident::new(&format!("{}Ref", ident), Span::call_site());
+
+        // Plain containers derive fixedness from the field types' `Encode`
+        // impls at runtime (const-foldable), so views stay in agreement with
+        // the owned encoding even for class or external field types.
+        if matches!(self.base, BaseClass::Container) {
+            let fixed_portion_expr = self.fixed_portion_size_expr();
+            let num_variable_expr = self.num_variable_fields_expr();
+
+            return quote! {
+                impl<'a> ssz::view::SszTypeInfo for #ref_ident<'a> {
+                    fn is_ssz_fixed_len() -> bool {
+                        #num_variable_expr == 0
+                    }
+
+                    fn ssz_fixed_len() -> usize {
+                        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                            #fixed_portion_expr
+                        } else {
+                            0
+                        }
+                    }
+                }
+            };
+        }
+
         let (_, fixed_size, _) = self.compute_layout();
 
         match fixed_size {

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1165,17 +1165,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1183,38 +1186,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1258,49 +1265,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1418,17 +1399,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1436,38 +1420,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1511,51 +1499,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1902,13 +1862,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1916,14 +1879,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1960,47 +1926,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2699,23 +2637,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2723,120 +2669,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2894,57 +2848,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3080,17 +3011,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3098,38 +3032,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3173,49 +3111,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3340,17 +3252,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3358,38 +3273,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3433,49 +3352,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4026,17 +3919,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4044,38 +3940,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4119,51 +4019,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4504,13 +4376,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4518,14 +4393,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4562,47 +4440,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4728,24 +4578,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4755,94 +4608,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4915,58 +4758,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1163,39 +1163,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1213,14 +1233,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1234,21 +1258,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1346,46 +1416,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1410,54 +1493,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1783,27 +1900,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1821,35 +1942,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2531,70 +2697,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2612,14 +2855,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2629,54 +2876,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2785,60 +3078,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2881,40 +3173,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3019,53 +3338,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3108,40 +3433,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3672,53 +4024,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3761,40 +4119,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4114,41 +4502,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4184,40 +4562,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4326,74 +4726,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4465,40 +4915,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -1165,17 +1165,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1183,38 +1186,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1258,49 +1265,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1418,17 +1399,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1436,38 +1420,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1511,51 +1499,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1902,13 +1862,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1916,14 +1879,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1960,47 +1926,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2699,23 +2637,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2723,120 +2669,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2894,57 +2848,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3080,17 +3011,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3098,38 +3032,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3173,49 +3111,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3340,17 +3252,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3358,38 +3273,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3433,49 +3352,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4026,17 +3919,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4044,38 +3940,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4119,51 +4019,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4504,13 +4376,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4518,14 +4393,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4562,47 +4440,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4728,24 +4578,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4755,94 +4608,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4915,58 +4758,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -1163,39 +1163,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1213,14 +1233,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1234,21 +1258,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1346,46 +1416,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1410,54 +1493,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1783,27 +1900,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1821,35 +1942,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2531,70 +2697,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2612,14 +2855,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2629,54 +2876,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2785,60 +3078,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2881,40 +3173,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3019,53 +3338,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3108,40 +3433,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3672,53 +4024,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3761,40 +4119,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4114,41 +4502,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4184,40 +4562,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4326,74 +4726,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4465,40 +4915,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -129,106 +129,245 @@ pub mod tests {
                 pub fn tiny_list(
                     &self,
                 ) -> Result<BitListRef<'a, 1usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        37usize,
-                        3usize,
+                        <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        37usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn std_list(
                     &self,
                 ) -> Result<BitListRef<'a, 64usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        37usize,
-                        3usize,
-                        1usize,
+                        <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        37usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_list(
                     &self,
                 ) -> Result<BitListRef<'a, 256usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        37usize,
-                        3usize,
-                        2usize,
+                        <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        37usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn tiny_vec(
                     &self,
                 ) -> Result<BitVectorRef<'a, 1usize>, ssz::DecodeError> {
-                    let offset = 12usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn std_vec(
                     &self,
                 ) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 13usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                        <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_vec(
                     &self,
                 ) -> Result<BitVectorRef<'a, 128usize>, ssz::DecodeError> {
-                    let offset = 21usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                        <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -292,40 +431,95 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BitfieldContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 37usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 37usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            37usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 37usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                        + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                        + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                        + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                        + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                        + <LargeBitvector as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(!<LargeBitlist as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BitfieldContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(!<LargeBitlist as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
+                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
+                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -131,31 +131,32 @@ pub mod tests {
                 ) -> Result<BitListRef<'a, 1usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -165,32 +166,33 @@ pub mod tests {
                 ) -> Result<BitListRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -199,36 +201,33 @@ pub mod tests {
                 ) -> Result<BitListRef<'a, 256usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -237,40 +236,33 @@ pub mod tests {
                 ) -> Result<BitVectorRef<'a, 1usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -279,44 +271,33 @@ pub mod tests {
                 ) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
-                        <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -325,48 +306,33 @@ pub mod tests {
                 ) -> Result<BitVectorRef<'a, 128usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
-                        <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                            + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                            + <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<TinyBitlist as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        5usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -431,64 +397,35 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BitfieldContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <TinyBitlist as ssz::Encode>::ssz_fixed_len()
-                        + <StandardBitlist as ssz::Encode>::ssz_fixed_len()
-                        + <LargeBitlist as ssz::Encode>::ssz_fixed_len()
-                        + <TinyBitvector as ssz::Encode>::ssz_fixed_len()
-                        + <StandardBitvector as ssz::Encode>::ssz_fixed_len()
-                        + <LargeBitvector as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(!<LargeBitlist as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <TinyBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitlist as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitlist as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TinyBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <TinyBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <StandardBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <StandardBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <LargeBitvector as ssz::Encode>::is_ssz_fixed_len(),
+                                <LargeBitvector as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_comments.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_comments.rs
@@ -85,15 +85,20 @@ pub mod tests {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -101,34 +106,42 @@ pub mod tests {
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -172,49 +185,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for PointRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -325,13 +312,16 @@ pub mod tests {
                 pub fn lat(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -339,14 +329,17 @@ pub mod tests {
                 pub fn lon(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -383,47 +376,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for CoordinateContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
-                        + <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_comments.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_comments.rs
@@ -83,39 +83,53 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointRef<'a> {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -133,40 +147,91 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let x = self.x().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&x);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let y = self.y().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&y);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 8usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for PointRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for PointRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    12usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -258,27 +323,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CoordinateContainerRef<'a> {
                 pub fn lat(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn lon(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -296,35 +365,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let lat = self.lat().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&lat);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 8usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let lon = self.lon().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&lon);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for CoordinateContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
+                        + <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for CoordinateContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    16usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -1003,39 +1003,49 @@ pub struct AlphaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u16 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 3usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1053,14 +1063,18 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let a = self.a().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&a);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let b = self.b().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&b);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let c = self.c().expect("valid view");
@@ -1074,21 +1088,62 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 13usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 13usize,
-            });
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u16 as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        13usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1167,46 +1222,53 @@ pub struct BetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            7usize,
-            1usize,
+            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            7usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 5usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1231,49 +1293,82 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let e = self.e().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&e);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 5usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let f = self.f().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&f);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 7usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 7usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 7usize, 1usize, i)?;
-            if i == 0 && offset != 7usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1551,27 +1646,31 @@ pub struct DeltaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <bool as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1589,35 +1688,76 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let z = self.z().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&z);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let w = self.w().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&w);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 2usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 2usize,
-            });
+        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        2usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <bool as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2192,70 +2332,115 @@ pub struct TestTypeRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            54usize,
-            1usize,
-            0usize,
+            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            54usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-        let offset = 6usize;
-        let end = offset + 16usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U128 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <U128 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-        let offset = 22usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U256 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len(),
+            <U256 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2273,14 +2458,18 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ccc = self.ccc().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ccc);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ddd = self.ddd().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ddd);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let eee = self.eee().expect("valid view");
@@ -2290,49 +2479,90 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 6usize;
-            let field_bytes = &self.bytes[offset..offset + 16usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_128 = self.large_int_128().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_128);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 22usize;
-            let field_bytes = &self.bytes[offset..offset + 32usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_256 = self.large_int_256().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_256);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 54usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 54usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 54usize, 1usize, i)?;
-            if i == 0 && offset != 54usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+            + <U128 as ssz::Encode>::ssz_fixed_len()
+            + <U256 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2424,60 +2654,53 @@ pub struct EtaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
+            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            1usize,
+            <TestType as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <TestType as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            2usize,
+            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len(),
+            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2520,35 +2743,63 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 12usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 12usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 12usize, 3usize, i)?;
-            if i == 0 && offset != 12usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+            + <TestType as ssz::Encode>::ssz_fixed_len()
+            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2636,53 +2887,53 @@ pub struct ThetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
+            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
-            1usize,
+            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2725,35 +2976,64 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 18usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 18usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 18usize, 2usize, i)?;
-            if i == 0 && offset != 18usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+            + <UnionC as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3191,53 +3471,53 @@ pub struct KappaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <Beta as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Beta as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len(),
+            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3280,35 +3560,64 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+            + <Beta as ssz::Encode>::ssz_fixed_len()
+            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3584,41 +3893,31 @@ pub struct MuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
+            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
-            1usize,
+            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <UnionA as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3654,35 +3953,60 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 8usize, 2usize, i)?;
-            if i == 0 && offset != 8usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+            + <UnionA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3771,72 +4095,88 @@ pub struct NuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
+            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            1usize,
+            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            2usize,
+            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
                 len: 0,
@@ -3908,35 +4248,69 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 3usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -1005,14 +1005,20 @@ impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1020,31 +1026,42 @@ impl<'a> AlphaRef<'a> {
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u16 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1088,46 +1105,23 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u16 as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1224,15 +1218,20 @@ impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1240,34 +1239,42 @@ impl<'a> BetaRef<'a> {
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1311,47 +1318,23 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1648,13 +1631,16 @@ impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <bool as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1662,14 +1648,17 @@ impl<'a> DeltaRef<'a> {
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1706,44 +1695,19 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2334,19 +2298,28 @@ impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2354,92 +2327,116 @@ impl<'a> TestTypeRef<'a> {
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U128 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <U128 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U256 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len(),
-            <U256 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            4usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2497,51 +2494,31 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-            + <U128 as ssz::Encode>::ssz_fixed_len()
-            + <U256 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2656,15 +2633,20 @@ impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2672,34 +2654,42 @@ impl<'a> EtaRef<'a> {
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <TestType as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <TestType as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len(),
-            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2743,46 +2733,23 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-            + <TestType as ssz::Encode>::ssz_fixed_len()
-            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2889,15 +2856,20 @@ impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2905,34 +2877,42 @@ impl<'a> ThetaRef<'a> {
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2976,47 +2956,23 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-            + <UnionC as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3473,15 +3429,20 @@ impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3489,34 +3450,42 @@ impl<'a> KappaRef<'a> {
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Beta as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Beta as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len(),
-            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3560,47 +3529,23 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-            + <Beta as ssz::Encode>::ssz_fixed_len()
-            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3895,13 +3840,16 @@ impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3909,14 +3857,17 @@ impl<'a> MuRef<'a> {
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <UnionA as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3953,45 +3904,19 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-            + <UnionA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -4097,18 +4022,24 @@ impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4116,66 +4047,75 @@ impl<'a> NuRef<'a> {
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
@@ -4248,49 +4188,27 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -62,13 +62,16 @@ impl<'a> ExportEntryRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len()
-                + <u32 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -76,14 +79,17 @@ impl<'a> ExportEntryRef<'a> {
     pub fn data(&self) -> Result<u32, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u32 as ssz::Encode>::is_ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len()
-                + <u32 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -120,44 +126,19 @@ impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
-            + <u32 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -251,17 +232,22 @@ impl<'a> ExportContainerRef<'a> {
     ) -> Result<ListRef<'a, ExportEntryRef<'a>, 4096usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <u32 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<VariableList<
-                    ExportEntry,
-                    4096usize,
-                > as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -269,23 +255,23 @@ impl<'a> ExportContainerRef<'a> {
     pub fn name(&self) -> Result<u32, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u32 as ssz::Encode>::is_ssz_fixed_len(),
-            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <u32 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<VariableList<
-                    ExportEntry,
-                    4096usize,
-                > as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(
-                !<VariableList<
-                    ExportEntry,
-                    4096usize,
-                > as ssz::Encode>::is_ssz_fixed_len(),
-            ),
+            &[
+                (
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -322,47 +308,25 @@ impl<'a> tree_hash::TreeHash for ExportContainerRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportContainerRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <VariableList<
-            ExportEntry,
-            4096usize,
-        > as ssz::Encode>::ssz_fixed_len() + <u32 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<VariableList<ExportEntry, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<
+                        ExportEntry,
+                        4096usize,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -60,27 +60,31 @@ pub struct ExportEntryRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len()
+                + <u32 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn data(&self) -> Result<u32, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u32 as ssz::Encode>::is_ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len()
+                + <u32 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -98,35 +102,76 @@ impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 8usize;
-            let field_bytes = &self.bytes[offset..offset + 4usize];
-            hasher.write(field_bytes).expect("write field");
+            let data = self.data().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&data);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 12usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 12usize,
-            });
+        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
+            + <u32 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ExportEntryRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        12usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u64 as ssz::Encode>::ssz_fixed_len() + <u32 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -204,34 +249,44 @@ impl<'a> ExportContainerRef<'a> {
     pub fn entries(
         &self,
     ) -> Result<ListRef<'a, ExportEntryRef<'a>, 4096usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            1usize,
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <u32 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<VariableList<
+                    ExportEntry,
+                    4096usize,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn name(&self) -> Result<u32, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u32 as ssz::Encode>::is_ssz_fixed_len(),
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <u32 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<VariableList<
+                    ExportEntry,
+                    4096usize,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(
+                !<VariableList<
+                    ExportEntry,
+                    4096usize,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+            ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -256,44 +311,74 @@ impl<'a> tree_hash::TreeHash for ExportContainerRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 4usize];
-            hasher.write(field_bytes).expect("write field");
+            let name = self.name().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&name);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportContainerRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 8usize, 1usize, i)?;
-            if i == 0 && offset != 8usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <VariableList<
+            ExportEntry,
+            4096usize,
+        > as ssz::Encode>::ssz_fixed_len() + <u32 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<VariableList<ExportEntry, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ExportContainerRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(
+            !<VariableList<ExportEntry, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <VariableList<ExportEntry, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <u32 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -68,27 +68,31 @@ pub mod test_cross_entry_state {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> StateRef<'a> {
         pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 48usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 48usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -113,30 +117,72 @@ pub mod test_cross_entry_state {
                 hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 48usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let counter = self.counter().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&counter);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 56usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 56usize,
-                });
+            let fixed_portion_size = <FixedBytes<
+                48usize,
+            > as ssz::Encode>::ssz_fixed_len() + <u64 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for StateRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            56usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -239,53 +285,65 @@ pub mod test_cross_entry_update {
             crate::tests::input::test_cross_entry_state::StateRef<'a>,
             ssz::DecodeError,
         > {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                2usize,
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(
+                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 4usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(
+                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
+                usize::from(
+                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                2usize,
-                1usize,
+                <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len(),
+                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(
+                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
+                usize::from(
+                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -310,9 +368,11 @@ pub mod test_cross_entry_update {
                 hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 4usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let timestamp = self.timestamp().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&timestamp);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
                 let updates = self.updates().expect("valid view");
@@ -326,40 +386,69 @@ pub mod test_cross_entry_update {
     }
     impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 16usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 16usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..2usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    16usize,
-                    2usize,
-                    i,
-                )?;
-                if i == 0 && offset != 16usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                );
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for UpdateRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                    + <u64 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -70,13 +70,16 @@ pub mod test_cross_entry_state {
         pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -84,14 +87,17 @@ pub mod test_cross_entry_state {
         pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -128,46 +134,19 @@ pub mod test_cross_entry_state {
     }
     impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <FixedBytes<
-                48usize,
-            > as ssz::Encode>::ssz_fixed_len() + <u64 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -287,18 +266,20 @@ pub mod test_cross_entry_update {
         > {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(
-                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                     ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -306,43 +287,42 @@ pub mod test_cross_entry_update {
         pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(
-                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                     ),
-                usize::from(
-                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len(),
-                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                    + <u64 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(
-                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                     ),
-                usize::from(
-                    !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -386,49 +366,23 @@ pub mod test_cross_entry_update {
     }
     impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-                );
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -66,15 +66,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeARef<'a> {
                 pub fn value(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -92,30 +92,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for CommonTypeARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for CommonTypeARef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    4usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -195,15 +235,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeBRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -221,30 +261,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for CommonTypeBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for CommonTypeBRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -349,22 +429,27 @@ pub mod tests {
                     crate::tests::input::test_cross_entry_common::CommonTypeARef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn list(
@@ -377,22 +462,35 @@ pub mod tests {
                     >,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <VariableList<
+                            crate::tests::input::test_cross_entry_common::CommonTypeB,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            crate::tests::input::test_cross_entry_common::CommonTypeB,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -428,40 +526,81 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            crate::tests::input::test_cross_entry_common::CommonTypeB,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<VariableList<
+                                crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerARef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<VariableList<
+                                crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -68,11 +68,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -103,46 +104,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for CommonTypeARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -237,11 +207,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -272,46 +243,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for CommonTypeBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -431,23 +371,22 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                crate::tests::input::test_cross_entry_common::CommonTypeB,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     crate::tests::input::test_cross_entry_common::CommonTypeB,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -464,32 +403,23 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            crate::tests::input::test_cross_entry_common::CommonTypeB,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            crate::tests::input::test_cross_entry_common::CommonTypeB,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                crate::tests::input::test_cross_entry_common::CommonTypeB,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     crate::tests::input::test_cross_entry_common::CommonTypeB,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -526,56 +456,25 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            crate::tests::input::test_cross_entry_common::CommonTypeB,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<VariableList<
-                                crate::tests::input::test_cross_entry_common::CommonTypeB,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_common::CommonTypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    crate::tests::input::test_cross_entry_common::CommonTypeB,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -81,14 +81,16 @@ pub mod tests {
                 ) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -96,17 +98,17 @@ pub mod tests {
                 pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(
-                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -143,49 +145,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <FixedBytes<
-                        48usize,
-                    > as ssz::Encode>::ssz_fixed_len()
-                        + <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -321,24 +293,23 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -346,27 +317,24 @@ pub mod tests {
                 pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -375,28 +343,24 @@ pub mod tests {
                 ) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -440,54 +404,26 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                        + <u64 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u8,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -79,27 +79,35 @@ pub mod tests {
                 pub fn data(
                     &self,
                 ) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 48usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 48usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(
+                            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -124,30 +132,76 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 48usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let counter = self.counter().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&counter);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 56usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 56usize,
-                        });
+                    let fixed_portion_size = <FixedBytes<
+                        48usize,
+                    > as ssz::Encode>::ssz_fixed_len()
+                        + <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for StateRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(
+                        !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    56usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -265,55 +319,85 @@ pub mod tests {
                     crate::tests::input::test_cross_entry_state::StateRef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn updates(
                     &self,
                 ) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -338,9 +422,11 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let timestamp = self.timestamp().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&timestamp);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let updates = self.updates().expect("valid view");
@@ -354,40 +440,77 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                        + <u64 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u8,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for UpdateRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u8,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -66,13 +66,16 @@ impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -80,14 +83,17 @@ impl<'a> StateRef<'a> {
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -124,45 +130,19 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -268,18 +248,20 @@ impl<'a> UpdateRef<'a> {
     > {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -287,43 +269,42 @@ impl<'a> UpdateRef<'a> {
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -367,49 +348,23 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            );
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -64,27 +64,31 @@ pub struct StateRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 48usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 48usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -109,30 +113,71 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 48usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let counter = self.counter().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&counter);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 56usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 56usize,
-            });
+        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for StateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        56usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -221,53 +266,65 @@ impl<'a> UpdateRef<'a> {
         crate::tests::input::test_cross_entry_state::StateRef<'a>,
         ssz::DecodeError,
     > {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -292,9 +349,11 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let timestamp = self.timestamp().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&timestamp);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let updates = self.updates().expect("valid view");
@@ -308,35 +367,69 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            );
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for UpdateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
@@ -75,15 +75,16 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -93,16 +94,17 @@ pub mod tests {
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -139,50 +141,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerDataRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
-                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -291,21 +262,22 @@ pub mod tests {
                 pub fn inner(&self) -> Result<InnerDataRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <InnerData as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <InnerData as ssz::Encode>::ssz_fixed_len(),
-                        <InnerData as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                InnerData,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <InnerData as ssz::Encode>::is_ssz_fixed_len(),
+                                <InnerData as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     InnerData,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -315,28 +287,23 @@ pub mod tests {
                 ) -> Result<ListRef<'a, InnerDataRef<'a>, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            InnerData,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <InnerData as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            InnerData,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <InnerData as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                InnerData,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <InnerData as ssz::Encode>::is_ssz_fixed_len(),
+                                <InnerData as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     InnerData,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len()),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -373,56 +340,25 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for OuterContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <InnerData as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            InnerData,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<InnerData as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<VariableList<
-                                InnerData,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <InnerData as ssz::Encode>::is_ssz_fixed_len(),
+                                <InnerData as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
@@ -73,29 +73,37 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerDataRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn hash(
                     &self,
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -113,9 +121,11 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let hash = self.hash().expect("valid view");
@@ -129,21 +139,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerDataRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 40usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 40usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len()
+                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerDataRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    40usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -233,43 +289,55 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OuterContainerRef<'a> {
                 pub fn inner(&self) -> Result<InnerDataRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <InnerData as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <InnerData as ssz::Encode>::ssz_fixed_len(),
+                        <InnerData as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                InnerData,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn items(
                     &self,
                 ) -> Result<ListRef<'a, InnerDataRef<'a>, 10usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <VariableList<
+                            InnerData,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <InnerData as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            InnerData,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <InnerData as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                InnerData,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    InnerData,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -305,40 +373,79 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for OuterContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <InnerData as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            InnerData,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<InnerData as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<VariableList<
+                                InnerData,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for OuterContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<InnerData as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                InnerData,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <InnerData as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                InnerData,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -1165,17 +1165,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1183,38 +1186,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1258,49 +1265,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1418,17 +1399,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1436,38 +1420,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1511,51 +1499,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1902,13 +1862,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1916,14 +1879,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1960,47 +1926,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2699,23 +2637,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2723,120 +2669,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2894,57 +2848,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3080,17 +3011,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3098,38 +3032,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3173,49 +3111,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3340,17 +3252,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3358,38 +3273,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3433,49 +3352,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4026,17 +3919,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4044,38 +3940,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4119,51 +4019,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4504,13 +4376,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4518,14 +4393,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4562,47 +4440,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4728,24 +4578,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4755,94 +4608,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4915,58 +4758,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -1163,39 +1163,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1213,14 +1233,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1234,21 +1258,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1346,46 +1416,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1410,54 +1493,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1783,27 +1900,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1821,35 +1942,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2531,70 +2697,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2612,14 +2855,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2629,54 +2876,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2785,60 +3078,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2881,40 +3173,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3019,53 +3338,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3108,40 +3433,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3672,53 +4024,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3761,40 +4119,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4114,41 +4502,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4184,40 +4562,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4326,74 +4726,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4465,40 +4915,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -1165,17 +1165,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1183,38 +1186,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1258,49 +1265,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1418,17 +1399,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1436,38 +1420,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1511,51 +1499,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1902,13 +1862,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1916,14 +1879,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1960,47 +1926,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2699,23 +2637,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2723,120 +2669,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2894,57 +2848,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3080,17 +3011,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3098,38 +3032,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3173,49 +3111,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3340,17 +3252,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3358,38 +3273,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3433,49 +3352,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4026,17 +3919,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4044,38 +3940,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4119,51 +4019,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4504,13 +4376,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4518,14 +4393,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4562,47 +4440,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4728,24 +4578,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4755,94 +4608,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4915,58 +4758,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -1163,39 +1163,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1213,14 +1233,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1234,21 +1258,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1346,46 +1416,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1410,54 +1493,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1783,27 +1900,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1821,35 +1942,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2531,70 +2697,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2612,14 +2855,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2629,54 +2876,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2785,60 +3078,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2881,40 +3173,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3019,53 +3338,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3108,40 +3433,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3672,53 +4024,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3761,40 +4119,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4114,41 +4502,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4184,40 +4562,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4326,74 +4726,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4465,40 +4915,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -1152,17 +1152,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1170,38 +1173,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1245,49 +1252,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1392,17 +1373,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1410,38 +1394,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1485,51 +1473,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1850,13 +1810,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1864,14 +1827,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1908,47 +1874,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2608,23 +2546,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2632,120 +2578,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2803,57 +2757,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2976,17 +2907,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2994,38 +2928,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3069,49 +3007,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3223,17 +3135,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3241,38 +3156,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3316,49 +3235,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3883,17 +3776,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3901,38 +3797,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3976,51 +3876,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4335,13 +4207,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4349,14 +4224,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4393,47 +4271,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4546,24 +4396,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4573,94 +4426,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4733,58 +4576,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -1150,39 +1150,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1200,14 +1220,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1221,21 +1245,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1320,46 +1390,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1384,54 +1467,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1731,27 +1848,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1769,35 +1890,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2440,70 +2606,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2521,14 +2764,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2538,54 +2785,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2681,60 +2974,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2777,40 +3069,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2902,53 +3221,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2991,40 +3316,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3529,53 +3881,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3618,40 +3976,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3945,41 +4333,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4015,40 +4393,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4144,74 +4544,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4283,40 +4733,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -79,34 +79,35 @@ pub mod tests {
                     crate::tests::input::test_multi_import_base::BaseTypeRef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        1usize,
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn data(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -131,49 +132,74 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let data = self.data().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&data);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TypeARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TypeARef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -287,22 +313,22 @@ pub mod tests {
                     crate::tests::input::test_multi_import_base::BaseTypeRef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        10usize,
-                        2usize,
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        10usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn type_a(
@@ -311,34 +337,49 @@ pub mod tests {
                     crate::tests::input::test_multi_import_a::TypeARef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        10usize,
-                        2usize,
-                        1usize,
+                        <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        10usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn extra(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(
+                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -370,49 +411,82 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 8usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let extra = self.extra().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&extra);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TypeBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 10usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 10usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            10usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 10usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                        + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TypeBRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -511,15 +585,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BaseTypeRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -537,30 +611,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BaseTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BaseTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -81,14 +81,16 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -96,17 +98,17 @@ pub mod tests {
                 pub fn data(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -143,47 +145,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TypeARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -315,18 +289,20 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -339,46 +315,42 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn extra(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(
-                            !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -422,51 +394,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TypeBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len()
-                        + <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_base::BaseType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_multi_import_a::TypeA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -587,11 +531,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -622,46 +567,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BaseTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
@@ -76,44 +76,7 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FooRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = 0usize;
-                    let num_variable_fields = 0usize;
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(bytes, &[])?;
                     Ok(Self { bytes })
                 }
             }
@@ -218,13 +181,16 @@ pub mod tests {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -232,14 +198,17 @@ pub mod tests {
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -276,47 +245,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for PointWithBothRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -418,11 +359,12 @@ pub mod tests {
                 pub fn field(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -453,46 +395,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestMergeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
@@ -76,21 +76,57 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FooRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 0usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 0usize,
-                        });
+                    let fixed_portion_size = 0usize;
+                    let num_variable_fields = 0usize;
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for FooRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    0usize == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        0usize
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -180,27 +216,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointWithBothRef<'a> {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -218,35 +258,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let x = self.x().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&x);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let y = self.y().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&y);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for PointWithBothRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for PointWithBothRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -331,15 +416,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestMergeRef<'a> {
                 pub fn field(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -357,30 +442,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let field = self.field().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&field);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestMergeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 1usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 1usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestMergeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    1usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -1003,39 +1003,49 @@ pub struct AlphaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u16 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 3usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1053,14 +1063,18 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let a = self.a().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&a);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let b = self.b().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&b);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let c = self.c().expect("valid view");
@@ -1074,21 +1088,62 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 13usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 13usize,
-            });
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u16 as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        13usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1167,46 +1222,53 @@ pub struct BetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            7usize,
-            1usize,
+            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            7usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 5usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1231,49 +1293,82 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let e = self.e().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&e);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 5usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let f = self.f().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&f);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 7usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 7usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 7usize, 1usize, i)?;
-            if i == 0 && offset != 7usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1551,27 +1646,31 @@ pub struct DeltaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <bool as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1589,35 +1688,76 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let z = self.z().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&z);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let w = self.w().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&w);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 2usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 2usize,
-            });
+        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        2usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <bool as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2192,70 +2332,115 @@ pub struct TestTypeRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            54usize,
-            1usize,
-            0usize,
+            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            54usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-        let offset = 6usize;
-        let end = offset + 16usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U128 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <U128 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-        let offset = 22usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U256 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len(),
+            <U256 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2273,14 +2458,18 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ccc = self.ccc().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ccc);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ddd = self.ddd().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ddd);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let eee = self.eee().expect("valid view");
@@ -2290,49 +2479,90 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 6usize;
-            let field_bytes = &self.bytes[offset..offset + 16usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_128 = self.large_int_128().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_128);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 22usize;
-            let field_bytes = &self.bytes[offset..offset + 32usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_256 = self.large_int_256().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_256);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 54usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 54usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 54usize, 1usize, i)?;
-            if i == 0 && offset != 54usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+            + <U128 as ssz::Encode>::ssz_fixed_len()
+            + <U256 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2424,60 +2654,53 @@ pub struct EtaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
+            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            1usize,
+            <TestType as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <TestType as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            2usize,
+            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len(),
+            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2520,35 +2743,63 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 12usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 12usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 12usize, 3usize, i)?;
-            if i == 0 && offset != 12usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+            + <TestType as ssz::Encode>::ssz_fixed_len()
+            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2636,53 +2887,53 @@ pub struct ThetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
+            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
-            1usize,
+            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2725,35 +2976,64 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 18usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 18usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 18usize, 2usize, i)?;
-            if i == 0 && offset != 18usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+            + <UnionC as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3191,53 +3471,53 @@ pub struct KappaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <Beta as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Beta as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len(),
+            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3280,35 +3560,64 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+            + <Beta as ssz::Encode>::ssz_fixed_len()
+            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3584,41 +3893,31 @@ pub struct MuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
+            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
-            1usize,
+            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <UnionA as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3654,35 +3953,60 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 8usize, 2usize, i)?;
-            if i == 0 && offset != 8usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+            + <UnionA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3771,72 +4095,88 @@ pub struct NuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
+            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            1usize,
+            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            2usize,
+            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
                 len: 0,
@@ -3908,35 +4248,69 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 3usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -1005,14 +1005,20 @@ impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1020,31 +1026,42 @@ impl<'a> AlphaRef<'a> {
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u16 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1088,46 +1105,23 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u16 as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1224,15 +1218,20 @@ impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1240,34 +1239,42 @@ impl<'a> BetaRef<'a> {
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1311,47 +1318,23 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1648,13 +1631,16 @@ impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <bool as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1662,14 +1648,17 @@ impl<'a> DeltaRef<'a> {
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1706,44 +1695,19 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2334,19 +2298,28 @@ impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2354,92 +2327,116 @@ impl<'a> TestTypeRef<'a> {
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U128 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <U128 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U256 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len(),
-            <U256 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            4usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2497,51 +2494,31 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-            + <U128 as ssz::Encode>::ssz_fixed_len()
-            + <U256 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2656,15 +2633,20 @@ impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2672,34 +2654,42 @@ impl<'a> EtaRef<'a> {
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <TestType as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <TestType as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len(),
-            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2743,46 +2733,23 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-            + <TestType as ssz::Encode>::ssz_fixed_len()
-            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2889,15 +2856,20 @@ impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2905,34 +2877,42 @@ impl<'a> ThetaRef<'a> {
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2976,47 +2956,23 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-            + <UnionC as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3473,15 +3429,20 @@ impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3489,34 +3450,42 @@ impl<'a> KappaRef<'a> {
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Beta as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Beta as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len(),
-            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3560,47 +3529,23 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-            + <Beta as ssz::Encode>::ssz_fixed_len()
-            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3895,13 +3840,16 @@ impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3909,14 +3857,17 @@ impl<'a> MuRef<'a> {
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <UnionA as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3953,45 +3904,19 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-            + <UnionA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -4097,18 +4022,24 @@ impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4116,66 +4047,75 @@ impl<'a> NuRef<'a> {
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
@@ -4248,49 +4188,27 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -92,14 +92,16 @@ pub mod tests {
                 ) -> Result<crate::existing_module::ExistingType, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
-                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -107,17 +109,17 @@ pub mod tests {
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(
-                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -154,47 +156,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestExistingModuleRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
-                        + <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -90,34 +90,35 @@ pub mod tests {
                 pub fn existing_field(
                     &self,
                 ) -> Result<crate::existing_module::ExistingType, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        1usize,
+                        <crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
+                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(
+                            !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -142,49 +143,74 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let slot = self.slot().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&slot);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestExistingModuleRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
+                        + <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestExistingModuleRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::existing_module::ExistingType as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::existing_module::ExistingType as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -1165,17 +1165,20 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1183,38 +1186,42 @@ pub mod tests {
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1258,49 +1265,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1418,17 +1399,20 @@ pub mod tests {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1436,38 +1420,42 @@ pub mod tests {
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1511,51 +1499,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1902,13 +1862,16 @@ pub mod tests {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <bool as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1916,14 +1879,17 @@ pub mod tests {
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <bool as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1960,47 +1926,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                                <bool as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2699,23 +2637,31 @@ pub mod tests {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2723,120 +2669,128 @@ pub mod tests {
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                            + <U128 as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u16,
                                     3usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<VariableList<
-                                    u16,
-                                    3usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -2894,57 +2848,34 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                        + <U128 as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u16,
-                                3usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U128 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3080,17 +3011,20 @@ pub mod tests {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3098,38 +3032,42 @@ pub mod tests {
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len(),
-                        <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len(),
-                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        <Zeta as ssz::Encode>::ssz_fixed_len()
-                            + <TestType as ssz::Encode>::ssz_fixed_len()
-                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3173,49 +3111,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                        + <TestType as ssz::Encode>::ssz_fixed_len()
-                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestType as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3340,17 +3252,20 @@ pub mod tests {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3358,38 +3273,42 @@ pub mod tests {
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len(),
-                        <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        <UnionB as ssz::Encode>::ssz_fixed_len()
-                            + <UnionC as ssz::Encode>::ssz_fixed_len()
-                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -3433,49 +3352,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                        + <UnionC as ssz::Encode>::ssz_fixed_len()
-                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4026,17 +3919,20 @@ pub mod tests {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4044,38 +3940,42 @@ pub mod tests {
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len(),
-                        <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len(),
-                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        <Alpha as ssz::Encode>::ssz_fixed_len()
-                            + <Beta as ssz::Encode>::ssz_fixed_len()
-                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4119,51 +4019,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                        + <Beta as ssz::Encode>::ssz_fixed_len()
-                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                                <Beta as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4504,13 +4376,16 @@ pub mod tests {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4518,14 +4393,17 @@ pub mod tests {
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len(),
-                        <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        <Lambda as ssz::Encode>::ssz_fixed_len()
-                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -4562,47 +4440,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                        + <UnionA as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4728,24 +4578,27 @@ pub mod tests {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4755,94 +4608,84 @@ pub mod tests {
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        <AliasMu as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
-                                    bool,
-                                    4usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedVector<
+                            (
+                                <FixedVector<
                                     bool,
                                     4usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -4915,58 +4758,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedVector<
-                                bool,
-                                4usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -1163,39 +1163,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1213,14 +1233,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let c = self.c().expect("valid view");
@@ -1234,21 +1258,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 13usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 13usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    13usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1346,46 +1416,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
                 pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        7usize,
-                        1usize,
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 5usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1410,54 +1493,88 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let e = self.e().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&e);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 5usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let f = self.f().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&f);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1783,27 +1900,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
                 pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1821,35 +1942,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let z = self.z().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&z);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let w = self.w().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&w);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<bool as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <bool as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2531,70 +2697,147 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        54usize,
-                        1usize,
-                        0usize,
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        54usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-                    let offset = 6usize;
-                    let end = offset + 16usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 22usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<VariableList<
+                                    u16,
+                                    3usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2612,14 +2855,18 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ccc = self.ccc().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ccc);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let ddd = self.ddd().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&ddd);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let eee = self.eee().expect("valid view");
@@ -2629,54 +2876,100 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 6usize;
-                        let field_bytes = &self.bytes[offset..offset + 16usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_128 = self.large_int_128().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_128);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 22usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let large_int_256 = self.large_int_256().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&large_int_256);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 54usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 54usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            54usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 54usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                        + <U128 as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u16,
+                                3usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                            + <U128 as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2785,60 +3078,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -2881,40 +3173,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                        + <TestType as ssz::Encode>::ssz_fixed_len()
+                        + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Zeta as ssz::Encode>::ssz_fixed_len()
+                            + <TestType as ssz::Encode>::ssz_fixed_len()
+                            + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3019,53 +3338,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
                 pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        18usize,
-                        2usize,
-                        1usize,
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        18usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 10usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3108,40 +3433,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 18usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 18usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            18usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 18usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                        + <UnionC as ssz::Encode>::ssz_fixed_len()
+                        + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <UnionB as ssz::Encode>::ssz_fixed_len()
+                            + <UnionC as ssz::Encode>::ssz_fixed_len()
+                            + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3672,53 +4024,59 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
                 pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        2usize,
-                        1usize,
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -3761,40 +4119,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                        + <Beta as ssz::Encode>::ssz_fixed_len()
+                        + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Alpha as ssz::Encode>::ssz_fixed_len()
+                            + <Beta as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4114,41 +4502,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
                 pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -4184,40 +4562,62 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                        + <UnionA as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Lambda as ssz::Encode>::ssz_fixed_len()
+                            + <UnionA as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -4326,74 +4726,124 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
                 pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn aaa(
                     &self,
                 ) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedVector<
+                                    bool,
+                                    4usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -4465,40 +4915,83 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                        + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                        + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedVector<
+                                bool,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AliasMu as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_external.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external.rs
@@ -405,43 +405,43 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExternalContainerRef<'a> {
                 pub fn field_a(&self) -> Result<external_ssz::A, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::A as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn field_b(
                     &self,
                 ) -> Result<external_ssz::module_a::module_b::B, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::A as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -477,40 +477,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <external_ssz::A as ssz::Encode>::ssz_fixed_len()
+                        + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ExternalContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<external_ssz::A as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <external_ssz::A as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_external.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external.rs
@@ -407,17 +407,16 @@ pub mod tests {
                 pub fn field_a(&self) -> Result<external_ssz::A, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::A as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -427,20 +426,17 @@ pub mod tests {
                 ) -> Result<external_ssz::module_a::module_b::B, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::A as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                            (
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -477,50 +473,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <external_ssz::A as ssz::Encode>::ssz_fixed_len()
-                        + <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <external_ssz::A as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::A as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::module_a::module_b::B as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container.rs
@@ -77,15 +77,16 @@ pub mod tests {
                 pub fn height(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -95,16 +96,17 @@ pub mod tests {
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -141,50 +143,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -309,17 +280,16 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -332,20 +302,17 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
-                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
-                            + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -382,50 +349,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockRangeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
-                        + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                                <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container.rs
@@ -75,29 +75,37 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 pub fn height(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn block_hash(
                     &self,
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -115,9 +123,11 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let height = self.height().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&height);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let block_hash = self.block_hash().expect("valid view");
@@ -131,21 +141,67 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 36usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 36usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    36usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -251,22 +307,21 @@ pub mod tests {
                     crate::tests::input::test_external_inner::BlockCommitmentRef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn end(
@@ -275,22 +330,23 @@ pub mod tests {
                     crate::tests::input::test_external_inner::BlockCommitmentRef<'a>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -326,40 +382,69 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockRangeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
+                        + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BlockRangeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
+                            + <crate::tests::input::test_external_inner::BlockCommitment as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -184,25 +184,18 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            PendingInputEntry,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <VariableList<
-                            PendingInputEntry,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            PendingInputEntry,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                PendingInputEntry,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <VariableList<
+                                    PendingInputEntry,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    PendingInputEntry,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -233,52 +226,21 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <VariableList<
-                        PendingInputEntry,
-                        10usize,
-                    > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<VariableList<
-                            PendingInputEntry,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    PendingInputEntry,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    PendingInputEntry,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -28,13 +28,13 @@ pub mod tests {
                 fn tree_hash_packing_factor() -> usize {
                     unreachable!("Union should never be packed")
                 }
-                fn tree_hash_root<__H: tree_hash::TreeHashDigest>(&self) -> __H::Output {
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     match self {
                         PendingInputEntry::Deposit(inner) => {
                             let root = <_ as tree_hash::TreeHash>::tree_hash_root::<
-                                __H,
+                                H,
                             >(inner);
-                            tree_hash::mix_in_selector_with_hasher::<__H>(&root, 0u8)
+                            tree_hash::mix_in_selector_with_hasher::<H>(&root, 0u8)
                                 .expect("valid selector")
                         }
                     }
@@ -182,22 +182,29 @@ pub mod tests {
                     ListRef<'a, PendingInputEntryRef<'a>, 10usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                PendingInputEntry,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -226,40 +233,73 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <VariableList<
+                        PendingInputEntry,
+                        10usize,
+                    > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<
+                            PendingInputEntry,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -112,47 +112,46 @@ pub mod tests {
                 ) -> Result<external_ssz::ChainStateRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     external_ssz::BlockHeader,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::Transaction,
                                     100usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::AccountId,
                                     50usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -162,50 +161,47 @@ pub mod tests {
                 ) -> Result<external_ssz::Balance, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     external_ssz::BlockHeader,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::Transaction,
                                     100usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::AccountId,
                                     50usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -217,60 +213,47 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedVector<
-                            external_ssz::BlockHeader,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
-                        <FixedVector<
-                            external_ssz::BlockHeader,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     external_ssz::BlockHeader,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::Transaction,
                                     100usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::AccountId,
                                     50usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -282,70 +265,47 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            external_ssz::Transaction,
-                            100usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            external_ssz::Transaction,
-                            100usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     external_ssz::BlockHeader,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::Transaction,
                                     100usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::AccountId,
                                     50usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
-                                    external_ssz::BlockHeader,
-                                    10usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -357,80 +317,47 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            external_ssz::AccountId,
-                            50usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            external_ssz::AccountId,
-                            50usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                            + <FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
                                     external_ssz::BlockHeader,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::Transaction,
                                     100usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::AccountId,
                                     50usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedVector<
-                                    external_ssz::BlockHeader,
-                                    10usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
-                                    external_ssz::Transaction,
-                                    100usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
+                        ],
+                        4usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -488,80 +415,49 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalPragmaTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
-                        + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
-                        + <FixedVector<
-                            external_ssz::BlockHeader,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            external_ssz::Transaction,
-                            100usize,
-                        > as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            external_ssz::AccountId,
-                            50usize,
-                        > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<FixedVector<
-                                external_ssz::BlockHeader,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<VariableList<
-                                external_ssz::Transaction,
-                                100usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<VariableList<
-                                external_ssz::AccountId,
-                                50usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -110,43 +110,103 @@ pub mod tests {
                 pub fn state(
                     &self,
                 ) -> Result<external_ssz::ChainStateRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        20usize,
-                        5usize,
+                        <external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        20usize,
-                        5usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn balance(
                     &self,
                 ) -> Result<external_ssz::Balance, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        20usize,
-                        5usize,
-                        1usize,
+                        <external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        20usize,
-                        5usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn headers(
@@ -155,22 +215,63 @@ pub mod tests {
                     FixedVectorRef<'a, external_ssz::BlockHeaderRef<'a>, 10usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        20usize,
-                        5usize,
-                        2usize,
+                        <FixedVector<
+                            external_ssz::BlockHeader,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len(),
+                        <FixedVector<
+                            external_ssz::BlockHeader,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        20usize,
-                        5usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn transactions(
@@ -179,22 +280,73 @@ pub mod tests {
                     ListRef<'a, external_ssz::TransactionRef<'a>, 100usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        20usize,
-                        5usize,
-                        3usize,
+                        <VariableList<
+                            external_ssz::Transaction,
+                            100usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            external_ssz::Transaction,
+                            100usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        20usize,
-                        5usize,
-                        4usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn account_ids(
@@ -203,22 +355,83 @@ pub mod tests {
                     ListRef<'a, external_ssz::AccountId, 50usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        20usize,
-                        5usize,
-                        4usize,
+                        <VariableList<
+                            external_ssz::AccountId,
+                            50usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            external_ssz::AccountId,
+                            50usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::AccountId,
+                                    50usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedVector<
+                                    external_ssz::BlockHeader,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::Transaction,
+                                    100usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        20usize,
-                        5usize,
-                        5usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -275,40 +488,129 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalPragmaTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 20usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 20usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..5usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            20usize,
-                            5usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 20usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                        + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                        + <FixedVector<
+                            external_ssz::BlockHeader,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            external_ssz::Transaction,
+                            100usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            external_ssz::AccountId,
+                            50usize,
+                        > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ExternalPragmaTestRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<external_ssz::ChainState as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<external_ssz::Balance as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <external_ssz::ChainState as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::Balance as ssz::Encode>::ssz_fixed_len()
+                            + <FixedVector<
+                                external_ssz::BlockHeader,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::Transaction,
+                                100usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::AccountId,
+                                50usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -90,27 +90,26 @@ pub mod tests {
                 ) -> Result<external_ssz::MsgPayloadRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::MessagePayload,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::MessagePayload,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -120,30 +119,27 @@ pub mod tests {
                 ) -> Result<external_ssz::AccountId, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::MessagePayload,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::MessagePayload,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -155,40 +151,27 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            external_ssz::MessagePayload,
-                            10usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            external_ssz::MessagePayload,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
-                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                external_ssz::MessagePayload,
-                                10usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     external_ssz::MessagePayload,
                                     10usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -232,60 +215,29 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithExternalRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
-                        + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            external_ssz::MessagePayload,
-                            10usize,
-                        > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<VariableList<
-                                external_ssz::MessagePayload,
-                                10usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                                <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -88,43 +88,63 @@ pub mod tests {
                 pub fn payload(
                     &self,
                 ) -> Result<external_ssz::MsgPayloadRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn account_id(
                     &self,
                 ) -> Result<external_ssz::AccountId, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn messages(
@@ -133,22 +153,43 @@ pub mod tests {
                     ListRef<'a, external_ssz::MessagePayloadRef<'a>, 10usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <VariableList<
+                            external_ssz::MessagePayload,
+                            10usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            external_ssz::MessagePayload,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    external_ssz::MessagePayload,
+                                    10usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -191,40 +232,89 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithExternalRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                        + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            external_ssz::MessagePayload,
+                            10usize,
+                        > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerWithExternalRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<external_ssz::MsgPayload as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<external_ssz::AccountId as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <external_ssz::MsgPayload as ssz::Encode>::ssz_fixed_len()
+                            + <external_ssz::AccountId as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                external_ssz::MessagePayload,
+                                10usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1020,15 +1020,20 @@ pub mod test_1 {
         pub fn a(&self) -> Result<u8, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u16 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1036,34 +1041,42 @@ pub mod test_1 {
         pub fn b(&self) -> Result<u16, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <u16 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u16 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u16 as ssz::Encode>::ssz_fixed_len(),
-                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u16 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -1107,47 +1120,23 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -1245,15 +1234,20 @@ pub mod test_1 {
         pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1261,34 +1255,42 @@ pub mod test_1 {
         pub fn e(&self) -> Result<u8, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn f(&self) -> Result<u16, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len(),
-                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -1332,47 +1334,23 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -1669,13 +1647,16 @@ pub mod test_1 {
         pub fn z(&self) -> Result<bool, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <bool as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <bool as ssz::Encode>::ssz_fixed_len(),
-                <bool as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1683,14 +1664,17 @@ pub mod test_1 {
         pub fn w(&self) -> Result<u8, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                <bool as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <bool as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -1727,45 +1711,19 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<bool as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <bool as ssz::Encode>::is_ssz_fixed_len(),
+                        <bool as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -2365,20 +2323,28 @@ pub mod test_1 {
         pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2386,99 +2352,116 @@ pub mod test_1 {
         pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len(),
-                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <U128 as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-                <U128 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
                     ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                3usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len(),
-                <U256 as ssz::Encode>::ssz_fixed_len(),
-                <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <u8 as ssz::Encode>::ssz_fixed_len()
-                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                    + <U128 as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                4usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -2536,52 +2519,31 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U128 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -2697,15 +2659,20 @@ pub mod test_1 {
         pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <Zeta as ssz::Encode>::ssz_fixed_len(),
-                <Zeta as ssz::Encode>::ssz_fixed_len()
-                    + <TestType as ssz::Encode>::ssz_fixed_len()
-                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2713,34 +2680,42 @@ pub mod test_1 {
         pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <TestType as ssz::Encode>::is_ssz_fixed_len(),
-                <Zeta as ssz::Encode>::ssz_fixed_len(),
-                <TestType as ssz::Encode>::ssz_fixed_len(),
-                <Zeta as ssz::Encode>::ssz_fixed_len()
-                    + <TestType as ssz::Encode>::ssz_fixed_len()
-                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-                <Zeta as ssz::Encode>::ssz_fixed_len()
-                    + <TestType as ssz::Encode>::ssz_fixed_len(),
-                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                <Zeta as ssz::Encode>::ssz_fixed_len()
-                    + <TestType as ssz::Encode>::ssz_fixed_len()
-                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -2784,47 +2759,23 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Zeta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                        <TestType as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -2931,15 +2882,20 @@ pub mod test_1 {
         pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <UnionB as ssz::Encode>::ssz_fixed_len(),
-                <UnionB as ssz::Encode>::ssz_fixed_len()
-                    + <UnionC as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2947,34 +2903,42 @@ pub mod test_1 {
         pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-                <UnionB as ssz::Encode>::ssz_fixed_len(),
-                <UnionC as ssz::Encode>::ssz_fixed_len(),
-                <UnionB as ssz::Encode>::ssz_fixed_len()
-                    + <UnionC as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-                <UnionB as ssz::Encode>::ssz_fixed_len()
-                    + <UnionC as ssz::Encode>::ssz_fixed_len(),
-                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                <UnionB as ssz::Encode>::ssz_fixed_len()
-                    + <UnionC as ssz::Encode>::ssz_fixed_len()
-                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -3018,47 +2982,23 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionB as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionC as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -3515,17 +3455,20 @@ pub mod test_1 {
         pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <Alpha as ssz::Encode>::ssz_fixed_len(),
-                <Alpha as ssz::Encode>::ssz_fixed_len()
-                    + <Beta as ssz::Encode>::ssz_fixed_len()
-                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
                     ),
+                    (
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3533,38 +3476,42 @@ pub mod test_1 {
         pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Beta as ssz::Encode>::is_ssz_fixed_len(),
-                <Alpha as ssz::Encode>::ssz_fixed_len(),
-                <Beta as ssz::Encode>::ssz_fixed_len(),
-                <Alpha as ssz::Encode>::ssz_fixed_len()
-                    + <Beta as ssz::Encode>::ssz_fixed_len()
-                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
                     ),
-                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+                    (
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-                <Alpha as ssz::Encode>::ssz_fixed_len()
-                    + <Beta as ssz::Encode>::ssz_fixed_len(),
-                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                <Alpha as ssz::Encode>::ssz_fixed_len()
-                    + <Beta as ssz::Encode>::ssz_fixed_len()
-                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
                     ),
-                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+                    (
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -3608,47 +3555,23 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                        <Alpha as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                        <Beta as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -3944,13 +3867,16 @@ pub mod test_1 {
         pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <Lambda as ssz::Encode>::ssz_fixed_len(),
-                <Lambda as ssz::Encode>::ssz_fixed_len()
-                    + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3958,14 +3884,17 @@ pub mod test_1 {
         pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-                <Lambda as ssz::Encode>::ssz_fixed_len(),
-                <UnionA as ssz::Encode>::ssz_fixed_len(),
-                <Lambda as ssz::Encode>::ssz_fixed_len()
-                    + <UnionA as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -4002,45 +3931,19 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                        <Lambda as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                        <UnionA as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -4154,18 +4057,24 @@ pub mod test_1 {
         pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4173,66 +4082,75 @@ pub mod test_1 {
         pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len(),
-                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-                <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                &[
+                    (
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
                     ),
+                    (
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                2usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                    + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                <AliasMu as ssz::Encode>::ssz_fixed_len()
-                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(
-                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                3usize,
             )?;
             if bytes.is_empty() {
                 return Err(ssz::DecodeError::InvalidByteLength {
@@ -4305,51 +4223,27 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-            )
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                        <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                        <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                        <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1018,39 +1018,53 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> AlphaRef<'a> {
         pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u16 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-            let offset = 1usize;
-            let end = offset + 2usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <u16 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u16 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-            let offset = 3usize;
-            let end = offset + 10usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u16 as ssz::Encode>::ssz_fixed_len(),
+                <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u16 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -1068,14 +1082,18 @@ pub mod test_1 {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let a = self.a().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&a);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 1usize;
-                let field_bytes = &self.bytes[offset..offset + 2usize];
-                hasher.write(field_bytes).expect("write field");
+                let b = self.b().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&b);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
                 let c = self.c().expect("valid view");
@@ -1089,21 +1107,64 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 13usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 13usize,
-                });
+            let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            13usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u16 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1182,46 +1243,53 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BetaRef<'a> {
         pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                7usize,
-                1usize,
+                <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                7usize,
-                1usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-            let offset = 4usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-            let offset = 5usize;
-            let end = offset + 2usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len(),
+                <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -1246,54 +1314,82 @@ pub mod test_1 {
                 hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 4usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let e = self.e().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&e);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 5usize;
-                let field_bytes = &self.bytes[offset..offset + 2usize];
-                hasher.write(field_bytes).expect("write field");
+                let f = self.f().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&f);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 7usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 7usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..1usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    7usize,
-                    1usize,
-                    i,
-                )?;
-                if i == 0 && offset != 7usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1571,27 +1667,31 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> DeltaRef<'a> {
         pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <bool as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <bool as ssz::Encode>::ssz_fixed_len(),
+                <bool as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-            let offset = 1usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                <bool as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <bool as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -1609,35 +1709,78 @@ pub mod test_1 {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let z = self.z().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&z);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 1usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let w = self.w().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&w);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 2usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 2usize,
-                });
+            let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<bool as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            2usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <bool as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2220,70 +2363,123 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> TestTypeRef<'a> {
         pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-            let offset = 1usize;
-            let end = offset + 1usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                54usize,
-                1usize,
-                0usize,
+                <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len(),
+                <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                54usize,
-                1usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-            let offset = 6usize;
-            let end = offset + 16usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                <U128 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-            let offset = 22usize;
-            let end = offset + 32usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len(),
+                <U256 as ssz::Encode>::ssz_fixed_len(),
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -2301,14 +2497,18 @@ pub mod test_1 {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let ccc = self.ccc().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&ccc);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 1usize;
-                let field_bytes = &self.bytes[offset..offset + 1usize];
-                hasher.write(field_bytes).expect("write field");
+                let ddd = self.ddd().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&ddd);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
                 let eee = self.eee().expect("valid view");
@@ -2318,54 +2518,92 @@ pub mod test_1 {
                 hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 6usize;
-                let field_bytes = &self.bytes[offset..offset + 16usize];
-                hasher.write(field_bytes).expect("write field");
+                let large_int_128 = self.large_int_128().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&large_int_128);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 22usize;
-                let field_bytes = &self.bytes[offset..offset + 32usize];
-                hasher.write(field_bytes).expect("write field");
+                let large_int_256 = self.large_int_256().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&large_int_256);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 54usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 54usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..1usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    54usize,
-                    1usize,
-                    i,
-                )?;
-                if i == 0 && offset != 54usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <u8 as ssz::Encode>::ssz_fixed_len()
+                    + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                    + <U128 as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2457,60 +2695,53 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EtaRef<'a> {
         pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                12usize,
-                3usize,
+                <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                <Zeta as ssz::Encode>::ssz_fixed_len()
+                    + <TestType as ssz::Encode>::ssz_fixed_len()
+                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                12usize,
-                3usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                12usize,
-                3usize,
-                1usize,
+                <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                <Zeta as ssz::Encode>::ssz_fixed_len(),
+                <TestType as ssz::Encode>::ssz_fixed_len(),
+                <Zeta as ssz::Encode>::ssz_fixed_len()
+                    + <TestType as ssz::Encode>::ssz_fixed_len()
+                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                12usize,
-                3usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                12usize,
-                3usize,
-                2usize,
+                <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                <Zeta as ssz::Encode>::ssz_fixed_len()
+                    + <TestType as ssz::Encode>::ssz_fixed_len(),
+                <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                <Zeta as ssz::Encode>::ssz_fixed_len()
+                    + <TestType as ssz::Encode>::ssz_fixed_len()
+                    + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                12usize,
-                3usize,
-                3usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -2553,40 +2784,64 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 12usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 12usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..3usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    12usize,
-                    3usize,
-                    i,
-                )?;
-                if i == 0 && offset != 12usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<Zeta as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <Zeta as ssz::Encode>::ssz_fixed_len()
+                    + <TestType as ssz::Encode>::ssz_fixed_len()
+                    + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2674,53 +2929,53 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> ThetaRef<'a> {
         pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                18usize,
-                2usize,
+                <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                <UnionB as ssz::Encode>::ssz_fixed_len()
+                    + <UnionC as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                18usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                18usize,
-                2usize,
-                1usize,
+                <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                <UnionB as ssz::Encode>::ssz_fixed_len(),
+                <UnionC as ssz::Encode>::ssz_fixed_len(),
+                <UnionB as ssz::Encode>::ssz_fixed_len()
+                    + <UnionC as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                18usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-            let offset = 8usize;
-            let end = offset + 10usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                <UnionB as ssz::Encode>::ssz_fixed_len()
+                    + <UnionC as ssz::Encode>::ssz_fixed_len(),
+                <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                <UnionB as ssz::Encode>::ssz_fixed_len()
+                    + <UnionC as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -2763,40 +3018,64 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 18usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 18usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..2usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    18usize,
-                    2usize,
-                    i,
-                )?;
-                if i == 0 && offset != 18usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <UnionB as ssz::Encode>::ssz_fixed_len()
+                    + <UnionC as ssz::Encode>::ssz_fixed_len()
+                    + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3234,53 +3513,59 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> KappaRef<'a> {
         pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                2usize,
+                <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                <Alpha as ssz::Encode>::ssz_fixed_len()
+                    + <Beta as ssz::Encode>::ssz_fixed_len()
+                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                2usize,
-                1usize,
+                <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                <Alpha as ssz::Encode>::ssz_fixed_len(),
+                <Beta as ssz::Encode>::ssz_fixed_len(),
+                <Alpha as ssz::Encode>::ssz_fixed_len()
+                    + <Beta as ssz::Encode>::ssz_fixed_len()
+                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
+                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-            let offset = 8usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                <Alpha as ssz::Encode>::ssz_fixed_len()
+                    + <Beta as ssz::Encode>::ssz_fixed_len(),
+                <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                <Alpha as ssz::Encode>::ssz_fixed_len()
+                    + <Beta as ssz::Encode>::ssz_fixed_len()
+                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
+                usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -3323,40 +3608,65 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 16usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 16usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..2usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    16usize,
-                    2usize,
-                    i,
-                )?;
-                if i == 0 && offset != 16usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len())
+                == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <Alpha as ssz::Encode>::ssz_fixed_len()
+                    + <Beta as ssz::Encode>::ssz_fixed_len()
+                    + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3632,41 +3942,31 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> MuRef<'a> {
         pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                8usize,
-                2usize,
+                <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                <Lambda as ssz::Encode>::ssz_fixed_len()
+                    + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                8usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                8usize,
-                2usize,
-                1usize,
+                <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                <Lambda as ssz::Encode>::ssz_fixed_len(),
+                <UnionA as ssz::Encode>::ssz_fixed_len(),
+                <Lambda as ssz::Encode>::ssz_fixed_len()
+                    + <UnionA as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                8usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -3702,40 +4002,60 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 8usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 8usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..2usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    8usize,
-                    2usize,
-                    i,
-                )?;
-                if i == 0 && offset != 8usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <Lambda as ssz::Encode>::ssz_fixed_len()
+                    + <UnionA as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3832,72 +4152,88 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> NuRef<'a> {
         pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                3usize,
+                <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
                 0usize,
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                3usize,
-                1usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-            let offset = 4usize;
-            let end = offset + 4usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                3usize,
-                1usize,
+                <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                3usize,
-                2usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-            let start = ssz::layout::read_variable_offset(
+            let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                16usize,
-                3usize,
-                2usize,
+                <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(
+                        !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
             )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                self.bytes,
-                16usize,
-                3usize,
-                3usize,
-            )?;
-            if start > end || end > self.bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &self.bytes[start..end];
             if bytes.is_empty() {
                 return Err(ssz::DecodeError::InvalidByteLength {
                     len: 0,
@@ -3969,40 +4305,71 @@ pub mod test_1 {
     }
     impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() < 16usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 16usize,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..3usize {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    16usize,
-                    3usize,
-                    i,
-                )?;
-                if i == 0 && offset != 16usize {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+            let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+            )
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
                 }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
                 }
-                prev_offset = Some(offset);
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            false
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            0
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <AliasMu as ssz::Encode>::ssz_fixed_len()
+                    + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                    + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                    + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
@@ -758,19 +758,20 @@ pub mod tests {
                 pub fn big(&self) -> Result<BigUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <BigUnion as ssz::Encode>::ssz_fixed_len(),
-                        <BigUnion as ssz::Encode>::ssz_fixed_len()
-                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
-                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <BigUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -778,44 +779,42 @@ pub mod tests {
                 pub fn same(&self) -> Result<SameTypeUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <BigUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
-                        <BigUnion as ssz::Encode>::ssz_fixed_len()
-                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
-                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <BigUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn mixed(&self) -> Result<MixedUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <BigUnion as ssz::Encode>::ssz_fixed_len()
-                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
-                        <MixedUnion as ssz::Encode>::ssz_fixed_len(),
-                        <BigUnion as ssz::Encode>::ssz_fixed_len()
-                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
-                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <BigUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -859,49 +858,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithBigUnionsRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <BigUnion as ssz::Encode>::ssz_fixed_len()
-                        + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
-                        + <MixedUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<BigUnion as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<MixedUnion as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <BigUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
@@ -756,60 +756,67 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithBigUnionsRef<'a> {
                 pub fn big(&self) -> Result<BigUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <BigUnion as ssz::Encode>::ssz_fixed_len(),
+                        <BigUnion as ssz::Encode>::ssz_fixed_len()
+                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
+                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn same(&self) -> Result<SameTypeUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <BigUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
+                        <BigUnion as ssz::Encode>::ssz_fixed_len()
+                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
+                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn mixed(&self) -> Result<MixedUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <BigUnion as ssz::Encode>::ssz_fixed_len()
+                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len(),
+                        <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                        <BigUnion as ssz::Encode>::ssz_fixed_len()
+                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
+                            + <MixedUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<MixedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -852,40 +859,68 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithBigUnionsRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <BigUnion as ssz::Encode>::ssz_fixed_len()
+                        + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
+                        + <MixedUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<BigUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<MixedUnion as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerWithBigUnionsRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<BigUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<SameTypeUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<MixedUnion as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <BigUnion as ssz::Encode>::ssz_fixed_len()
+                            + <SameTypeUnion as ssz::Encode>::ssz_fixed_len()
+                            + <MixedUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -103,22 +103,21 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NestedAliasContainerRef<'a> {
                 pub fn field1(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        4usize,
+                        <D as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <D as ssz::Encode>::ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len()
+                            + <G as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn field2(
@@ -127,41 +126,41 @@ pub mod tests {
                     FixedVectorRef<'a, BytesRef<'a, 10usize>, 5usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        4usize,
-                        1usize,
+                        <E as ssz::Encode>::is_ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len(),
+                        <E as ssz::Encode>::ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len()
+                            + <G as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn field3(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        4usize,
-                        2usize,
+                        <F as ssz::Encode>::is_ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len(),
+                        <F as ssz::Encode>::ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len()
+                            + <G as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn field4(
@@ -170,22 +169,25 @@ pub mod tests {
                     FixedVectorRef<'a, BytesRef<'a, 10usize>, 10usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        4usize,
-                        3usize,
+                        <G as ssz::Encode>::is_ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len(),
+                        <G as ssz::Encode>::ssz_fixed_len(),
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len()
+                            + <G as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -235,40 +237,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NestedAliasContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..4usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            4usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <D as ssz::Encode>::ssz_fixed_len()
+                        + <E as ssz::Encode>::ssz_fixed_len()
+                        + <F as ssz::Encode>::ssz_fixed_len()
+                        + <G as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<D as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for NestedAliasContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <D as ssz::Encode>::ssz_fixed_len()
+                            + <E as ssz::Encode>::ssz_fixed_len()
+                            + <F as ssz::Encode>::ssz_fixed_len()
+                            + <G as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -105,17 +105,24 @@ pub mod tests {
                 pub fn field1(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <D as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <D as ssz::Encode>::ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len()
-                            + <F as ssz::Encode>::ssz_fixed_len()
-                            + <G as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <D as ssz::Encode>::is_ssz_fixed_len(),
+                                <D as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <E as ssz::Encode>::is_ssz_fixed_len(),
+                                <E as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <F as ssz::Encode>::is_ssz_fixed_len(),
+                                <F as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <G as ssz::Encode>::is_ssz_fixed_len(),
+                                <G as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -128,38 +135,50 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <E as ssz::Encode>::is_ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len(),
-                        <E as ssz::Encode>::ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len()
-                            + <F as ssz::Encode>::ssz_fixed_len()
-                            + <G as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <D as ssz::Encode>::is_ssz_fixed_len(),
+                                <D as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <E as ssz::Encode>::is_ssz_fixed_len(),
+                                <E as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <F as ssz::Encode>::is_ssz_fixed_len(),
+                                <F as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <G as ssz::Encode>::is_ssz_fixed_len(),
+                                <G as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn field3(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <F as ssz::Encode>::is_ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len(),
-                        <F as ssz::Encode>::ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len()
-                            + <F as ssz::Encode>::ssz_fixed_len()
-                            + <G as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <D as ssz::Encode>::is_ssz_fixed_len(),
+                                <D as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <E as ssz::Encode>::is_ssz_fixed_len(),
+                                <E as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <F as ssz::Encode>::is_ssz_fixed_len(),
+                                <F as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <G as ssz::Encode>::is_ssz_fixed_len(),
+                                <G as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -171,22 +190,25 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <G as ssz::Encode>::is_ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len()
-                            + <F as ssz::Encode>::ssz_fixed_len(),
-                        <G as ssz::Encode>::ssz_fixed_len(),
-                        <D as ssz::Encode>::ssz_fixed_len()
-                            + <E as ssz::Encode>::ssz_fixed_len()
-                            + <F as ssz::Encode>::ssz_fixed_len()
-                            + <G as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<D as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <D as ssz::Encode>::is_ssz_fixed_len(),
+                                <D as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <E as ssz::Encode>::is_ssz_fixed_len(),
+                                <E as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <F as ssz::Encode>::is_ssz_fixed_len(),
+                                <F as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <G as ssz::Encode>::is_ssz_fixed_len(),
+                                <G as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -237,51 +259,27 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for NestedAliasContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <D as ssz::Encode>::ssz_fixed_len()
-                        + <E as ssz::Encode>::ssz_fixed_len()
-                        + <F as ssz::Encode>::ssz_fixed_len()
-                        + <G as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<D as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<E as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<F as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<G as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <D as ssz::Encode>::is_ssz_fixed_len(),
+                                <D as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <E as ssz::Encode>::is_ssz_fixed_len(),
+                                <E as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <F as ssz::Encode>::is_ssz_fixed_len(),
+                                <F as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <G as ssz::Encode>::is_ssz_fixed_len(),
+                                <G as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -1,0 +1,917 @@
+pub mod tests {
+    #![allow(unused_imports, reason = "generated code using ssz-gen")]
+    pub mod input {
+        #![allow(unused_imports, reason = "generated code using ssz-gen")]
+        pub mod test_nested_fixed_container {
+            #![allow(unused_imports, reason = "generated code using ssz-gen")]
+            use ssz_types::*;
+            use ssz_types::view::{FixedVectorRef, VariableListRef};
+            use ssz_primitives::{U128, U256};
+            use ssz_derive::{Encode, Decode};
+            use tree_hash::TreeHashDigest;
+            use tree_hash_derive::TreeHash;
+            use ssz::view::*;
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            pub const MAX_TAIL: u64 = 16u64;
+            /// A fixed-size inner container (1 byte).
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct FixedInner {
+                pub tag: u8,
+            }
+            impl tree_hash::TreeHash for FixedInner {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.tag)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`FixedInner`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct FixedInnerRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedInnerRef<'a> {
+                pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
+                    let offset = 0usize;
+                    let end = offset + 1usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for FixedInnerRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
+                    {
+                        let offset = 0usize;
+                        let field_bytes = &self.bytes[offset..offset + 1usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for FixedInnerRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    if bytes.len() != 1usize {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: bytes.len(),
+                            expected: 1usize,
+                        });
+                    }
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for FixedInnerRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    true
+                }
+                fn ssz_fixed_len() -> usize {
+                    1usize
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<FixedInner> for FixedInnerRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> FixedInner {
+                    <FixedInnerRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedInnerRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> FixedInner {
+                    FixedInner {
+                        tag: self.tag().expect("valid view"),
+                    }
+                }
+            }
+            /// A larger fixed-size inner container (8 bytes).
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct FixedPair {
+                pub x: u32,
+                pub y: u32,
+            }
+            impl tree_hash::TreeHash for FixedPair {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.x)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.y)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`FixedPair`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct FixedPairRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedPairRef<'a> {
+                pub fn x(&self) -> Result<u32, ssz::DecodeError> {
+                    let offset = 0usize;
+                    let end = offset + 4usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn y(&self) -> Result<u32, ssz::DecodeError> {
+                    let offset = 4usize;
+                    let end = offset + 4usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for FixedPairRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    {
+                        let offset = 0usize;
+                        let field_bytes = &self.bytes[offset..offset + 4usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    {
+                        let offset = 4usize;
+                        let field_bytes = &self.bytes[offset..offset + 4usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for FixedPairRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    if bytes.len() != 8usize {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: bytes.len(),
+                            expected: 8usize,
+                        });
+                    }
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for FixedPairRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    true
+                }
+                fn ssz_fixed_len() -> usize {
+                    8usize
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<FixedPair> for FixedPairRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> FixedPair {
+                    <FixedPairRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedPairRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> FixedPair {
+                    FixedPair {
+                        x: self.x().expect("valid view"),
+                        y: self.y().expect("valid view"),
+                    }
+                }
+            }
+            /// Mixed container: fixed containers inline, one variable tail.
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct MixedOuter {
+                pub inner: FixedInner,
+                pub count: u32,
+                pub pair: FixedPair,
+                pub tail: VariableList<u8, 16usize>,
+            }
+            impl tree_hash::TreeHash for MixedOuter {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.inner)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.count)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.pair)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.tail)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`MixedOuter`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct MixedOuterRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> MixedOuterRef<'a> {
+                pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
+                    let start = ssz::layout::read_variable_offset(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        0usize,
+                    )?;
+                    let end = ssz::layout::read_variable_offset_or_end(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        1usize,
+                    )?;
+                    if start > end || end > self.bytes.len() {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
+                    }
+                    let bytes = &self.bytes[start..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn count(&self) -> Result<u32, ssz::DecodeError> {
+                    let offset = 4usize;
+                    let end = offset + 4usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
+                    let start = ssz::layout::read_variable_offset(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        1usize,
+                    )?;
+                    let end = ssz::layout::read_variable_offset_or_end(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        2usize,
+                    )?;
+                    if start > end || end > self.bytes.len() {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
+                    }
+                    let bytes = &self.bytes[start..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn tail(&self) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
+                    let start = ssz::layout::read_variable_offset(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        2usize,
+                    )?;
+                    let end = ssz::layout::read_variable_offset_or_end(
+                        self.bytes,
+                        16usize,
+                        3usize,
+                        3usize,
+                    )?;
+                    if start > end || end > self.bytes.len() {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
+                    }
+                    let bytes = &self.bytes[start..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for MixedOuterRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(4usize);
+                    {
+                        let inner = self.inner().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&inner);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let offset = 4usize;
+                        let field_bytes = &self.bytes[offset..offset + 4usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    {
+                        let pair = self.pair().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&pair);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let tail = self.tail().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&tail);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for MixedOuterRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    if bytes.len() < 16usize {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: bytes.len(),
+                            expected: 16usize,
+                        });
+                    }
+                    let mut prev_offset: Option<usize> = None;
+                    for i in 0..3usize {
+                        let offset = ssz::layout::read_variable_offset(
+                            bytes,
+                            16usize,
+                            3usize,
+                            i,
+                        )?;
+                        if i == 0 && offset != 16usize {
+                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                        }
+                        if let Some(prev) = prev_offset && offset < prev {
+                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                        }
+                        if offset > bytes.len() {
+                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        }
+                        prev_offset = Some(offset);
+                    }
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for MixedOuterRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    false
+                }
+                fn ssz_fixed_len() -> usize {
+                    0
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<MixedOuter> for MixedOuterRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> MixedOuter {
+                    <MixedOuterRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> MixedOuterRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> MixedOuter {
+                    MixedOuter {
+                        inner: {
+                            let view = self.inner().expect("valid view");
+                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                        },
+                        count: self.count().expect("valid view"),
+                        pair: {
+                            let view = self.pair().expect("valid view");
+                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                        },
+                        tail: ssz_types::VariableList::new(
+                                self.tail().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
+                    }
+                }
+            }
+            /// Fully fixed container nesting fixed containers.
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct FixedOuter {
+                pub inner: FixedInner,
+                pub pair: FixedPair,
+            }
+            impl tree_hash::TreeHash for FixedOuter {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.inner)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.pair)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`FixedOuter`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct FixedOuterRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedOuterRef<'a> {
+                pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
+                    let start = ssz::layout::read_variable_offset(
+                        self.bytes,
+                        8usize,
+                        2usize,
+                        0usize,
+                    )?;
+                    let end = ssz::layout::read_variable_offset_or_end(
+                        self.bytes,
+                        8usize,
+                        2usize,
+                        1usize,
+                    )?;
+                    if start > end || end > self.bytes.len() {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
+                    }
+                    let bytes = &self.bytes[start..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
+                    let start = ssz::layout::read_variable_offset(
+                        self.bytes,
+                        8usize,
+                        2usize,
+                        1usize,
+                    )?;
+                    let end = ssz::layout::read_variable_offset_or_end(
+                        self.bytes,
+                        8usize,
+                        2usize,
+                        2usize,
+                    )?;
+                    if start > end || end > self.bytes.len() {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
+                    }
+                    let bytes = &self.bytes[start..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for FixedOuterRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    {
+                        let inner = self.inner().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&inner);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let pair = self.pair().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&pair);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for FixedOuterRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    if bytes.len() < 8usize {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: bytes.len(),
+                            expected: 8usize,
+                        });
+                    }
+                    let mut prev_offset: Option<usize> = None;
+                    for i in 0..2usize {
+                        let offset = ssz::layout::read_variable_offset(
+                            bytes,
+                            8usize,
+                            2usize,
+                            i,
+                        )?;
+                        if i == 0 && offset != 8usize {
+                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                        }
+                        if let Some(prev) = prev_offset && offset < prev {
+                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                        }
+                        if offset > bytes.len() {
+                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        }
+                        prev_offset = Some(offset);
+                    }
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for FixedOuterRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    false
+                }
+                fn ssz_fixed_len() -> usize {
+                    0
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<FixedOuter> for FixedOuterRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> FixedOuter {
+                    <FixedOuterRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> FixedOuterRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> FixedOuter {
+                    FixedOuter {
+                        inner: {
+                            let view = self.inner().expect("valid view");
+                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                        },
+                        pair: {
+                            let view = self.pair().expect("valid view");
+                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                        },
+                    }
+                }
+            }
+            /// Basic-fields-only container: decodes fine either way, but exercises the view
+            /// TreeHash leaf packing.
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct BasicPair {
+                pub tag: u8,
+                pub b: u32,
+            }
+            impl tree_hash::TreeHash for BasicPair {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.tag)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.b)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`BasicPair`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct BasicPairRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> BasicPairRef<'a> {
+                pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
+                    let offset = 0usize;
+                    let end = offset + 1usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn b(&self) -> Result<u32, ssz::DecodeError> {
+                    let offset = 1usize;
+                    let end = offset + 4usize;
+                    if end > self.bytes.len() {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: end,
+                        });
+                    }
+                    let bytes = &self.bytes[offset..end];
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for BasicPairRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    {
+                        let offset = 0usize;
+                        let field_bytes = &self.bytes[offset..offset + 1usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    {
+                        let offset = 1usize;
+                        let field_bytes = &self.bytes[offset..offset + 4usize];
+                        hasher.write(field_bytes).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for BasicPairRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    if bytes.len() != 5usize {
+                        return Err(ssz::DecodeError::InvalidByteLength {
+                            len: bytes.len(),
+                            expected: 5usize,
+                        });
+                    }
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for BasicPairRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    true
+                }
+                fn ssz_fixed_len() -> usize {
+                    5usize
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<BasicPair> for BasicPairRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> BasicPair {
+                    <BasicPairRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> BasicPairRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> BasicPair {
+                    BasicPair {
+                        tag: self.tag().expect("valid view"),
+                        b: self.b().expect("valid view"),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -71,11 +71,12 @@ pub mod tests {
                 pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -106,46 +107,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedInnerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -248,13 +218,16 @@ pub mod tests {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -262,14 +235,17 @@ pub mod tests {
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -306,47 +282,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedPairRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -466,27 +414,27 @@ pub mod tests {
                 pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                16usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     16usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -494,92 +442,84 @@ pub mod tests {
                 pub fn count(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                16usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     16usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len()),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <FixedPair as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                16usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     16usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn tail(&self) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u8, 16usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                u8,
-                                16usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     u8,
                                     16usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
+                        ],
+                        3usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -630,56 +570,30 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MixedOuterRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <FixedInner as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <FixedPair as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<FixedInner as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<VariableList<
-                                u8,
-                                16usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -805,15 +719,16 @@ pub mod tests {
                 pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -821,16 +736,17 @@ pub mod tests {
                 pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
-                        <FixedPair as ssz::Encode>::ssz_fixed_len(),
-                        <FixedInner as ssz::Encode>::ssz_fixed_len()
-                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -867,47 +783,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedOuterRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <FixedInner as ssz::Encode>::ssz_fixed_len()
-                        + <FixedPair as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<FixedInner as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1021,13 +909,16 @@ pub mod tests {
                 pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1035,14 +926,17 @@ pub mod tests {
                 pub fn b(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -1079,47 +973,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BasicPairRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1157,6 +1023,474 @@ pub mod tests {
                     BasicPair {
                         tag: self.tag().expect("valid view"),
                         b: self.b().expect("valid view"),
+                    }
+                }
+            }
+            /// Variable-size field before a fixed-size one: the offset entry sits at the
+            /// variable field's own position in the fixed portion, not at the end.
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct VarThenFixed {
+                pub entries: VariableList<u8, 16usize>,
+                pub name: u32,
+            }
+            impl tree_hash::TreeHash for VarThenFixed {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<
+                                H,
+                            >(&self.entries)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.name)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`VarThenFixed`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct VarThenFixedRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> VarThenFixedRef<'a> {
+                pub fn entries(
+                    &self,
+                ) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        0usize,
+                    )?;
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn name(&self) -> Result<u32, ssz::DecodeError> {
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
+                    )?;
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for VarThenFixedRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
+                    {
+                        let entries = self.entries().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&entries);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let name = self.name().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&name);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for VarThenFixedRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for VarThenFixedRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    usize::from(
+                        !<VariableList<u8, 16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
+                }
+                fn ssz_fixed_len() -> usize {
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<VarThenFixed> for VarThenFixedRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> VarThenFixed {
+                    <VarThenFixedRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> VarThenFixedRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> VarThenFixed {
+                    VarThenFixed {
+                        entries: ssz_types::VariableList::new(
+                                self.entries().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
+                        name: self.name().expect("valid view"),
+                    }
+                }
+            }
+            /// Variable fields interleaved with fixed fields.
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                ssz_derive::Encode,
+                ssz_derive::Decode
+            )]
+            #[ssz(struct_behaviour = "container")]
+            pub struct Interleaved {
+                pub head: VariableList<u8, 16usize>,
+                pub mid: u8,
+                pub tail: VariableList<u8, 16usize>,
+            }
+            impl tree_hash::TreeHash for Interleaved {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::Container
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.head)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.mid)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .write(
+                            <_ as tree_hash::TreeHash>::tree_hash_root::<H>(&self.tail)
+                                .as_ref(),
+                        )
+                        .expect("tree hash derive should not apply too many leaves");
+                    hasher
+                        .finish()
+                        .expect("tree hash derive should not have a remaining buffer")
+                }
+            }
+            /// Zero-copy view over [`Interleaved`].
+            ///
+            /// This type wraps SSZ-encoded bytes without allocating. Fields are accessed
+            /// via lazy getter methods. Use `.to_owned()` to convert to the owned type when
+            /// needed.
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            #[derive(
+                std::clone::Clone,
+                std::fmt::Debug,
+                std::cmp::PartialEq,
+                std::cmp::Eq,
+                std::marker::Copy
+            )]
+            pub struct InterleavedRef<'a> {
+                bytes: &'a [u8],
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> InterleavedRef<'a> {
+                pub fn head(&self) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        0usize,
+                    )?;
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn mid(&self) -> Result<u8, ssz::DecodeError> {
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
+                    )?;
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+                pub fn tail(&self) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
+                    )?;
+                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                }
+            }
+            impl<'a> tree_hash::TreeHash for InterleavedRef<'a> {
+                fn tree_hash_type() -> tree_hash::TreeHashType {
+                    tree_hash::TreeHashType::StableContainer
+                }
+                fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_packing_factor() -> usize {
+                    unreachable!("Container should never be packed")
+                }
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
+                    use tree_hash::TreeHash;
+                    let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
+                    {
+                        let head = self.head().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&head);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let mid = self.mid().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&mid);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    {
+                        let tail = self.tail().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&tail);
+                        hasher.write(root.as_ref()).expect("write field");
+                    }
+                    hasher.finish().expect("finish hasher")
+                }
+            }
+            impl<'a> ssz::view::DecodeView<'a> for InterleavedRef<'a> {
+                fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
+                    Ok(Self { bytes })
+                }
+            }
+            impl<'a> ssz::view::SszTypeInfo for InterleavedRef<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    usize::from(
+                        !<VariableList<u8, 16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
+                }
+                fn ssz_fixed_len() -> usize {
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len()
+                            + <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> ssz_types::view::ToOwnedSsz<Interleaved> for InterleavedRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                fn to_owned(&self) -> Interleaved {
+                    <InterleavedRef<'a>>::to_owned(self)
+                }
+            }
+            #[allow(dead_code, reason = "generated code using ssz-gen")]
+            impl<'a> InterleavedRef<'a> {
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn to_owned(&self) -> Interleaved {
+                    Interleaved {
+                        head: ssz_types::VariableList::new(
+                                self.head().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
+                        mid: self.mid().expect("valid view"),
+                        tail: ssz_types::VariableList::new(
+                                self.tail().expect("valid view").to_owned(),
+                            )
+                            .expect("valid view"),
                     }
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -69,15 +69,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedInnerRef<'a> {
                 pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -95,30 +95,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let tag = self.tag().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&tag);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedInnerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 1usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 1usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for FixedInnerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    1usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -206,27 +246,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedPairRef<'a> {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -244,35 +288,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let x = self.x().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&x);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let y = self.y().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&y);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedPairRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for FixedPairRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -375,72 +464,123 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MixedOuterRef<'a> {
                 pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
+                        <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn count(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        1usize,
+                        <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn tail(&self) -> Result<BytesRef<'a, 16usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        16usize,
-                        3usize,
-                        2usize,
+                        <VariableList<u8, 16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<VariableList<
+                                    u8,
+                                    16usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        16usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -465,9 +605,11 @@ pub mod tests {
                         hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let count = self.count().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&count);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
                         let pair = self.pair().expect("valid view");
@@ -488,40 +630,80 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MixedOuterRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 16usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 16usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            16usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 16usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <FixedInner as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MixedOuterRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<VariableList<
+                                u8,
+                                16usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<u8, 16usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -621,41 +803,35 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedOuterRef<'a> {
                 pub fn inner(&self) -> Result<FixedInnerRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
+                        <FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn pair(&self) -> Result<FixedPairRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        8usize,
-                        2usize,
-                        1usize,
+                        <FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len(),
+                        <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<FixedPair as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -691,40 +867,63 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FixedOuterRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            8usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 8usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <FixedInner as ssz::Encode>::ssz_fixed_len()
+                        + <FixedPair as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<FixedInner as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for FixedOuterRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<FixedInner as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<FixedPair as ssz::Encode>::is_ssz_fixed_len())
+                        == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <FixedInner as ssz::Encode>::ssz_fixed_len()
+                            + <FixedPair as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -820,27 +1019,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicPairRef<'a> {
                 pub fn tag(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn b(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -858,35 +1061,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let tag = self.tag().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&tag);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let b = self.b().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&b);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BasicPairRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 5usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 5usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BasicPairRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    5usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -66,13 +66,16 @@ impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -80,14 +83,17 @@ impl<'a> StateRef<'a> {
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -124,45 +130,19 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -268,18 +248,20 @@ impl<'a> UpdateRef<'a> {
     > {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -287,43 +269,42 @@ impl<'a> UpdateRef<'a> {
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -367,49 +348,23 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            );
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -64,27 +64,31 @@ pub struct StateRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 48usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 48usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -109,30 +113,71 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 48usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let counter = self.counter().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&counter);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 56usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 56usize,
-            });
+        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for StateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        56usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -221,53 +266,65 @@ impl<'a> UpdateRef<'a> {
         crate::tests::input::test_cross_entry_state::StateRef<'a>,
         ssz::DecodeError,
     > {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -292,9 +349,11 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let timestamp = self.timestamp().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&timestamp);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let updates = self.updates().expect("valid view");
@@ -308,35 +367,69 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            );
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for UpdateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -66,13 +66,16 @@ impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -80,14 +83,17 @@ impl<'a> StateRef<'a> {
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -124,45 +130,19 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -268,18 +248,20 @@ impl<'a> UpdateRef<'a> {
     > {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -287,43 +269,42 @@ impl<'a> UpdateRef<'a> {
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(
-                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -367,49 +348,23 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
-            );
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -64,27 +64,31 @@ pub struct StateRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     pub fn data(&self) -> Result<FixedBytesRef<'a, 48usize>, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 48usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn counter(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 48usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -109,30 +113,71 @@ impl<'a> tree_hash::TreeHash for StateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 48usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let counter = self.counter().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&counter);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for StateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 56usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 56usize,
-            });
+        let fixed_portion_size = <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for StateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<FixedBytes<48usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        56usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <FixedBytes<48usize> as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -221,53 +266,65 @@ impl<'a> UpdateRef<'a> {
         crate::tests::input::test_cross_entry_state::StateRef<'a>,
         ssz::DecodeError,
     > {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn timestamp(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn updates(&self) -> Result<BytesRef<'a, 10usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(
+                !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -292,9 +349,11 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let timestamp = self.timestamp().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&timestamp);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let updates = self.updates().expect("valid view");
@@ -308,35 +367,69 @@ impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for UpdateRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            );
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for UpdateRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(
+            !<crate::tests::input::test_cross_entry_state::State as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u8, 10usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <crate::tests::input::test_cross_entry_state::State as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u8, 10usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
@@ -69,15 +69,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicContainerRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -95,30 +95,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let a = self.a().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&a);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BasicContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 1usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 1usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BasicContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    1usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
@@ -71,11 +71,12 @@ pub mod tests {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -106,46 +107,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BasicContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
@@ -69,11 +69,12 @@ pub mod tests {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -104,46 +105,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EmptyPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -239,11 +209,12 @@ pub mod tests {
                 pub fn y(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -274,46 +245,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for EmptyValueContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u16 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
@@ -67,15 +67,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyPragmaContainerRef<'a> {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -93,30 +93,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let x = self.x().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&x);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for EmptyPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 1usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 1usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EmptyPragmaContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    1usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -197,15 +237,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyValueContainerRef<'a> {
                 pub fn y(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -223,30 +263,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let y = self.y().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&y);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for EmptyValueContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for EmptyValueContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u16 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
@@ -89,39 +89,53 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FieldPragmaContainerRef<'a> {
                 pub fn normal_field(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn pragma_field(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn multi_pragma_field(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 3usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -139,40 +153,93 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let normal_field = self.normal_field().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&normal_field);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 1usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let pragma_field = self.pragma_field().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&pragma_field);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 3usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let multi_pragma_field = self
+                            .multi_pragma_field()
+                            .expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&multi_pragma_field);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FieldPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+                        + <u16 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for FieldPragmaContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    7usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <u16 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
@@ -91,15 +91,20 @@ pub mod tests {
                 pub fn normal_field(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -107,34 +112,42 @@ pub mod tests {
                 pub fn pragma_field(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn multi_pragma_field(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len()
-                            + <u16 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -180,49 +193,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for FieldPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-                        + <u16 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
@@ -81,13 +81,16 @@ pub mod tests {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -95,14 +98,17 @@ pub mod tests {
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u32 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -139,47 +145,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for MultiPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u32 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
@@ -79,27 +79,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MultiPragmaContainerRef<'a> {
                 pub fn x(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn y(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -117,35 +121,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let x = self.x().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&x);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let y = self.y().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&y);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for MultiPragmaContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u32 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for MultiPragmaContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u32 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
@@ -89,13 +89,16 @@ pub mod tests {
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Slot as ssz::Encode>::ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -103,14 +106,17 @@ pub mod tests {
                 pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -147,47 +153,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Slot as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -286,11 +264,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -321,46 +300,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
@@ -87,27 +87,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -125,35 +129,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let slot = self.slot().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&slot);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 8usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let blkid = self.blkid().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&blkid);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 40usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 40usize,
-                        });
+                    let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    40usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -235,15 +284,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -261,30 +310,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
@@ -81,13 +81,16 @@ pub mod test_rkyv_derives {
         pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Slot as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <Slot as ssz::Encode>::ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -95,14 +98,17 @@ pub mod test_rkyv_derives {
         pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len(),
-                <U256 as ssz::Encode>::ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -139,45 +145,19 @@ pub mod test_rkyv_derives {
     }
     impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<Slot as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -266,11 +246,12 @@ pub mod test_rkyv_derives {
         pub fn value(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -301,44 +282,15 @@ pub mod test_rkyv_derives {
     }
     impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-            );
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
@@ -79,27 +79,31 @@ pub mod test_rkyv_derives {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <Slot as ssz::Encode>::ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-            let offset = 8usize;
-            let end = offset + 32usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len(),
+                <U256 as ssz::Encode>::ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -117,35 +121,78 @@ pub mod test_rkyv_derives {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let slot = self.slot().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&slot);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 8usize;
-                let field_bytes = &self.bytes[offset..offset + 32usize];
-                hasher.write(field_bytes).expect("write field");
+                let blkid = self.blkid().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&blkid);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 40usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 40usize,
-                });
+            let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<Slot as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            40usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -217,15 +264,15 @@ pub mod test_rkyv_derives {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {
         pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -243,30 +290,68 @@ pub mod test_rkyv_derives {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let value = self.value().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&value);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 8usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 8usize,
-                });
+            let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+            );
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            8usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <u64 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
@@ -74,27 +74,31 @@ pub struct BlockCommitmentRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <Slot as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Slot as ssz::Encode>::ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U256 as ssz::Encode>::is_ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len(),
+            <U256 as ssz::Encode>::ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -112,35 +116,77 @@ impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let slot = self.slot().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&slot);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 8usize;
-            let field_bytes = &self.bytes[offset..offset + 32usize];
-            hasher.write(field_bytes).expect("write field");
+            let blkid = self.blkid().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&blkid);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 40usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 40usize,
-            });
+        let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+            + <U256 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        40usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -210,15 +256,15 @@ pub struct OtherTypeRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -236,30 +282,66 @@ impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
+        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        8usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
@@ -76,13 +76,16 @@ impl<'a> BlockCommitmentRef<'a> {
     pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Slot as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Slot as ssz::Encode>::ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -90,14 +93,17 @@ impl<'a> BlockCommitmentRef<'a> {
     pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U256 as ssz::Encode>::is_ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len(),
-            <U256 as ssz::Encode>::ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -134,44 +140,19 @@ impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-            + <U256 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -258,11 +239,12 @@ impl<'a> OtherTypeRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -293,42 +275,15 @@ impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
@@ -87,13 +87,16 @@ pub mod tests {
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <Slot as ssz::Encode>::ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -101,14 +104,17 @@ pub mod tests {
                 pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len(),
-                        <U256 as ssz::Encode>::ssz_fixed_len(),
-                        <Slot as ssz::Encode>::ssz_fixed_len()
-                            + <U256 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -145,47 +151,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-                        + <U256 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<Slot as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                                <Slot as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                                <U256 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -284,11 +262,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -319,46 +298,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
@@ -85,27 +85,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -123,35 +127,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let slot = self.slot().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&slot);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 8usize;
-                        let field_bytes = &self.bytes[offset..offset + 32usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let blkid = self.blkid().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&blkid);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 40usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 40usize,
-                        });
+                    let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+                        + <U256 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    40usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <Slot as ssz::Encode>::ssz_fixed_len()
+                            + <U256 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -233,15 +282,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -259,30 +308,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
@@ -79,13 +79,16 @@ pub mod test_serde_derives {
         pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <Slot as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <Slot as ssz::Encode>::ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -93,14 +96,17 @@ pub mod test_serde_derives {
         pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <U256 as ssz::Encode>::is_ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len(),
-                <U256 as ssz::Encode>::ssz_fixed_len(),
-                <Slot as ssz::Encode>::ssz_fixed_len()
-                    + <U256 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+                1usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
@@ -137,45 +143,19 @@ pub mod test_serde_derives {
     }
     impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<Slot as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                        <Slot as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                    (
+                        <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                        <U256 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -264,11 +244,12 @@ pub mod test_serde_derives {
         pub fn value(&self) -> Result<u64, ssz::DecodeError> {
             let bytes = ssz::layout::read_field_bytes(
                 self.bytes,
-                <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                0usize,
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                <u64 as ssz::Encode>::ssz_fixed_len(),
-                usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                &[
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
                 0usize,
             )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -299,44 +280,15 @@ pub mod test_serde_derives {
     }
     impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-            let num_variable_fields = usize::from(
-                !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-            );
-            if num_variable_fields == 0 {
-                if bytes.len() != fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-            } else {
-                if bytes.len() < fixed_portion_size {
-                    return Err(ssz::DecodeError::InvalidByteLength {
-                        len: bytes.len(),
-                        expected: fixed_portion_size,
-                    });
-                }
-                let mut prev_offset: Option<usize> = None;
-                for i in 0..num_variable_fields {
-                    let offset = ssz::layout::read_variable_offset(
-                        bytes,
-                        fixed_portion_size,
-                        num_variable_fields,
-                        i,
-                    )?;
-                    if i == 0 && offset != fixed_portion_size {
-                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                    }
-                    if let Some(prev) = prev_offset && offset < prev {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                    }
-                    if offset > bytes.len() {
-                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                    }
-                    prev_offset = Some(offset);
-                }
-            }
+            ssz::layout::validate_container(
+                bytes,
+                &[
+                    (
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                    ),
+                ],
+            )?;
             Ok(Self { bytes })
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
@@ -77,27 +77,31 @@ pub mod test_serde_derives {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <Slot as ssz::Encode>::ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
         pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-            let offset = 8usize;
-            let end = offset + 32usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len(),
+                <U256 as ssz::Encode>::ssz_fixed_len(),
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                    + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+                usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -115,35 +119,78 @@ pub mod test_serde_derives {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let slot = self.slot().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&slot);
+                hasher.write(root.as_ref()).expect("write field");
             }
             {
-                let offset = 8usize;
-                let field_bytes = &self.bytes[offset..offset + 32usize];
-                hasher.write(field_bytes).expect("write field");
+                let blkid = self.blkid().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&blkid);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 40usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 40usize,
-                });
+            let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<Slot as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            40usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <Slot as ssz::Encode>::ssz_fixed_len()
+                    + <U256 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -215,15 +262,15 @@ pub mod test_serde_derives {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {
         pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-            let offset = 0usize;
-            let end = offset + 8usize;
-            if end > self.bytes.len() {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: self.bytes.len(),
-                    expected: end,
-                });
-            }
-            let bytes = &self.bytes[offset..end];
+            let bytes = ssz::layout::read_field_bytes(
+                self.bytes,
+                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                0usize,
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                <u64 as ssz::Encode>::ssz_fixed_len(),
+                usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                0usize,
+            )?;
             ssz::view::DecodeView::from_ssz_bytes(bytes)
         }
     }
@@ -241,30 +288,68 @@ pub mod test_serde_derives {
             use tree_hash::TreeHash;
             let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
             {
-                let offset = 0usize;
-                let field_bytes = &self.bytes[offset..offset + 8usize];
-                hasher.write(field_bytes).expect("write field");
+                let value = self.value().expect("valid view");
+                let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                    H,
+                >(&value);
+                hasher.write(root.as_ref()).expect("write field");
             }
             hasher.finish().expect("finish hasher")
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-            if bytes.len() != 8usize {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: 8usize,
-                });
+            let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+            let num_variable_fields = usize::from(
+                !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+            );
+            if num_variable_fields == 0 {
+                if bytes.len() != fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+            } else {
+                if bytes.len() < fixed_portion_size {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: fixed_portion_size,
+                    });
+                }
+                let mut prev_offset: Option<usize> = None;
+                for i in 0..num_variable_fields {
+                    let offset = ssz::layout::read_variable_offset(
+                        bytes,
+                        fixed_portion_size,
+                        num_variable_fields,
+                        i,
+                    )?;
+                    if i == 0 && offset != fixed_portion_size {
+                        return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    }
+                    if let Some(prev) = prev_offset && offset < prev {
+                        return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    }
+                    if offset > bytes.len() {
+                        return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                    }
+                    prev_offset = Some(offset);
+                }
             }
             Ok(Self { bytes })
         }
     }
     impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
         fn is_ssz_fixed_len() -> bool {
-            true
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
         }
         fn ssz_fixed_len() -> usize {
-            8usize
+            if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                <u64 as ssz::Encode>::ssz_fixed_len()
+            } else {
+                0
+            }
         }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
@@ -74,13 +74,16 @@ impl<'a> BlockCommitmentRef<'a> {
     pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Slot as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Slot as ssz::Encode>::ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -88,14 +91,17 @@ impl<'a> BlockCommitmentRef<'a> {
     pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U256 as ssz::Encode>::is_ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len(),
-            <U256 as ssz::Encode>::ssz_fixed_len(),
-            <Slot as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -132,44 +138,19 @@ impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
-            + <U256 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Slot as ssz::Encode>::is_ssz_fixed_len(),
+                    <Slot as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -256,11 +237,12 @@ impl<'a> OtherTypeRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -291,42 +273,15 @@ impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
@@ -72,27 +72,31 @@ pub struct BlockCommitmentRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     pub fn slot(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <Slot as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Slot as ssz::Encode>::ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn blkid(&self) -> Result<U256, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U256 as ssz::Encode>::is_ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len(),
+            <U256 as ssz::Encode>::ssz_fixed_len(),
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -110,35 +114,77 @@ impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let slot = self.slot().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&slot);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 8usize;
-            let field_bytes = &self.bytes[offset..offset + 32usize];
-            hasher.write(field_bytes).expect("write field");
+            let blkid = self.blkid().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&blkid);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for BlockCommitmentRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 40usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 40usize,
-            });
+        let fixed_portion_size = <Slot as ssz::Encode>::ssz_fixed_len()
+            + <U256 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for BlockCommitmentRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<Slot as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        40usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Slot as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -208,15 +254,15 @@ pub struct OtherTypeRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -234,30 +280,66 @@ impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for OtherTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
+        let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for OtherTypeRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        8usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1003,39 +1003,49 @@ pub struct AlphaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u16 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 3usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1053,14 +1063,18 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(3usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let a = self.a().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&a);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let b = self.b().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&b);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let c = self.c().expect("valid view");
@@ -1074,21 +1088,62 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 13usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 13usize,
-            });
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u16 as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for AlphaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        13usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecB as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1167,46 +1222,53 @@ pub struct BetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            7usize,
-            1usize,
+            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            7usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 5usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1231,49 +1293,82 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let e = self.e().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&e);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 5usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let f = self.f().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&f);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 7usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 7usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 7usize, 1usize, i)?;
-            if i == 0 && offset != 7usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for BetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1551,27 +1646,31 @@ pub struct DeltaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <bool as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <bool as ssz::Encode>::ssz_fixed_len()
+                + <u8 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -1589,35 +1688,76 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let z = self.z().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&z);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let w = self.w().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&w);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 2usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 2usize,
-            });
+        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for DeltaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        2usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <bool as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2192,70 +2332,115 @@ pub struct TestTypeRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 1usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            54usize,
-            1usize,
-            0usize,
+            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            54usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
-        let offset = 6usize;
-        let end = offset + 16usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U128 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+            <U128 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
-        let offset = 22usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <U256 as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len(),
+            <U256 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2273,14 +2458,18 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(5usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ccc = self.ccc().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ccc);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 1usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let ddd = self.ddd().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&ddd);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let eee = self.eee().expect("valid view");
@@ -2290,49 +2479,90 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
             hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 6usize;
-            let field_bytes = &self.bytes[offset..offset + 16usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_128 = self.large_int_128().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_128);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 22usize;
-            let field_bytes = &self.bytes[offset..offset + 32usize];
-            hasher.write(field_bytes).expect("write field");
+            let large_int_256 = self.large_int_256().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&large_int_256);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 54usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 54usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 54usize, 1usize, i)?;
-            if i == 0 && offset != 54usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <u8 as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+            + <U128 as ssz::Encode>::ssz_fixed_len()
+            + <U256 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for TestTypeRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
+                + <U128 as ssz::Encode>::ssz_fixed_len()
+                + <U256 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2424,60 +2654,53 @@ pub struct EtaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
+            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            1usize,
+            <TestType as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len(),
+            <TestType as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            12usize,
-            3usize,
-            2usize,
+            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len(),
+            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            12usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2520,35 +2743,63 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 12usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 12usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 12usize, 3usize, i)?;
-            if i == 0 && offset != 12usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
+            + <TestType as ssz::Encode>::ssz_fixed_len()
+            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for EtaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Zeta as ssz::Encode>::ssz_fixed_len()
+                + <TestType as ssz::Encode>::ssz_fixed_len()
+                + <FirstUnion as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2636,53 +2887,53 @@ pub struct ThetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
+            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            18usize,
-            2usize,
-            1usize,
+            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len(),
+            <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            18usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 10usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len(),
+            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -2725,35 +2976,64 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 18usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 18usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 18usize, 2usize, i)?;
-            if i == 0 && offset != 18usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
+            + <UnionC as ssz::Encode>::ssz_fixed_len()
+            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ThetaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <UnionB as ssz::Encode>::ssz_fixed_len()
+                + <UnionC as ssz::Encode>::ssz_fixed_len()
+                + <AliasVecA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3191,53 +3471,53 @@ pub struct KappaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
+            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            2usize,
-            1usize,
+            <Beta as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len(),
+            <Beta as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len(),
+            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3280,35 +3560,64 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 2usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
+            + <Beta as ssz::Encode>::ssz_fixed_len()
+            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for KappaRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Alpha as ssz::Encode>::ssz_fixed_len()
+                + <Beta as ssz::Encode>::ssz_fixed_len()
+                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3584,41 +3893,31 @@ pub struct MuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
+            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            8usize,
-            2usize,
-            1usize,
+            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len(),
+            <UnionA as ssz::Encode>::ssz_fixed_len(),
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -3654,35 +3953,60 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 8usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 8usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 8usize, 2usize, i)?;
-            if i == 0 && offset != 8usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
+            + <UnionA as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for MuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <Lambda as ssz::Encode>::ssz_fixed_len()
+                + <UnionA as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -3771,72 +4095,88 @@ pub struct NuRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
+            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len(),
+            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            1usize,
+            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+            <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            16usize,
-            3usize,
-            2usize,
+            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
+            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            16usize,
-            3usize,
-            3usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
                 len: 0,
@@ -3908,35 +4248,69 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 16usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 16usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..3usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 16usize, 3usize, i)?;
-            if i == 0 && offset != 16usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
+            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+            + <BitAlias as ssz::Encode>::ssz_fixed_len()
+            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for NuRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <AliasMu as ssz::Encode>::ssz_fixed_len()
+                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
+                + <BitAlias as ssz::Encode>::ssz_fixed_len()
+                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1005,14 +1005,20 @@ impl<'a> AlphaRef<'a> {
     pub fn a(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1020,31 +1026,42 @@ impl<'a> AlphaRef<'a> {
     pub fn b(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u16 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u16 as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1088,46 +1105,23 @@ impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u16 as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecB as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecB as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecB as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1224,15 +1218,20 @@ impl<'a> BetaRef<'a> {
     pub fn d(&self) -> Result<BytesRef<'a, 5usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1240,34 +1239,42 @@ impl<'a> BetaRef<'a> {
     pub fn e(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn f(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasListAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1311,47 +1318,23 @@ impl<'a> tree_hash::TreeHash for BetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for BetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasListAlias as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <AliasUintAlias as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasUintAlias as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasListAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasListAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasUintAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasUintAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -1648,13 +1631,16 @@ impl<'a> DeltaRef<'a> {
     pub fn z(&self) -> Result<bool, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <bool as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1662,14 +1648,17 @@ impl<'a> DeltaRef<'a> {
     pub fn w(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <bool as ssz::Encode>::ssz_fixed_len()
-                + <u8 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -1706,44 +1695,19 @@ impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for DeltaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <bool as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<bool as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <bool as ssz::Encode>::is_ssz_fixed_len(),
+                    <bool as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2334,19 +2298,28 @@ impl<'a> TestTypeRef<'a> {
     pub fn ccc(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2354,92 +2327,116 @@ impl<'a> TestTypeRef<'a> {
     pub fn ddd(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn eee(&self) -> Result<ListRef<'a, u16, 3usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_128(&self) -> Result<U128, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U128 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
-            <U128 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn large_int_256(&self) -> Result<U256, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <U256 as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len(),
-            <U256 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len() + <u8 as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-                + <U128 as ssz::Encode>::ssz_fixed_len()
-                + <U256 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            4usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2497,51 +2494,31 @@ impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for TestTypeRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <u8 as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len()
-            + <U128 as ssz::Encode>::ssz_fixed_len()
-            + <U256 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<U128 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<U256 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<u16, 3usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u16, 3usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U128 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U128 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <U256 as ssz::Encode>::is_ssz_fixed_len(),
+                    <U256 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2656,15 +2633,20 @@ impl<'a> EtaRef<'a> {
     pub fn l(&self) -> Result<ZetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Zeta as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2672,34 +2654,42 @@ impl<'a> EtaRef<'a> {
     pub fn m(&self) -> Result<TestTypeRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <TestType as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len(),
-            <TestType as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn n(&self) -> Result<FirstUnionRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len(),
-            <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            <Zeta as ssz::Encode>::ssz_fixed_len()
-                + <TestType as ssz::Encode>::ssz_fixed_len()
-                + <FirstUnion as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2743,46 +2733,23 @@ impl<'a> tree_hash::TreeHash for EtaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for EtaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Zeta as ssz::Encode>::ssz_fixed_len()
-            + <TestType as ssz::Encode>::ssz_fixed_len()
-            + <FirstUnion as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<Zeta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<TestType as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<FirstUnion as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Zeta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Zeta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <TestType as ssz::Encode>::is_ssz_fixed_len(),
+                    <TestType as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FirstUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    <FirstUnion as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -2889,15 +2856,20 @@ impl<'a> ThetaRef<'a> {
     pub fn o(&self) -> Result<UnionBRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionB as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -2905,34 +2877,42 @@ impl<'a> ThetaRef<'a> {
     pub fn p(&self) -> Result<UnionCRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionC as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len(),
-            <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn q(&self) -> Result<FixedBytesRef<'a, 10usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len(),
-            <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            <UnionB as ssz::Encode>::ssz_fixed_len()
-                + <UnionC as ssz::Encode>::ssz_fixed_len()
-                + <AliasVecA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<UnionB as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -2976,47 +2956,23 @@ impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ThetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <UnionB as ssz::Encode>::ssz_fixed_len()
-            + <UnionC as ssz::Encode>::ssz_fixed_len()
-            + <AliasVecA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<UnionB as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionC as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<AliasVecA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <UnionB as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionB as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionC as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionC as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <AliasVecA as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasVecA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3473,15 +3429,20 @@ impl<'a> KappaRef<'a> {
     pub fn t(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3489,34 +3450,42 @@ impl<'a> KappaRef<'a> {
     pub fn u(&self) -> Result<BetaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Beta as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len(),
-            <Beta as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn v(&self) -> Result<BitVectorRef<'a, 64usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len(),
-            <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            <Alpha as ssz::Encode>::ssz_fixed_len()
-                + <Beta as ssz::Encode>::ssz_fixed_len()
-                + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3560,47 +3529,23 @@ impl<'a> tree_hash::TreeHash for KappaRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for KappaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Alpha as ssz::Encode>::ssz_fixed_len()
-            + <Beta as ssz::Encode>::ssz_fixed_len()
-            + <BitVector<64usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Alpha as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<Beta as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                    <Alpha as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Beta as ssz::Encode>::is_ssz_fixed_len(),
+                    <Beta as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitVector<64usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitVector<64usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -3895,13 +3840,16 @@ impl<'a> MuRef<'a> {
     pub fn y(&self) -> Result<LambdaRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Lambda as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -3909,14 +3857,17 @@ impl<'a> MuRef<'a> {
     pub fn z(&self) -> Result<UnionARef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <UnionA as ssz::Encode>::is_ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len(),
-            <UnionA as ssz::Encode>::ssz_fixed_len(),
-            <Lambda as ssz::Encode>::ssz_fixed_len()
-                + <UnionA as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<Lambda as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -3953,45 +3904,19 @@ impl<'a> tree_hash::TreeHash for MuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for MuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <Lambda as ssz::Encode>::ssz_fixed_len()
-            + <UnionA as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<Lambda as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<UnionA as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <Lambda as ssz::Encode>::is_ssz_fixed_len(),
+                    <Lambda as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <UnionA as ssz::Encode>::is_ssz_fixed_len(),
+                    <UnionA as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -4097,18 +4022,24 @@ impl<'a> NuRef<'a> {
     pub fn zz(&self) -> Result<AliasMuRef<'a>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -4116,66 +4047,75 @@ impl<'a> NuRef<'a> {
     pub fn aaa(&self) -> Result<FixedVectorRef<'a, bool, 4usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len(),
-            <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn bbb(&self) -> Result<BitListRef<'a, 42usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
-            <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn test(&self) -> Result<Option<AliasMuRef<'a>>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len(),
-            <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            <AliasMu as ssz::Encode>::ssz_fixed_len()
-                + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-                + <BitAlias as ssz::Encode>::ssz_fixed_len()
-                + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<AliasMu as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
-                ) + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            3usize,
         )?;
         if bytes.is_empty() {
             return Err(ssz::DecodeError::InvalidByteLength {
@@ -4248,49 +4188,27 @@ impl<'a> tree_hash::TreeHash for NuRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for NuRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <AliasMu as ssz::Encode>::ssz_fixed_len()
-            + <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len()
-            + <BitAlias as ssz::Encode>::ssz_fixed_len()
-            + <Option<AliasMu> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<AliasMu as ssz::Encode>::is_ssz_fixed_len(),
-        ) + usize::from(!<FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<BitAlias as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <AliasMu as ssz::Encode>::is_ssz_fixed_len(),
+                    <AliasMu as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedVector<bool, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedVector<bool, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <BitAlias as ssz::Encode>::is_ssz_fixed_len(),
+                    <BitAlias as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Option<AliasMu> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Option<AliasMu> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -62,15 +62,19 @@ pub struct ContainerARef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerARef<'a> {
     pub fn value(&self) -> Result<u8, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 1usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn b_ref(
@@ -79,22 +83,19 @@ impl<'a> ContainerARef<'a> {
         crate::tests::input::test_three_way_b::ContainerBRef<'a>,
         ssz::DecodeError,
     > {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            5usize,
-            1usize,
-            0usize,
+            <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+            <u8 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            5usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -112,9 +113,11 @@ impl<'a> tree_hash::TreeHash for ContainerARef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 1usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let b_ref = self.b_ref().expect("valid view");
@@ -128,35 +131,63 @@ impl<'a> tree_hash::TreeHash for ContainerARef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerARef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 5usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 5usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 5usize, 1usize, i)?;
-            if i == 0 && offset != 5usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
+            + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+            );
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ContainerARef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+            ) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u8 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -235,15 +266,19 @@ pub struct ContainerBRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerBRef<'a> {
     pub fn value(&self) -> Result<u16, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 2usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u16 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u16 as ssz::Encode>::ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn c_ref(
@@ -252,22 +287,19 @@ impl<'a> ContainerBRef<'a> {
         crate::tests::input::test_three_way_c::ContainerCRef<'a>,
         ssz::DecodeError,
     > {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            6usize,
-            1usize,
-            0usize,
+            <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len(),
+            <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+            <u16 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(
+                    !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            6usize,
-            1usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -285,9 +317,11 @@ impl<'a> tree_hash::TreeHash for ContainerBRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 2usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
             let c_ref = self.c_ref().expect("valid view");
@@ -301,35 +335,63 @@ impl<'a> tree_hash::TreeHash for ContainerBRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerBRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 6usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 6usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..1usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 6usize, 1usize, i)?;
-            if i == 0 && offset != 6usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len()
+            + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+            );
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ContainerBRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+            ) == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u16 as ssz::Encode>::ssz_fixed_len()
+                + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -404,15 +466,15 @@ pub struct ContainerCRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerCRef<'a> {
     pub fn value(&self) -> Result<u32, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u32 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -430,30 +492,66 @@ impl<'a> tree_hash::TreeHash for ContainerCRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 4usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerCRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 4usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 4usize,
-            });
+        let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ContainerCRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        4usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u32 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -64,15 +64,16 @@ impl<'a> ContainerARef<'a> {
     pub fn value(&self) -> Result<u8, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u8 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len()
-                + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -85,16 +86,17 @@ impl<'a> ContainerARef<'a> {
     > {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
-            <u8 as ssz::Encode>::ssz_fixed_len()
-                + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                (
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -131,46 +133,19 @@ impl<'a> tree_hash::TreeHash for ContainerARef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerARef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len()
-            + <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
-            );
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u8 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_b::ContainerB as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -268,15 +243,16 @@ impl<'a> ContainerBRef<'a> {
     pub fn value(&self) -> Result<u16, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u16 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u16 as ssz::Encode>::ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len()
-                + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -289,16 +265,17 @@ impl<'a> ContainerBRef<'a> {
     > {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len(),
-            <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
-            <u16 as ssz::Encode>::ssz_fixed_len()
-                + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(
-                    !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
                 ),
-            usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                (
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -335,46 +312,19 @@ impl<'a> tree_hash::TreeHash for ContainerBRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerBRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len()
-            + <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(
-                !<crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
-            );
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u16 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::is_ssz_fixed_len(),
+                    <crate::tests::input::test_three_way_c::ContainerC as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -468,11 +418,12 @@ impl<'a> ContainerCRef<'a> {
     pub fn value(&self) -> Result<u32, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u32 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -503,42 +454,15 @@ impl<'a> tree_hash::TreeHash for ContainerCRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ContainerCRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
@@ -928,31 +928,32 @@ pub mod tests {
                 pub fn simple(&self) -> Result<SimpleUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -960,108 +961,99 @@ pub mod tests {
                 pub fn nested(&self) -> Result<NestedUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
-                        <NestedUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn complex(&self) -> Result<ComplexUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len(),
-                        <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn opt_simple(&self) -> Result<Option<u8>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
-                        <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        3usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -1092,44 +1084,33 @@ pub mod tests {
                 ) -> Result<Option<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        4usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -1162,48 +1143,33 @@ pub mod tests {
                 ) -> Result<Option<SimpleUnionRef<'a>>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
-                        <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        5usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -1290,61 +1256,35 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionEdgeCasesRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                        + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                        + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
-                        + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
-                        + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
-                        + <OptionalUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(!<ComplexUnion as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1493,19 +1433,20 @@ pub mod tests {
                 pub fn union1(&self) -> Result<SimpleUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1513,44 +1454,42 @@ pub mod tests {
                 pub fn union2(&self) -> Result<NestedUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
-                        <NestedUnion as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len()),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn union3(&self) -> Result<Option<u8>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len(),
-                        <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(
-                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -1616,51 +1555,23 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AllUnionsRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <SimpleUnion as ssz::Encode>::ssz_fixed_len()
-                        + <NestedUnion as ssz::Encode>::ssz_fixed_len()
-                        + <OptionalSimple as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
-                        + usize::from(
-                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                                <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
@@ -926,79 +926,143 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionEdgeCasesRef<'a> {
                 pub fn simple(&self) -> Result<SimpleUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
+                        <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn nested(&self) -> Result<NestedUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
-                        1usize,
+                        <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                        <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn complex(&self) -> Result<ComplexUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
-                        2usize,
+                        <ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                        <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn opt_simple(&self) -> Result<Option<u8>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
-                        3usize,
+                        <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len(),
+                        <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -1026,22 +1090,47 @@ pub mod tests {
                 pub fn opt_complex(
                     &self,
                 ) -> Result<Option<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
-                        4usize,
+                        <OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -1071,22 +1160,51 @@ pub mod tests {
                 pub fn opt_union(
                     &self,
                 ) -> Result<Option<SimpleUnionRef<'a>>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        24usize,
-                        6usize,
-                        5usize,
+                        <OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len(),
+                        <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<ComplexUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -1172,40 +1290,90 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionEdgeCasesRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 24usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 24usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..6usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            24usize,
-                            6usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 24usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                        + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                        + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                        + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                        + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                        + <OptionalUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<ComplexUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for UnionEdgeCasesRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<ComplexUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<OptionalComplex as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<OptionalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <ComplexUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalComplex as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1323,60 +1491,67 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AllUnionsRef<'a> {
                 pub fn union1(&self) -> Result<SimpleUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
+                        <SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn union2(&self) -> Result<NestedUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        1usize,
+                        <NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len(),
+                        <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len()),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn union3(&self) -> Result<Option<u8>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        12usize,
-                        3usize,
-                        2usize,
+                        <OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len(),
+                        <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(
+                                !<NestedUnion as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     if bytes.is_empty() {
                         return Err(ssz::DecodeError::InvalidByteLength {
                             len: 0,
@@ -1441,40 +1616,70 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for AllUnionsRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..3usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            12usize,
-                            3usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 12usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                        + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                        + <OptionalSimple as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<SimpleUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for AllUnionsRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<SimpleUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<NestedUnion as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<OptionalSimple as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <SimpleUnion as ssz::Encode>::ssz_fixed_len()
+                            + <NestedUnion as ssz::Encode>::ssz_fixed_len()
+                            + <OptionalSimple as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -202,11 +202,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -237,46 +238,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for DataVariantRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -372,11 +342,12 @@ pub mod tests {
                 pub fn state(&self) -> Result<TestUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <TestUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <TestUnion as ssz::Encode>::ssz_fixed_len(),
-                        <TestUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<TestUnion as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <TestUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -407,46 +378,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <TestUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<TestUnion as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <TestUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <TestUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -30,22 +30,18 @@ pub mod tests {
                 fn tree_hash_packing_factor() -> usize {
                     unreachable!("Union should never be packed")
                 }
-                fn tree_hash_root<__H: tree_hash::TreeHashDigest>(&self) -> __H::Output {
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     match self {
                         TestUnion::Empty => {
-                            let zero_root = <__H as tree_hash::TreeHashDigest>::get_zero_hash(
-                                0,
-                            );
-                            tree_hash::mix_in_selector_with_hasher::<
-                                __H,
-                            >(&zero_root, 0u8)
+                            let zero_root = H::get_zero_hash(0);
+                            tree_hash::mix_in_selector_with_hasher::<H>(&zero_root, 0u8)
                                 .expect("valid selector")
                         }
                         TestUnion::Data(inner) => {
                             let root = <_ as tree_hash::TreeHash>::tree_hash_root::<
-                                __H,
+                                H,
                             >(inner);
-                            tree_hash::mix_in_selector_with_hasher::<__H>(&root, 1u8)
+                            tree_hash::mix_in_selector_with_hasher::<H>(&root, 1u8)
                                 .expect("valid selector")
                         }
                     }
@@ -204,15 +200,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DataVariantRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -230,30 +226,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for DataVariantRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for DataVariantRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -334,22 +370,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {
                 pub fn state(&self) -> Result<TestUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <TestUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <TestUnion as ssz::Encode>::ssz_fixed_len(),
+                        <TestUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<TestUnion as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -378,40 +407,59 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <TestUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<TestUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<TestUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <TestUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
@@ -213,11 +213,12 @@ pub mod tests {
                 ) -> Result<ExternalUnionRef<'a>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
-                        <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<ExternalUnion as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -248,46 +249,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <ExternalUnion as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                                <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
@@ -211,22 +211,15 @@ pub mod tests {
                 pub fn union_field(
                     &self,
                 ) -> Result<ExternalUnionRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
+                        <ExternalUnion as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<ExternalUnion as ssz::Encode>::is_ssz_fixed_len()),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -255,40 +248,59 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for TestContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <ExternalUnion as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<ExternalUnion as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for TestContainerRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<ExternalUnion as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <ExternalUnion as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -462,11 +462,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u8, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        <u8 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -497,46 +498,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionTypeAliasVariant1Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u8 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -632,11 +602,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u16, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        <u16 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -667,46 +638,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionTypeAliasVariant2Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u16 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u16 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -808,25 +748,18 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            UnionClass,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <VariableList<
-                            UnionClass,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            UnionClass,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                UnionClass,
-                                65536usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <VariableList<
+                                    UnionClass,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionClass,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -857,52 +790,21 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithUnionClassRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <VariableList<
-                        UnionClass,
-                        65536usize,
-                    > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<VariableList<
-                            UnionClass,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    UnionClass,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionClass,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1023,25 +925,18 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            UnionClassWithExternal,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <VariableList<
-                            UnionClassWithExternal,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            UnionClassWithExternal,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                UnionClassWithExternal,
-                                65536usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <VariableList<
+                                    UnionClassWithExternal,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionClassWithExternal,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1073,52 +968,21 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a>
             for ContainerWithUnionClassExternalRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <VariableList<
-                        UnionClassWithExternal,
-                        65536usize,
-                    > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<VariableList<
-                            UnionClassWithExternal,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    UnionClassWithExternal,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionClassWithExternal,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1241,25 +1105,18 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            UnionTypeAlias,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <VariableList<
-                            UnionTypeAlias,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            UnionTypeAlias,
-                            65536usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                UnionTypeAlias,
-                                65536usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                        &[
+                            (
+                                <VariableList<
+                                    UnionTypeAlias,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionTypeAlias,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -1290,52 +1147,21 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithUnionTypeAliasRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <VariableList<
-                        UnionTypeAlias,
-                        65536usize,
-                    > as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<VariableList<
-                            UnionTypeAlias,
-                            65536usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    UnionTypeAlias,
+                                    65536usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    UnionTypeAlias,
+                                    65536usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -30,20 +30,20 @@ pub mod tests {
                 fn tree_hash_packing_factor() -> usize {
                     unreachable!("Union should never be packed")
                 }
-                fn tree_hash_root<__H: tree_hash::TreeHashDigest>(&self) -> __H::Output {
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     match self {
                         UnionClass::Variant1(inner) => {
                             let root = <_ as tree_hash::TreeHash>::tree_hash_root::<
-                                __H,
+                                H,
                             >(inner);
-                            tree_hash::mix_in_selector_with_hasher::<__H>(&root, 0u8)
+                            tree_hash::mix_in_selector_with_hasher::<H>(&root, 0u8)
                                 .expect("valid selector")
                         }
                         UnionClass::Variant2(inner) => {
                             let root = <_ as tree_hash::TreeHash>::tree_hash_root::<
-                                __H,
+                                H,
                             >(inner);
-                            tree_hash::mix_in_selector_with_hasher::<__H>(&root, 1u8)
+                            tree_hash::mix_in_selector_with_hasher::<H>(&root, 1u8)
                                 .expect("valid selector")
                         }
                     }
@@ -169,13 +169,13 @@ pub mod tests {
                 fn tree_hash_packing_factor() -> usize {
                     unreachable!("Union should never be packed")
                 }
-                fn tree_hash_root<__H: tree_hash::TreeHashDigest>(&self) -> __H::Output {
+                fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     match self {
                         UnionClassWithExternal::Deposit(inner) => {
                             let root = <_ as tree_hash::TreeHash>::tree_hash_root::<
-                                __H,
+                                H,
                             >(inner);
-                            tree_hash::mix_in_selector_with_hasher::<__H>(&root, 0u8)
+                            tree_hash::mix_in_selector_with_hasher::<H>(&root, 0u8)
                                 .expect("valid selector")
                         }
                     }
@@ -460,15 +460,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant1Ref<'a> {
                 pub fn value(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        <u8 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -486,30 +486,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 1usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionTypeAliasVariant1Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 1usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 1usize,
-                        });
+                    let fixed_portion_size = <u8 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u8 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for UnionTypeAliasVariant1Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    1usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -590,15 +630,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant2Ref<'a> {
                 pub fn value(&self) -> Result<u16, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u16 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        <u16 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -616,30 +656,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 2usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionTypeAliasVariant2Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 2usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 2usize,
-                        });
+                    let fixed_portion_size = <u16 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u16 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for UnionTypeAliasVariant2Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u16 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    2usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u16 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -726,22 +806,29 @@ pub mod tests {
                     ListRef<'a, UnionClassRef<'a>, 65536usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                UnionClass,
+                                65536usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -770,40 +857,73 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithUnionClassRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <VariableList<
+                        UnionClass,
+                        65536usize,
+                    > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerWithUnionClassRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<
+                            UnionClass,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -901,22 +1021,29 @@ pub mod tests {
                     ListRef<'a, UnionClassWithExternalRef<'a>, 65536usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                UnionClassWithExternal,
+                                65536usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -946,40 +1073,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a>
             for ContainerWithUnionClassExternalRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <VariableList<
+                        UnionClassWithExternal,
+                        65536usize,
+                    > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerWithUnionClassExternalRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<
+                            UnionClassWithExternal,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1079,22 +1239,29 @@ pub mod tests {
                     ListRef<'a, UnionTypeAliasRef<'a>, 65536usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        4usize,
-                        1usize,
+                        <VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                UnionTypeAlias,
+                                65536usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -1123,40 +1290,73 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ContainerWithUnionTypeAliasRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <VariableList<
+                        UnionTypeAlias,
+                        65536usize,
+                    > as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ContainerWithUnionTypeAliasRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                    ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<
+                            UnionTypeAlias,
+                            65536usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -174,11 +174,12 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -209,46 +210,15 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for UnderlyingTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
-                    );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -172,15 +172,15 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnderlyingTypeRef<'a> {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -198,30 +198,70 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(1usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnderlyingTypeRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 8usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 8usize,
-                        });
+                    let fixed_portion_size = <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for UnderlyingTypeRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    8usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -60,27 +60,31 @@ pub struct ExportEntryRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     pub fn key(&self) -> Result<u32, ssz::DecodeError> {
-        let offset = 0usize;
-        let end = offset + 4usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u32 as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            0usize,
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-        let offset = 4usize;
-        let end = offset + 8usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <u64 as ssz::Encode>::is_ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len(),
+            <u64 as ssz::Encode>::ssz_fixed_len(),
+            <u32 as ssz::Encode>::ssz_fixed_len()
+                + <u64 as ssz::Encode>::ssz_fixed_len(),
+            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -98,35 +102,76 @@ impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
         use tree_hash::TreeHash;
         let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
         {
-            let offset = 0usize;
-            let field_bytes = &self.bytes[offset..offset + 4usize];
-            hasher.write(field_bytes).expect("write field");
+            let key = self.key().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&key);
+            hasher.write(root.as_ref()).expect("write field");
         }
         {
-            let offset = 4usize;
-            let field_bytes = &self.bytes[offset..offset + 8usize];
-            hasher.write(field_bytes).expect("write field");
+            let value = self.value().expect("valid view");
+            let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                H,
+            >(&value);
+            hasher.write(root.as_ref()).expect("write field");
         }
         hasher.finish().expect("finish hasher")
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() != 12usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 12usize,
-            });
+        let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+            + <u64 as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
+            }
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
+            }
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ExportEntryRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        true
+        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
     }
     fn ssz_fixed_len() -> usize {
-        12usize
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <u32 as ssz::Encode>::ssz_fixed_len() + <u64 as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -208,55 +253,85 @@ pub struct ViewTypeTestRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ViewTypeTestRef<'a> {
     pub fn payload(&self) -> Result<BytesRef<'a, 4096usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            40usize,
-            2usize,
+            <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            0usize,
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
+                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            )
+                + usize::from(
+                    !<VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                )
+                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
             0usize,
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            40usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn entries(
         &self,
     ) -> Result<ListRef<'a, ExportEntryRef<'a>, 256usize>, ssz::DecodeError> {
-        let start = ssz::layout::read_variable_offset(
+        let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            40usize,
-            2usize,
-            1usize,
+            <VariableList<ExportEntry, 256usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
+                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            )
+                + usize::from(
+                    !<VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                )
+                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(
+                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ),
         )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            self.bytes,
-            40usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > self.bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &self.bytes[start..end];
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn hash(&self) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
-        let offset = 8usize;
-        let end = offset + 32usize;
-        if end > self.bytes.len() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: self.bytes.len(),
-                expected: end,
-            });
-        }
-        let bytes = &self.bytes[offset..end];
+        let bytes = ssz::layout::read_field_bytes(
+            self.bytes,
+            <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+            <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
+                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+            usize::from(
+                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            )
+                + usize::from(
+                    !<VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                )
+                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
+            usize::from(
+                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+            )
+                + usize::from(
+                    !<VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                ),
+        )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
 }
@@ -299,35 +374,71 @@ impl<'a> tree_hash::TreeHash for ViewTypeTestRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ViewTypeTestRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < 40usize {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: 40usize,
-            });
-        }
-        let mut prev_offset: Option<usize> = None;
-        for i in 0..2usize {
-            let offset = ssz::layout::read_variable_offset(bytes, 40usize, 2usize, i)?;
-            if i == 0 && offset != 40usize {
-                return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+        let fixed_portion_size = <VariableList<
+            u8,
+            4096usize,
+        > as ssz::Encode>::ssz_fixed_len()
+            + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
+            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
+        let num_variable_fields = usize::from(
+            !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+        )
+            + usize::from(
+                !<VariableList<ExportEntry, 256usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len());
+        if num_variable_fields == 0 {
+            if bytes.len() != fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if let Some(prev) = prev_offset && offset < prev {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+        } else {
+            if bytes.len() < fixed_portion_size {
+                return Err(ssz::DecodeError::InvalidByteLength {
+                    len: bytes.len(),
+                    expected: fixed_portion_size,
+                });
             }
-            if offset > bytes.len() {
-                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+            let mut prev_offset: Option<usize> = None;
+            for i in 0..num_variable_fields {
+                let offset = ssz::layout::read_variable_offset(
+                    bytes,
+                    fixed_portion_size,
+                    num_variable_fields,
+                    i,
+                )?;
+                if i == 0 && offset != fixed_portion_size {
+                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                }
+                if let Some(prev) = prev_offset && offset < prev {
+                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                }
+                if offset > bytes.len() {
+                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                }
+                prev_offset = Some(offset);
             }
-            prev_offset = Some(offset);
         }
         Ok(Self { bytes })
     }
 }
 impl<'a> ssz::view::SszTypeInfo for ViewTypeTestRef<'a> {
     fn is_ssz_fixed_len() -> bool {
-        false
+        usize::from(!<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len())
+            + usize::from(
+                !<VariableList<ExportEntry, 256usize> as ssz::Encode>::is_ssz_fixed_len(),
+            ) + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len())
+            == 0
     }
     fn ssz_fixed_len() -> usize {
-        0
+        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
+                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len()
+        } else {
+            0
+        }
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -62,13 +62,16 @@ impl<'a> ExportEntryRef<'a> {
     pub fn key(&self) -> Result<u32, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u32 as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -76,14 +79,17 @@ impl<'a> ExportEntryRef<'a> {
     pub fn value(&self) -> Result<u64, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <u64 as ssz::Encode>::is_ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len(),
-            <u64 as ssz::Encode>::ssz_fixed_len(),
-            <u32 as ssz::Encode>::ssz_fixed_len()
-                + <u64 as ssz::Encode>::ssz_fixed_len(),
-            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+            &[
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -120,44 +126,19 @@ impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u32 as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                    <u64 as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }
@@ -255,22 +236,23 @@ impl<'a> ViewTypeTestRef<'a> {
     pub fn payload(&self) -> Result<BytesRef<'a, 4096usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            0usize,
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
-                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            )
-                + usize::from(
-                    !<VariableList<
+            &[
+                (
+                    <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<
                         ExportEntry,
                         256usize,
                     > as ssz::Encode>::is_ssz_fixed_len(),
-                )
-                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
+                    <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
             0usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -280,57 +262,48 @@ impl<'a> ViewTypeTestRef<'a> {
     ) -> Result<ListRef<'a, ExportEntryRef<'a>, 256usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <VariableList<ExportEntry, 256usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
-                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            )
-                + usize::from(
-                    !<VariableList<
+            &[
+                (
+                    <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<
                         ExportEntry,
                         256usize,
                     > as ssz::Encode>::is_ssz_fixed_len(),
-                )
-                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(
-                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ),
+                    <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            1usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
     pub fn hash(&self) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
         let bytes = ssz::layout::read_field_bytes(
             self.bytes,
-            <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
-            <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-            <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
-                + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-            usize::from(
-                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            )
-                + usize::from(
-                    !<VariableList<
-                        ExportEntry,
-                        256usize,
-                    > as ssz::Encode>::is_ssz_fixed_len(),
-                )
-                + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len()),
-            usize::from(
-                !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-            )
-                + usize::from(
-                    !<VariableList<
-                        ExportEntry,
-                        256usize,
-                    > as ssz::Encode>::is_ssz_fixed_len(),
+            &[
+                (
+                    <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
                 ),
+                (
+                    <VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+            2usize,
         )?;
         ssz::view::DecodeView::from_ssz_bytes(bytes)
     }
@@ -374,52 +347,26 @@ impl<'a> tree_hash::TreeHash for ViewTypeTestRef<'a> {
 }
 impl<'a> ssz::view::DecodeView<'a> for ViewTypeTestRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-        let fixed_portion_size = <VariableList<
-            u8,
-            4096usize,
-        > as ssz::Encode>::ssz_fixed_len()
-            + <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len()
-            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
-        let num_variable_fields = usize::from(
-            !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-        )
-            + usize::from(
-                !<VariableList<ExportEntry, 256usize> as ssz::Encode>::is_ssz_fixed_len(),
-            ) + usize::from(!<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len());
-        if num_variable_fields == 0 {
-            if bytes.len() != fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-        } else {
-            if bytes.len() < fixed_portion_size {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: fixed_portion_size,
-                });
-            }
-            let mut prev_offset: Option<usize> = None;
-            for i in 0..num_variable_fields {
-                let offset = ssz::layout::read_variable_offset(
-                    bytes,
-                    fixed_portion_size,
-                    num_variable_fields,
-                    i,
-                )?;
-                if i == 0 && offset != fixed_portion_size {
-                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                }
-                if let Some(prev) = prev_offset && offset < prev {
-                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                }
-                if offset > bytes.len() {
-                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                }
-                prev_offset = Some(offset);
-            }
-        }
+        ssz::layout::validate_container(
+            bytes,
+            &[
+                (
+                    <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <VariableList<
+                        ExportEntry,
+                        256usize,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <VariableList<ExportEntry, 256usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ],
+        )?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -75,13 +75,16 @@ pub mod tests {
                 pub fn key(&self) -> Result<u32, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -89,14 +92,17 @@ pub mod tests {
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len(),
-                        <u64 as ssz::Encode>::ssz_fixed_len(),
-                        <u32 as ssz::Encode>::ssz_fixed_len()
-                            + <u64 as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
-                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
-                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -133,47 +139,19 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
-                        + <u64 as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
-                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u32 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                                <u64 as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -291,30 +269,32 @@ pub mod tests {
                 ) -> Result<BytesRef<'a, 4096usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        0usize,
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                ExportEntry,
-                                256usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                u8,
-                                4096usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     ExportEntry,
                                     256usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
                         0usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
@@ -327,42 +307,33 @@ pub mod tests {
                 > {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <VariableList<
-                            ExportEntry,
-                            256usize,
-                        > as ssz::Encode>::is_ssz_fixed_len(),
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<
-                            ExportEntry,
-                            256usize,
-                        > as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                ExportEntry,
-                                256usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                u8,
-                                4096usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     ExportEntry,
                                     256usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
-                        usize::from(
-                            !<VariableList<
-                                u8,
-                                4096usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        1usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -371,46 +342,33 @@ pub mod tests {
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
                     let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                ExportEntry,
-                                256usize,
-                            > as ssz::Encode>::ssz_fixed_len(),
-                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
-                            + <VariableList<
-                                ExportEntry,
-                                256usize,
-                            > as ssz::Encode>::ssz_fixed_len()
-                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
-                        usize::from(
-                            !<VariableList<
-                                u8,
-                                4096usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
                                     ExportEntry,
                                     256usize,
                                 > as ssz::Encode>::is_ssz_fixed_len(),
-                            )
-                            + usize::from(
-                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                            ),
-                        usize::from(
-                            !<VariableList<
-                                u8,
-                                4096usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                            + usize::from(
-                                !<VariableList<
+                                <VariableList<
                                     ExportEntry,
                                     256usize,
-                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                > as ssz::Encode>::ssz_fixed_len(),
                             ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                        2usize,
                     )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
@@ -454,63 +412,35 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ViewTypeTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    let fixed_portion_size = <VariableList<
-                        u8,
-                        4096usize,
-                    > as ssz::Encode>::ssz_fixed_len()
-                        + <VariableList<
-                            ExportEntry,
-                            256usize,
-                        > as ssz::Encode>::ssz_fixed_len()
-                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
-                    let num_variable_fields = usize::from(
-                        !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
-                    )
-                        + usize::from(
-                            !<VariableList<
-                                ExportEntry,
-                                256usize,
-                            > as ssz::Encode>::is_ssz_fixed_len(),
-                        )
-                        + usize::from(
-                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
-                        );
-                    if num_variable_fields == 0 {
-                        if bytes.len() != fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                    } else {
-                        if bytes.len() < fixed_portion_size {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: fixed_portion_size,
-                            });
-                        }
-                        let mut prev_offset: Option<usize> = None;
-                        for i in 0..num_variable_fields {
-                            let offset = ssz::layout::read_variable_offset(
-                                bytes,
-                                fixed_portion_size,
-                                num_variable_fields,
-                                i,
-                            )?;
-                            if i == 0 && offset != fixed_portion_size {
-                                return Err(
-                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
-                                );
-                            }
-                            if let Some(prev) = prev_offset && offset < prev {
-                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                            }
-                            if offset > bytes.len() {
-                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                            }
-                            prev_offset = Some(offset);
-                        }
-                    }
+                    ssz::layout::validate_container(
+                        bytes,
+                        &[
+                            (
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    u8,
+                                    4096usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                                <VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                            (
+                                <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                                <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                            ),
+                        ],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -73,27 +73,31 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExportEntryRef<'a> {
                 pub fn key(&self) -> Result<u32, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 4usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u32 as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        0usize,
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn value(&self) -> Result<u64, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 8usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <u64 as ssz::Encode>::is_ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len(),
+                        <u64 as ssz::Encode>::ssz_fixed_len(),
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                            + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()),
+                        usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len()),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -111,35 +115,80 @@ pub mod tests {
                     use tree_hash::TreeHash;
                     let mut hasher = tree_hash::MerkleHasher::<H>::with_leaves(2usize);
                     {
-                        let offset = 0usize;
-                        let field_bytes = &self.bytes[offset..offset + 4usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let key = self.key().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&key);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     {
-                        let offset = 4usize;
-                        let field_bytes = &self.bytes[offset..offset + 8usize];
-                        hasher.write(field_bytes).expect("write field");
+                        let value = self.value().expect("valid view");
+                        let root: <H as tree_hash::TreeHashDigest>::Output = <_ as tree_hash::TreeHash>::tree_hash_root::<
+                            H,
+                        >(&value);
+                        hasher.write(root.as_ref()).expect("write field");
                     }
                     hasher.finish().expect("finish hasher")
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for ExportEntryRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() != 12usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 12usize,
-                        });
+                    let fixed_portion_size = <u32 as ssz::Encode>::ssz_fixed_len()
+                        + <u64 as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<u32 as ssz::Encode>::is_ssz_fixed_len(),
+                    ) + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len());
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
+                        }
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
+                        }
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ExportEntryRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    true
+                    usize::from(!<u32 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(!<u64 as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    12usize
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u32 as ssz::Encode>::ssz_fixed_len()
+                            + <u64 as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -240,22 +289,34 @@ pub mod tests {
                 pub fn payload(
                     &self,
                 ) -> Result<BytesRef<'a, 4096usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        40usize,
-                        2usize,
+                        <VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        0usize,
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                u8,
+                                4096usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
                         0usize,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        40usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn entries(
@@ -264,36 +325,93 @@ pub mod tests {
                     ListRef<'a, ExportEntryRef<'a>, 256usize>,
                     ssz::DecodeError,
                 > {
-                    let start = ssz::layout::read_variable_offset(
+                    let bytes = ssz::layout::read_field_bytes(
                         self.bytes,
-                        40usize,
-                        2usize,
-                        1usize,
+                        <VariableList<
+                            ExportEntry,
+                            256usize,
+                        > as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<
+                            ExportEntry,
+                            256usize,
+                        > as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                u8,
+                                4096usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<VariableList<
+                                u8,
+                                4096usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        ),
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        40usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
                 pub fn hash(
                     &self,
                 ) -> Result<FixedBytesRef<'a, 32usize>, ssz::DecodeError> {
-                    let offset = 8usize;
-                    let end = offset + 32usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
+                    let bytes = ssz::layout::read_field_bytes(
+                        self.bytes,
+                        <FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len(),
+                        usize::from(
+                            !<VariableList<
+                                u8,
+                                4096usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            )
+                            + usize::from(
+                                !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                        usize::from(
+                            !<VariableList<
+                                u8,
+                                4096usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                            + usize::from(
+                                !<VariableList<
+                                    ExportEntry,
+                                    256usize,
+                                > as ssz::Encode>::is_ssz_fixed_len(),
+                            ),
+                    )?;
                     ssz::view::DecodeView::from_ssz_bytes(bytes)
                 }
             }
@@ -336,40 +454,92 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for ViewTypeTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 40usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 40usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..2usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            40usize,
-                            2usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 40usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
+                    let fixed_portion_size = <VariableList<
+                        u8,
+                        4096usize,
+                    > as ssz::Encode>::ssz_fixed_len()
+                        + <VariableList<
+                            ExportEntry,
+                            256usize,
+                        > as ssz::Encode>::ssz_fixed_len()
+                        + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len();
+                    let num_variable_fields = usize::from(
+                        !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        );
+                    if num_variable_fields == 0 {
+                        if bytes.len() != fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                    } else {
+                        if bytes.len() < fixed_portion_size {
+                            return Err(ssz::DecodeError::InvalidByteLength {
+                                len: bytes.len(),
+                                expected: fixed_portion_size,
+                            });
                         }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                        let mut prev_offset: Option<usize> = None;
+                        for i in 0..num_variable_fields {
+                            let offset = ssz::layout::read_variable_offset(
+                                bytes,
+                                fixed_portion_size,
+                                num_variable_fields,
+                                i,
+                            )?;
+                            if i == 0 && offset != fixed_portion_size {
+                                return Err(
+                                    ssz::DecodeError::OffsetIntoFixedPortion(offset),
+                                );
+                            }
+                            if let Some(prev) = prev_offset && offset < prev {
+                                return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
+                            }
+                            if offset > bytes.len() {
+                                return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
+                            }
+                            prev_offset = Some(offset);
                         }
-                        prev_offset = Some(offset);
                     }
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for ViewTypeTestRef<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<u8, 4096usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                        )
+                        + usize::from(
+                            !<FixedBytes<32usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<u8, 4096usize> as ssz::Encode>::ssz_fixed_len()
+                            + <VariableList<
+                                ExportEntry,
+                                256usize,
+                            > as ssz::Encode>::ssz_fixed_len()
+                            + <FixedBytes<32usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]

--- a/crates/ssz_codegen/tests/input/test_nested_fixed_container.ssz
+++ b/crates/ssz_codegen/tests/input/test_nested_fixed_container.ssz
@@ -31,3 +31,15 @@ class FixedOuter(Container):
 class BasicPair(Container):
     tag: uint8
     b: uint32
+
+### Variable-size field before a fixed-size one: the offset entry sits at
+### the variable field's own position in the fixed portion, not at the end.
+class VarThenFixed(Container):
+    entries: List[uint8, MAX_TAIL]
+    name: uint32
+
+### Variable fields interleaved with fixed fields.
+class Interleaved(Container):
+    head: List[uint8, MAX_TAIL]
+    mid: uint8
+    tail: List[uint8, MAX_TAIL]

--- a/crates/ssz_codegen/tests/input/test_nested_fixed_container.ssz
+++ b/crates/ssz_codegen/tests/input/test_nested_fixed_container.ssz
@@ -1,0 +1,33 @@
+# Regression test: containers whose fields are themselves fixed-size
+# containers. The owned ssz_derive encoding inlines fixed-size container
+# fields, so generated views must not assume container-typed fields are
+# variable-size (offset table entries).
+
+MAX_TAIL = 16
+
+### A fixed-size inner container (1 byte).
+class FixedInner(Container):
+    tag: uint8
+
+### A larger fixed-size inner container (8 bytes).
+class FixedPair(Container):
+    x: uint32
+    y: uint32
+
+### Mixed container: fixed containers inline, one variable tail.
+class MixedOuter(Container):
+    inner: FixedInner
+    count: uint32
+    pair: FixedPair
+    tail: List[uint8, MAX_TAIL]
+
+### Fully fixed container nesting fixed containers.
+class FixedOuter(Container):
+    inner: FixedInner
+    pair: FixedPair
+
+### Basic-fields-only container: decodes fine either way, but exercises the
+### view TreeHash leaf packing.
+class BasicPair(Container):
+    tag: uint8
+    b: uint32

--- a/crates/ssz_codegen/tests/input/test_with_pragma.ssz
+++ b/crates/ssz_codegen/tests/input/test_with_pragma.ssz
@@ -1,0 +1,6 @@
+### Test that field-level ssz(with) overrides flow into the view layout
+class WithCodecContainer(Container):
+    lead: uint8
+    #~# field_attr: #[ssz(with = "custom_codec")]
+    wrapped: uint64
+    tail: List[uint8, 32]

--- a/crates/ssz_codegen/tests/nested_fixed_container_view.rs
+++ b/crates/ssz_codegen/tests/nested_fixed_container_view.rs
@@ -1,0 +1,84 @@
+//! Regression test: views over containers with fixed-size container fields.
+//!
+//! The owned `ssz_derive` encoding inlines fixed-size container fields in the
+//! fixed portion, but generated views assume every container-typed field is
+//! variable-size (an offset-table entry), so they fail to decode
+//! owned-encoded bytes with `OffsetIntoFixedPortion`. Similarly, the view
+//! TreeHash impl writes raw basic-field bytes into the `MerkleHasher` (which
+//! only forms a leaf per `HASH_SIZE` bytes) while the owned impl gives every
+//! field a padded leaf, so their roots disagree.
+//!
+//! These tests currently PIN THE BROKEN BEHAVIOR to document the bug; the
+//! fix flips them to assert agreement with the owned encoding.
+
+#![allow(dead_code)]
+#![allow(unused_crate_dependencies)]
+#![allow(missing_docs)]
+
+use ssz_derive as _;
+use ssz_primitives as _;
+use tree_hash_derive as _;
+
+// Include generated code
+include!("expected_output/test_nested_fixed_container.rs");
+
+use ssz::{DecodeError, Encode, view::DecodeView};
+use ssz_types::VariableList;
+use tests::input::test_nested_fixed_container::{
+    BasicPair, BasicPairRef, FixedInner, FixedOuter, FixedOuterRef, FixedPair, MixedOuter,
+    MixedOuterRef,
+};
+use tree_hash::TreeHash;
+
+fn sample_mixed() -> MixedOuter {
+    MixedOuter {
+        inner: FixedInner { tag: 7 },
+        count: 0xAABBCCDD,
+        pair: FixedPair { x: 1, y: 2 },
+        tail: VariableList::new(vec![1, 2, 3]).expect("within bound"),
+    }
+}
+
+#[test]
+fn mixed_view_rejects_owned_encoding() {
+    let owned = sample_mixed();
+    let bytes = owned.as_ssz_bytes();
+
+    // BUG: the view assumes `inner` and `pair` sit behind offset-table
+    // entries, but the owned encoding inlines them (they are fixed-size), so
+    // the view cannot decode bytes produced by the owned Encode impl.
+    let err = MixedOuterRef::from_ssz_bytes(&bytes).expect_err("view layout disagrees");
+    assert!(matches!(err, DecodeError::OffsetIntoFixedPortion(_)));
+}
+
+#[test]
+fn fully_fixed_view_rejects_owned_encoding() {
+    let owned = FixedOuter {
+        inner: FixedInner { tag: 3 },
+        pair: FixedPair { x: 9, y: 10 },
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    // BUG: same disagreement for a container whose owned encoding is fully
+    // fixed-size (9 bytes inline; the view expects an 8-byte offset table).
+    assert!(FixedOuterRef::from_ssz_bytes(&bytes).is_err());
+}
+
+#[test]
+fn basic_view_tree_hash_disagrees_with_owned() {
+    let owned = BasicPair {
+        tag: 0x11,
+        b: 0x22334455,
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    // Basic-only containers decode fine (their layout has no container
+    // fields), but the view TreeHash packs the raw field bytes into a single
+    // leaf while the owned impl hashes one padded leaf per field.
+    let view = BasicPairRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_ne!(
+        view.tree_hash_root::<tree_hash::Sha256Hasher>(),
+        owned.tree_hash_root::<tree_hash::Sha256Hasher>(),
+        "BUG: view and owned tree hashes should agree but do not yet"
+    );
+}

--- a/crates/ssz_codegen/tests/nested_fixed_container_view.rs
+++ b/crates/ssz_codegen/tests/nested_fixed_container_view.rs
@@ -25,8 +25,8 @@ use ssz::{
 };
 use ssz_types::VariableList;
 use tests::input::test_nested_fixed_container::{
-    BasicPair, BasicPairRef, FixedInner, FixedOuter, FixedOuterRef, FixedPair, MixedOuter,
-    MixedOuterRef,
+    BasicPair, BasicPairRef, FixedInner, FixedOuter, FixedOuterRef, FixedPair, Interleaved,
+    InterleavedRef, MixedOuter, MixedOuterRef, VarThenFixed, VarThenFixedRef,
 };
 use tree_hash::TreeHash;
 
@@ -77,6 +77,48 @@ fn view_tree_hash_agrees_with_owned() {
     let owned = sample_mixed();
     let bytes = owned.as_ssz_bytes();
     let view = MixedOuterRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(
+        view.tree_hash_root::<tree_hash::Sha256Hasher>(),
+        owned.tree_hash_root::<tree_hash::Sha256Hasher>()
+    );
+}
+
+/// Regression test for reading variable offsets from the field's own slot:
+/// the offset entry of `entries` sits at position 0 of the fixed portion,
+/// followed by `name`. An end-packed offset table reading would interpret
+/// `name`'s bytes as the offset and reject valid owned encodings.
+#[test]
+fn variable_before_fixed_view_agrees_with_owned_encoding() {
+    let owned = VarThenFixed {
+        entries: VariableList::new(vec![1, 2, 3]).expect("within bound"),
+        name: 0xDEADBEEF,
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = VarThenFixedRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.entries().expect("entries").len(), 3);
+    assert_eq!(view.name().expect("name"), 0xDEADBEEF);
+    assert_eq!(view.to_owned(), owned);
+    assert_eq!(
+        view.tree_hash_root::<tree_hash::Sha256Hasher>(),
+        owned.tree_hash_root::<tree_hash::Sha256Hasher>()
+    );
+}
+
+#[test]
+fn interleaved_view_agrees_with_owned_encoding() {
+    let owned = Interleaved {
+        head: VariableList::new(vec![0xAA, 0xBB]).expect("within bound"),
+        mid: 7,
+        tail: VariableList::new(vec![0xCC]).expect("within bound"),
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = InterleavedRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.head().expect("head").to_owned(), vec![0xAA, 0xBB]);
+    assert_eq!(view.mid().expect("mid"), 7);
+    assert_eq!(view.tail().expect("tail").to_owned(), vec![0xCC]);
+    assert_eq!(view.to_owned(), owned);
     assert_eq!(
         view.tree_hash_root::<tree_hash::Sha256Hasher>(),
         owned.tree_hash_root::<tree_hash::Sha256Hasher>()

--- a/crates/ssz_codegen/tests/nested_fixed_container_view.rs
+++ b/crates/ssz_codegen/tests/nested_fixed_container_view.rs
@@ -1,15 +1,12 @@
 //! Regression test: views over containers with fixed-size container fields.
 //!
 //! The owned `ssz_derive` encoding inlines fixed-size container fields in the
-//! fixed portion, but generated views assume every container-typed field is
-//! variable-size (an offset-table entry), so they fail to decode
-//! owned-encoded bytes with `OffsetIntoFixedPortion`. Similarly, the view
-//! TreeHash impl writes raw basic-field bytes into the `MerkleHasher` (which
-//! only forms a leaf per `HASH_SIZE` bytes) while the owned impl gives every
-//! field a padded leaf, so their roots disagree.
-//!
-//! These tests currently PIN THE BROKEN BEHAVIOR to document the bug; the
-//! fix flips them to assert agreement with the owned encoding.
+//! fixed portion. Views used to assume every container-typed field was
+//! variable-size (an offset-table entry) and failed to decode owned-encoded
+//! bytes with `OffsetIntoFixedPortion`; the view TreeHash also wrote raw
+//! basic-field bytes instead of one padded leaf per field. Views now derive
+//! their layout from the field types' `Encode` impls and must agree with the
+//! owned encoding.
 
 #![allow(dead_code)]
 #![allow(unused_crate_dependencies)]
@@ -22,7 +19,10 @@ use tree_hash_derive as _;
 // Include generated code
 include!("expected_output/test_nested_fixed_container.rs");
 
-use ssz::{DecodeError, Encode, view::DecodeView};
+use ssz::{
+    Encode,
+    view::{DecodeView, SszTypeInfo},
+};
 use ssz_types::VariableList;
 use tests::input::test_nested_fixed_container::{
     BasicPair, BasicPairRef, FixedInner, FixedOuter, FixedOuterRef, FixedPair, MixedOuter,
@@ -40,45 +40,60 @@ fn sample_mixed() -> MixedOuter {
 }
 
 #[test]
-fn mixed_view_rejects_owned_encoding() {
+fn mixed_view_agrees_with_owned_encoding() {
     let owned = sample_mixed();
     let bytes = owned.as_ssz_bytes();
 
-    // BUG: the view assumes `inner` and `pair` sit behind offset-table
-    // entries, but the owned encoding inlines them (they are fixed-size), so
-    // the view cannot decode bytes produced by the owned Encode impl.
-    let err = MixedOuterRef::from_ssz_bytes(&bytes).expect_err("view layout disagrees");
-    assert!(matches!(err, DecodeError::OffsetIntoFixedPortion(_)));
+    let view = MixedOuterRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.inner().expect("inner").tag().expect("tag"), 7);
+    assert_eq!(view.count().expect("count"), 0xAABBCCDD);
+    let pair = view.pair().expect("pair");
+    assert_eq!(pair.x().expect("x"), 1);
+    assert_eq!(pair.y().expect("y"), 2);
+    assert_eq!(view.tail().expect("tail").len(), 3);
+    assert_eq!(view.to_owned(), owned);
 }
 
 #[test]
-fn fully_fixed_view_rejects_owned_encoding() {
+fn fully_fixed_view_agrees_with_owned_encoding() {
     let owned = FixedOuter {
         inner: FixedInner { tag: 3 },
         pair: FixedPair { x: 9, y: 10 },
     };
     let bytes = owned.as_ssz_bytes();
 
-    // BUG: same disagreement for a container whose owned encoding is fully
-    // fixed-size (9 bytes inline; the view expects an 8-byte offset table).
-    assert!(FixedOuterRef::from_ssz_bytes(&bytes).is_err());
+    assert!(<FixedOuterRef<'_> as SszTypeInfo>::is_ssz_fixed_len());
+    assert_eq!(
+        <FixedOuterRef<'_> as SszTypeInfo>::ssz_fixed_len(),
+        bytes.len()
+    );
+
+    let view = FixedOuterRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.to_owned(), owned);
 }
 
 #[test]
-fn basic_view_tree_hash_disagrees_with_owned() {
+fn view_tree_hash_agrees_with_owned() {
+    let owned = sample_mixed();
+    let bytes = owned.as_ssz_bytes();
+    let view = MixedOuterRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(
+        view.tree_hash_root::<tree_hash::Sha256Hasher>(),
+        owned.tree_hash_root::<tree_hash::Sha256Hasher>()
+    );
+}
+
+#[test]
+fn basic_view_tree_hash_agrees_with_owned() {
     let owned = BasicPair {
         tag: 0x11,
         b: 0x22334455,
     };
     let bytes = owned.as_ssz_bytes();
 
-    // Basic-only containers decode fine (their layout has no container
-    // fields), but the view TreeHash packs the raw field bytes into a single
-    // leaf while the owned impl hashes one padded leaf per field.
     let view = BasicPairRef::from_ssz_bytes(&bytes).expect("view decode");
-    assert_ne!(
+    assert_eq!(
         view.tree_hash_root::<tree_hash::Sha256Hasher>(),
-        owned.tree_hash_root::<tree_hash::Sha256Hasher>(),
-        "BUG: view and owned tree hashes should agree but do not yet"
+        owned.tree_hash_root::<tree_hash::Sha256Hasher>()
     );
 }

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -815,6 +815,53 @@ fn test_pragmas_inheritance() {
     assert_eq!(expected_output, actual_output);
 }
 
+/// Test that a field-level `#[ssz(with = ...)]` pragma flows into the view
+/// layout: `ssz_derive` encodes such fields through `module::encode::*`
+/// instead of the field type's `Encode` impl, so the generated view layout
+/// expressions must call the same functions to agree with the owned encoding.
+#[test]
+fn test_view_layout_honors_field_ssz_with() {
+    build_ssz_files(
+        &["test_with_pragma.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_with_pragma.rs",
+        ModuleGeneration::NestedModules,
+    )
+    .expect("Failed to generate SSZ types with ssz(with) field pragma");
+
+    let generated = fs::read_to_string("tests/output/test_with_pragma.rs")
+        .expect("Failed to read generated output");
+
+    // The owned struct forwards the attribute to ssz_derive.
+    assert!(
+        generated.contains(r#"#[ssz(with = "custom_codec")]"#),
+        "owned struct should carry the ssz(with) field attribute"
+    );
+
+    // View layout expressions must size the overridden field via the
+    // with-module's encode fns.
+    assert!(
+        generated.contains("custom_codec::encode::ssz_fixed_len()"),
+        "view layout should size the overridden field via the with-module"
+    );
+    assert!(
+        generated.contains("custom_codec::encode::is_ssz_fixed_len()"),
+        "view layout should derive the overridden field's fixedness via the with-module"
+    );
+
+    // The overridden field is the only u64; its bare `Encode` impl must not
+    // appear anywhere in the layout expressions.
+    assert!(
+        !generated.contains("<u64 as ssz::Encode>::ssz_fixed_len()"),
+        "view layout must not bypass the with-module via the bare field type"
+    );
+    assert!(
+        !generated.contains("<u64 as ssz::Encode>::is_ssz_fixed_len()"),
+        "view layout must not bypass the with-module via the bare field type"
+    );
+}
+
 /// Test edge case: empty pragmas don't break codegen.
 #[test]
 fn test_pragmas_empty() {

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -2276,3 +2276,22 @@ fn test_container_filter_removes_qualified_ordering_derives() {
 fn test_unqualified_pragma_derive_panics() {
     ssz_codegen::pragma::ParsedPragma::parse(&["derive: Copy".to_string()]);
 }
+
+#[test]
+fn test_nested_fixed_container_views() {
+    build_ssz_files(
+        &["test_nested_fixed_container.ssz"],
+        "tests/input",
+        &[],
+        "tests/output/test_nested_fixed_container.rs",
+        ModuleGeneration::NestedModules,
+    )
+    .expect("Failed to generate SSZ types");
+
+    let expected_output =
+        fs::read_to_string("tests/expected_output/test_nested_fixed_container.rs")
+            .expect("Failed to read expected output");
+    let actual_output = fs::read_to_string("tests/output/test_nested_fixed_container.rs")
+        .expect("Failed to read actual output");
+    assert_eq!(expected_output, actual_output);
+}

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -860,6 +860,17 @@ fn test_view_layout_honors_field_ssz_with() {
         !generated.contains("<u64 as ssz::Encode>::is_ssz_fixed_len()"),
         "view layout must not bypass the with-module via the bare field type"
     );
+
+    // The getter decodes the slice through the with-module to the owned
+    // field type, mirroring ssz_derive's Decode impl.
+    assert!(
+        generated.contains("custom_codec::decode::from_ssz_bytes(bytes)"),
+        "view getter should decode the overridden field via the with-module"
+    );
+    assert!(
+        generated.contains("pub fn wrapped(&self) -> Result<u64, ssz::DecodeError>"),
+        "with-field getter should return the owned field type"
+    );
 }
 
 /// Test edge case: empty pragmas don't break codegen.

--- a/crates/ssz_codegen/tests/to_owned_ssz_integration.rs
+++ b/crates/ssz_codegen/tests/to_owned_ssz_integration.rs
@@ -15,9 +15,12 @@ use tree_hash_derive as _;
 // Include generated code
 include!("expected_output/test_external_container.rs");
 
-use ssz::view::DecodeView;
+use ssz::{Encode, view::DecodeView};
 use ssz_types::view::ToOwnedSsz;
-use tests::input::{test_external_inner::BlockCommitmentRef, test_external_outer::BlockRangeRef};
+use tests::input::{
+    test_external_inner::{BlockCommitment, BlockCommitmentRef},
+    test_external_outer::{BlockRange, BlockRangeRef},
+};
 
 /// External BlockCommitment - simulates bitcoin feature where height is absolute::Height
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,27 +57,21 @@ impl<'a> ToOwnedSsz<ExternalBlockRange> for BlockRangeRef<'a> {
     }
 }
 
-/// Manually construct SSZ bytes for BlockRange with variable-length layout.
-/// Layout: [offset_start:4][offset_end:4][start_data:36][end_data:36]
+/// Constructs SSZ bytes for BlockRange via the owned `Encode` impl, so the
+/// fixture always matches the canonical encoding (both BlockCommitment fields
+/// are fixed-size, hence inlined - no offset table).
 fn create_block_range_bytes(start_height: u32, end_height: u32) -> Vec<u8> {
-    let mut bytes = Vec::new();
-
-    // Fixed portion: 2 offsets (4 bytes each)
-    let offset_start: u32 = 8; // Start data begins after fixed portion
-    let offset_end: u32 = 8 + 36; // End data begins after start data
-
-    bytes.extend_from_slice(&offset_start.to_le_bytes());
-    bytes.extend_from_slice(&offset_end.to_le_bytes());
-
-    // Start BlockCommitment: height (4 bytes) + block_hash (32 bytes)
-    bytes.extend_from_slice(&start_height.to_le_bytes());
-    bytes.extend_from_slice(&[0xAA; 32]); // start block_hash
-
-    // End BlockCommitment: height (4 bytes) + block_hash (32 bytes)
-    bytes.extend_from_slice(&end_height.to_le_bytes());
-    bytes.extend_from_slice(&[0xBB; 32]); // end block_hash
-
-    bytes
+    let range = BlockRange {
+        start: BlockCommitment {
+            height: start_height,
+            block_hash: [0xAA; 32].into(),
+        },
+        end: BlockCommitment {
+            height: end_height,
+            block_hash: [0xBB; 32].into(),
+        },
+    };
+    range.as_ssz_bytes()
 }
 
 #[test]


### PR DESCRIPTION
## Description

Generated `Ref` views computed their layout at codegen time from `TypeResolution::is_fixed_size()`, which hardcodes class and external field types as variable-size. The owned encoding produced by `ssz_derive` resolves fixedness from the actual `Encode` impls and inlines fixed-size containers, so a view over any container with a fixed-size container field failed to decode its own owned encoding (`OffsetIntoFixedPortion`). Separately, the view `TreeHash` impl packed raw basic-field bytes into the hasher instead of giving each field a padded 32-byte leaf, so view and owned tree hash roots disagreed even for containers that decoded fine.

Views now emit their layout (getters, `DecodeView` validation, `SszTypeInfo`) as const-foldable expressions over the field types' `Encode` impls — the same source of truth `ssz_derive` uses — making them correct by construction, including for external types whose fixedness is unknowable at codegen time. The view `TreeHash` impl now hashes every field through its decoded value, matching the owned impl.

Found while embedding a fixed-size external container in the ASM anchor state (alpenlabs/asm#184).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

The review entry points are `crates/ssz_codegen/src/types/mod.rs` (layout expression emission) and `crates/ssz/src/layout.rs` (the shared `read_field_bytes` slicing helper). The bulk of the diff is regenerated `expected_output` fixtures.

The branch is deliberately structured pin-then-flip: the first commit adds tests asserting the broken behavior (green on the broken code), and the fix commit flips them to assert agreement with the owned encoding — every commit stays green for CI and bisect while history documents both symptoms. Verified that the flipped assertions fail 4/4 when run against the pre-fix code.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Related to alpenlabs/asm#184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
