### PR TITLE
chore(deps): update crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Description

`cargo audit` (the `just audit` recipe) currently fails on `main` with RUSTSEC-2026-0204: an invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl, fixed in 0.9.20. This bumps the locked version from 0.9.18 to 0.9.20 — a lockfile-only, semver-compatible update, no manifest changes.

`crossbeam-epoch` only reaches this workspace as a bench-only transitive dependency (criterion → rayon → crossbeam-deque), so no runtime code is affected.

The two remaining `rand` unsound advisories (RUSTSEC-2026-0097) are warn-level and don't fail the audit; fixing them would require real dependency upgrades in `tree_hash`/`ruint` and is out of scope here.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency update
- [x] Security fix

## Notes to Reviewers

Verified locally: `cargo audit` exits 0 (only the two allowed `rand` warnings remain), workspace benches compile with the updated lock, and the full nextest suite passes (477/477).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
