### PR TITLE
fix: make StableContainer/Profile views and Profile serialization agree with EIP-7495

### DIFF
--- a/crates/ssz/src/layout.rs
+++ b/crates/ssz/src/layout.rs
@@ -205,13 +205,11 @@ fn validate_offset_table(
 ///
 /// Assumes the offset entries form a contiguous table at the end of the
 /// fixed portion, which holds only when no fixed-size field follows a
-/// variable-size one (e.g. all-`Optional` StableContainers). In canonical
-/// SSZ each offset entry sits at its field's own position in the fixed
-/// portion; use [`read_field_bytes`] with a field table for such layouts.
-///
-/// FIXME: the StableContainer/Profile codegen path still relies on this
-/// end-packed assumption, which is wrong for Profiles that mix required
-/// fixed-size fields after variable-size ones (pre-existing).
+/// variable-size one. In canonical SSZ each offset entry sits at its
+/// field's own position in the fixed portion; use [`read_field_bytes`]
+/// (or [`read_active_field_bytes`] for StableContainer/Profile bodies)
+/// with a field table for such layouts. Generated view code no longer
+/// uses this helper; it is kept for compatibility.
 ///
 /// # Arguments
 ///
@@ -332,10 +330,46 @@ pub fn read_field_bytes<'a>(
     fields: &[FieldInfo],
     index: usize,
 ) -> Result<&'a [u8], DecodeError> {
+    let field = read_active_field_bytes(bytes, fields, |_| true, index)?;
+    Ok(field.expect("every field is active"))
+}
+
+/// Slices the field at `index` out of a container body in which only *active*
+/// fields are serialized (EIP-7495 `StableContainer`/`Profile` semantics).
+///
+/// `bytes` is the container body *after* the leading active-fields bitvector;
+/// `fields` holds the layout facts for **all declared fields** and `active(i)`
+/// reports whether field `i` is present. An inactive field contributes
+/// neither inline data nor an offset slot to the body, so positions are
+/// computed over active fields only. Offset entries stay interleaved at their
+/// (active) field's own position, exactly as in [`read_field_bytes`].
+///
+/// Returns `Ok(None)` when field `index` itself is inactive.
+///
+/// # Arguments
+///
+/// * `bytes` - The container body after the bitvector
+/// * `fields` - Per-field layout facts for all declared fields, in field order
+/// * `active` - Presence predicate, typically backed by the bitvector
+/// * `index` - The index of the field to slice
+pub fn read_active_field_bytes<'a>(
+    bytes: &'a [u8],
+    fields: &[FieldInfo],
+    active: impl Fn(usize) -> bool,
+    index: usize,
+) -> Result<Option<&'a [u8]>, DecodeError> {
     let &(is_fixed, fixed_len) = fields
         .get(index)
         .ok_or(DecodeError::OutOfBoundsByte { i: index })?;
-    let pos: usize = fields[..index].iter().map(|&(_, len)| len).sum();
+    if !active(index) {
+        return Ok(None);
+    }
+    let pos: usize = fields[..index]
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| active(i))
+        .map(|(_, &(_, len))| len)
+        .sum();
 
     if is_fixed {
         let end = pos
@@ -347,15 +381,19 @@ pub fn read_field_bytes<'a>(
                 expected: end,
             });
         }
-        Ok(&bytes[pos..end])
+        Ok(Some(&bytes[pos..end]))
     } else {
         let start = read_offset_at(bytes, pos)?;
 
-        // The field ends where the next variable-size field begins, whose
-        // offset entry sits after the intervening fixed-size fields.
+        // The field ends where the next active variable-size field begins,
+        // whose offset entry sits after the intervening active fixed-size
+        // fields.
         let mut next_pos = pos + BYTES_PER_LENGTH_OFFSET;
         let mut end = bytes.len();
-        for &(next_is_fixed, next_len) in &fields[index + 1..] {
+        for (i, &(next_is_fixed, next_len)) in fields.iter().enumerate().skip(index + 1) {
+            if !active(i) {
+                continue;
+            }
             if next_is_fixed {
                 next_pos += next_len;
             } else {
@@ -367,7 +405,7 @@ pub fn read_field_bytes<'a>(
         if start > end || end > bytes.len() {
             return Err(DecodeError::OffsetsAreDecreasing(end));
         }
-        Ok(&bytes[start..end])
+        Ok(Some(&bytes[start..end]))
     }
 }
 
@@ -384,8 +422,37 @@ pub fn read_field_bytes<'a>(
 /// * `bytes` - The complete container bytes
 /// * `fields` - Per-field layout facts, in field order
 pub fn validate_container(bytes: &[u8], fields: &[FieldInfo]) -> Result<(), DecodeError> {
-    let fixed_portion_size: usize = fields.iter().map(|&(_, len)| len).sum();
-    let num_variable_fields = fields.iter().filter(|&&(is_fixed, _)| !is_fixed).count();
+    validate_active_container(bytes, fields, |_| true)
+}
+
+/// Validates a container body in which only *active* fields are serialized
+/// (EIP-7495 `StableContainer`/`Profile` semantics; see
+/// [`read_active_field_bytes`] for the layout).
+///
+/// Performs the same structural checks as [`validate_container`], computed
+/// over the active fields only.
+///
+/// # Arguments
+///
+/// * `bytes` - The container body after the bitvector
+/// * `fields` - Per-field layout facts for all declared fields, in field order
+/// * `active` - Presence predicate, typically backed by the bitvector
+pub fn validate_active_container(
+    bytes: &[u8],
+    fields: &[FieldInfo],
+    active: impl Fn(usize) -> bool,
+) -> Result<(), DecodeError> {
+    let fixed_portion_size: usize = fields
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| active(i))
+        .map(|(_, &(_, len))| len)
+        .sum();
+    let num_variable_fields = fields
+        .iter()
+        .enumerate()
+        .filter(|&(i, &(is_fixed, _))| active(i) && !is_fixed)
+        .count();
 
     if num_variable_fields == 0 {
         if bytes.len() != fixed_portion_size {
@@ -406,7 +473,10 @@ pub fn validate_container(bytes: &[u8], fields: &[FieldInfo]) -> Result<(), Deco
 
     let mut pos = 0usize;
     let mut prev_offset: Option<usize> = None;
-    for &(is_fixed, fixed_len) in fields {
+    for (i, &(is_fixed, fixed_len)) in fields.iter().enumerate() {
+        if !active(i) {
+            continue;
+        }
         if !is_fixed {
             let offset = read_offset_at(bytes, pos)?;
 
@@ -671,6 +741,97 @@ mod tests {
             0xBB, 0xCC,
         ];
         assert!(validate_container(&invalid, fields).is_err());
+    }
+
+    #[test]
+    fn read_active_field_bytes_inactive_field() {
+        // StableContainer body: [u8?][u16?] with field 1 inactive -> only the
+        // u8 is serialized.
+        let fields: &[FieldInfo] = &[(true, 1), (true, 2)];
+        let bytes = vec![0xAA];
+
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, |i| i == 0, 0).unwrap(),
+            Some(&[0xAA][..])
+        );
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, |i| i == 0, 1).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn read_active_field_bytes_positions_skip_inactive() {
+        // [u8?][u32?][u16?] with the u32 inactive: the u16 starts right after
+        // the u8 instead of at offset 5.
+        let fields: &[FieldInfo] = &[(true, 1), (true, 4), (true, 2)];
+        let bytes = vec![0xAA, 0xBB, 0xCC];
+        let active = |i: usize| i != 1;
+
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, active, 0).unwrap(),
+            Some(&[0xAA][..])
+        );
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, active, 2).unwrap(),
+            Some(&[0xBB, 0xCC][..])
+        );
+    }
+
+    #[test]
+    fn read_active_field_bytes_variable_skips_inactive_successors() {
+        // [list?][list?][list?] with field 1 inactive: field 0's end is field
+        // 2's offset, read from the second (not third) slot.
+        let fields: &[FieldInfo] = &[
+            (false, BYTES_PER_LENGTH_OFFSET),
+            (false, BYTES_PER_LENGTH_OFFSET),
+            (false, BYTES_PER_LENGTH_OFFSET),
+        ];
+        let active = |i: usize| i != 1;
+        let bytes = vec![
+            0x08, 0x00, 0x00, 0x00, // offset for field 0 = 8
+            0x0A, 0x00, 0x00, 0x00, // offset for field 2 = 10
+            0xAA, 0xBB, // field 0 contents
+            0xCC, // field 2 contents
+        ];
+
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, active, 0).unwrap(),
+            Some(&[0xAA, 0xBB][..])
+        );
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, active, 1).unwrap(),
+            None
+        );
+        assert_eq!(
+            read_active_field_bytes(&bytes, fields, active, 2).unwrap(),
+            Some(&[0xCC][..])
+        );
+    }
+
+    #[test]
+    fn validate_active_container_skips_inactive() {
+        // [u8?][list?][u32?] with the list inactive: all-fixed body of 5
+        // bytes, no offset table.
+        let fields: &[FieldInfo] = &[(true, 1), (false, BYTES_PER_LENGTH_OFFSET), (true, 4)];
+        let active = |i: usize| i != 1;
+
+        assert!(validate_active_container(&[0; 5], fields, active).is_ok());
+        assert!(validate_active_container(&[0; 4], fields, active).is_err());
+        assert!(validate_active_container(&[0; 6], fields, active).is_err());
+    }
+
+    #[test]
+    fn validate_active_container_checks_active_offsets() {
+        // [u8?][list?] with both active: offset entry at position 1 must
+        // point to the end of the 5-byte fixed portion.
+        let fields: &[FieldInfo] = &[(true, 1), (false, BYTES_PER_LENGTH_OFFSET)];
+
+        let valid = vec![0xAA, 0x05, 0x00, 0x00, 0x00, 0xBB];
+        assert!(validate_active_container(&valid, fields, |_| true).is_ok());
+
+        let invalid = vec![0xAA, 0x03, 0x00, 0x00, 0x00, 0xBB];
+        assert!(validate_active_container(&invalid, fields, |_| true).is_err());
     }
 
     #[test]

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1078,41 +1078,6 @@ impl ClassDef {
         }
     }
 
-    /// Computes the SSZ layout for this container.
-    ///
-    /// This determines field offsets and whether the container is fixed or variable-size.
-    ///
-    /// # Returns
-    ///
-    /// A tuple of:
-    /// - fixed_portion_size: size in bytes of the fixed portion
-    /// - fixed_size: `Some(size)` if all fields are fixed-size, `None` otherwise
-    /// - num_variable_fields: count of variable-length fields
-    fn compute_layout(&self) -> (usize, Option<usize>, usize) {
-        let mut fixed_offset = 0usize;
-        let mut num_variable_fields = 0usize;
-        let mut has_variable_fields = false;
-
-        for field in &self.fields {
-            if field.ty.is_fixed_size() {
-                fixed_offset += field.ty.fixed_size();
-            } else {
-                has_variable_fields = true;
-                num_variable_fields += 1;
-                // Variable-length fields add an offset pointer to the fixed portion
-                fixed_offset += 4; // BYTES_PER_LENGTH_OFFSET
-            }
-        }
-
-        let fixed_size = if has_variable_fields {
-            None
-        } else {
-            Some(fixed_offset)
-        };
-
-        (fixed_offset, fixed_size, num_variable_fields)
-    }
-
     /// Sums a list of `usize` expressions, or `0usize` when empty.
     fn sum_expr(terms: &[TokenStream]) -> TokenStream {
         if terms.is_empty() {
@@ -1178,62 +1143,94 @@ impl ClassDef {
         }
     }
 
-    /// Generates field layout information for a given field index.
-    ///
-    /// Only used for StableContainer/Profile views; plain containers use
-    /// [`Self::field_bytes_expr`].
-    ///
-    /// FIXME: this path still computes the layout at codegen time and reads
-    /// variable offsets via the end-packed [`ssz::layout::read_variable_offset`],
-    /// which is correct for all-`Optional` StableContainers (every field is
-    /// variable) but wrong for Profiles mixing required fixed-size fields
-    /// after variable-size ones; it also ignores `#[ssz(with = ...)]`
-    /// overrides. Migrating it to the per-field layout table used by plain
-    /// containers would fix both.
-    ///
-    /// Returns (offset_expr, is_fixed, size_expr) where:
-    /// - offset_expr: TokenStream to compute the field's byte offset
-    /// - is_fixed: whether the field is at a fixed offset
-    /// - size_expr: TokenStream to compute the field's size (or None for variable fields)
-    fn generate_field_layout(
-        &self,
-        field_index: usize,
-    ) -> (TokenStream, bool, Option<TokenStream>) {
-        let field = &self.fields[field_index];
+    /// Number of `Optional`-typed fields.
+    fn optional_field_count(&self) -> usize {
+        self.fields
+            .iter()
+            .filter(|f| matches!(f.ty.resolution, TypeResolutionKind::Optional(_)))
+            .count()
+    }
 
-        // Calculate the offset based on preceding fields
-        let mut offset = 0usize;
-        let mut variable_index = 0usize;
-
-        for (i, f) in self.fields.iter().enumerate() {
-            if i == field_index {
-                break;
-            }
-            if f.ty.is_fixed_size() {
-                offset += f.ty.fixed_size();
-            } else {
-                variable_index += 1;
-                offset += 4; // BYTES_PER_LENGTH_OFFSET
-            }
+    /// Byte length of the leading active-fields bitvector in the
+    /// StableContainer/Profile encoding.
+    ///
+    /// A StableContainer always serializes a `BitVector[max_fields]`; a
+    /// Profile serializes a `BitVector[optional_count]` only when it has
+    /// optional fields.
+    fn active_bitvector_length(&self) -> usize {
+        match self.base {
+            BaseClass::StableContainer(Some(max_fields)) => (max_fields as usize).div_ceil(8),
+            BaseClass::Profile(Some(_)) => self.optional_field_count().div_ceil(8),
+            _ => 0,
         }
+    }
 
-        if field.ty.is_fixed_size() {
-            let size = field.ty.fixed_size();
-            (quote! { #offset }, true, Some(quote! { #size }))
+    /// Tokens binding `body`, `field_active`, and `field_layout` for a
+    /// StableContainer/Profile view, reading from the `&[u8]` expression
+    /// `source`.
+    ///
+    /// The encoding serializes only the *active* fields after the leading
+    /// bitvector (EIP-7495): a StableContainer field is active when its bit
+    /// is set, a Profile field when it is required or its optional bit is
+    /// set. Layout facts come from the fields' owned encoding (their
+    /// `ssz::Encode` impls, or the `#[ssz(with = ...)]` module when
+    /// overridden), so views agree with `ssz_derive` by construction.
+    fn active_layout_preamble(&self, source: TokenStream) -> TokenStream {
+        let bitvector_length = self.active_bitvector_length();
+
+        let bitvector_bits = match self.base {
+            BaseClass::StableContainer(Some(max_fields)) => max_fields as usize,
+            BaseClass::Profile(Some(_)) => self.optional_field_count(),
+            _ => panic!("active layout only applies to StableContainer/Profile"),
+        };
+
+        let mut optional_index = 0usize;
+        let active_exprs: Vec<TokenStream> = self
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(idx, field)| {
+                let is_optional = matches!(field.ty.resolution, TypeResolutionKind::Optional(_));
+                if !is_optional {
+                    return quote! { true };
+                }
+                let bit = match self.base {
+                    // StableContainer bits cover every declared field.
+                    BaseClass::StableContainer(_) => idx,
+                    // Profile bits cover only the optional fields, in order.
+                    _ => optional_index,
+                };
+                optional_index += 1;
+                quote! { bitvector.get(#bit).unwrap_or(false) }
+            })
+            .collect();
+
+        let table = self.field_layout_table_expr();
+
+        let parse_bitvector = if bitvector_length == 0 {
+            quote! {
+                let body = #source;
+            }
         } else {
-            let (fixed_portion_size, _, num_variable_fields) = self.compute_layout();
-            (
-                quote! {
-                    ssz::layout::read_variable_offset(
-                        self.bytes,
-                        #fixed_portion_size,
-                        #num_variable_fields,
-                        #variable_index
-                    )?
-                },
-                false,
-                None,
-            )
+            quote! {
+                use ssz::Decode;
+                let bitvector_bytes = #source
+                    .get(..#bitvector_length)
+                    .ok_or(ssz::DecodeError::InvalidByteLength {
+                        len: #source.len(),
+                        expected: #bitvector_length,
+                    })?;
+                let bitvector = ssz_types::BitVector::<#bitvector_bits>::from_ssz_bytes(
+                    bitvector_bytes
+                )?;
+                let body = &#source[#bitvector_length..];
+            }
+        };
+
+        quote! {
+            #parse_bitvector
+            let field_active: &[bool] = &[ #(#active_exprs),* ];
+            let field_layout: &[ssz::layout::FieldInfo] = #table;
         }
     }
 
@@ -1556,9 +1553,7 @@ impl ClassDef {
                             use ssz_types::BitVector;
 
                             #(
-                                {
-                                    let #field_names = self.#field_names().expect("valid view");
-                                }
+                                let #field_names = self.#field_names().expect("valid view");
                             )*
                             let mut active_fields = BitVector::<#max>::new();
                             #(
@@ -1779,6 +1774,117 @@ impl ClassDef {
         }
     }
 
+    /// Union-with-null selector decode for an `Option` value in `bytes_expr`.
+    fn option_selector_decode(inner_view_ty: &Type, bytes_expr: TokenStream) -> TokenStream {
+        quote! {
+            {
+                let bytes = #bytes_expr;
+                if bytes.is_empty() {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: 0,
+                        expected: 1,
+                    });
+                }
+                let selector = bytes[0];
+                match selector {
+                    0 => Ok(None),
+                    1 => {
+                        let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
+                        Ok(Some(inner))
+                    }
+                    _ => Err(ssz::DecodeError::BytesInvalid(
+                        format!("Invalid union selector for Option: {}", selector)
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Generates a single view getter for a StableContainer/Profile field.
+    ///
+    /// The field slice is obtained via
+    /// [`ssz::layout::read_active_field_bytes`] with the active set read from
+    /// the leading bitvector and the layout facts derived from the fields'
+    /// owned encoding (see [`Self::active_layout_preamble`]), so the accessor
+    /// agrees with the owned `ssz_derive` encoding by construction. An
+    /// inactive `Optional` field decodes to `Optional::None` without touching
+    /// the body.
+    fn stable_view_getter(&self, idx: usize, field: &ClassFieldDef) -> TokenStream {
+        let field_name = Ident::new(&field.name, Span::call_site());
+        let preamble = self.active_layout_preamble(quote! { self.bytes });
+        let read_field = quote! {
+            ssz::layout::read_active_field_bytes(body, field_layout, |i| field_active[i], #idx)?
+        };
+
+        // `#[ssz(with = ...)]` fields have a module-defined encoding with no
+        // view-side counterpart, so their getter decodes the slice to the
+        // owned field type through `module::decode`, mirroring the
+        // `ssz_derive` `Decode` impl.
+        if let Some(module) = field.ssz_with_module() {
+            let owned_ty = field.ty.unwrap_type();
+            let absent = if matches!(field.ty.resolution, TypeResolutionKind::Optional(_)) {
+                quote! { return Ok(ssz_types::Optional::None) }
+            } else {
+                quote! { unreachable!("required field is always active") }
+            };
+            return quote! {
+                pub fn #field_name(&self) -> Result<#owned_ty, ssz::DecodeError> {
+                    #preamble
+                    let field_bytes = match #read_field {
+                        Some(bytes) => bytes,
+                        None => #absent,
+                    };
+                    #module::decode::from_ssz_bytes(field_bytes)
+                }
+            };
+        }
+
+        let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);
+
+        match &field.ty.resolution {
+            TypeResolutionKind::Optional(inner_ty) => {
+                let inner_view_ty = inner_ty.to_view_type_with_pragmas(&field.pragmas);
+                quote! {
+                    pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
+                        #preamble
+                        let field_bytes = match #read_field {
+                            Some(bytes) => bytes,
+                            None => return Ok(ssz_types::Optional::None),
+                        };
+                        let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                        Ok(ssz_types::Optional::Some(inner))
+                    }
+                }
+            }
+            // Option (from Union[null, T]): encoded as a union with a
+            // selector byte.
+            TypeResolutionKind::Option(inner_ty) => {
+                let inner_view_ty = inner_ty.to_view_type_with_pragmas(&field.pragmas);
+                let decode = Self::option_selector_decode(&inner_view_ty, quote! { field_bytes });
+                quote! {
+                    pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
+                        #preamble
+                        let field_bytes = match #read_field {
+                            Some(bytes) => bytes,
+                            None => unreachable!("required field is always active"),
+                        };
+                        #decode
+                    }
+                }
+            }
+            _ => quote! {
+                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
+                    #preamble
+                    let field_bytes = match #read_field {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
+                }
+            },
+        }
+    }
+
     /// Generates getter methods for view struct fields.
     ///
     /// Each field gets a method that computes its position and decodes on-demand.
@@ -1813,300 +1919,14 @@ impl ClassDef {
             };
         }
 
-        let (fixed_portion_size, _, num_variable_fields) = self.compute_layout();
-
-        // Check if we need to account for bitvector (StableContainer/Profile with Optional fields)
-        let optional_count = self
-            .fields
-            .iter()
-            .filter(|f| matches!(f.ty.resolution, TypeResolutionKind::Optional(_)))
-            .count();
-
-        let bitvector_offset = match self.base {
-            BaseClass::StableContainer(Some(max_fields))
-            | BaseClass::Profile(Some((_, max_fields)))
-                if optional_count > 0 =>
-            {
-                (max_fields as usize).div_ceil(8)
-            }
-            _ => 0,
-        };
-
+        // StableContainer/Profile: only active fields are serialized after
+        // the leading bitvector, so getters derive the layout at runtime from
+        // the bitvector plus the fields' owned encoding.
         let getters: Vec<TokenStream> = self
             .fields
             .iter()
             .enumerate()
-            .map(|(idx, field)| {
-                let field_name = Ident::new(&field.name, Span::call_site());
-                let view_ty = field.ty.to_view_type_with_pragmas(&field.pragmas);
-                let (offset_expr, is_fixed, size_expr) = self.generate_field_layout(idx);
-
-                // Special handling for Option types (from Union[null, T])
-                // These are encoded as unions with a selector byte
-                if matches!(field.ty.resolution, TypeResolutionKind::Option(_)) {
-                    let inner_ty = match &field.ty.resolution {
-                        TypeResolutionKind::Option(inner) => inner,
-                        _ => unreachable!(),
-                    };
-                    let inner_view_ty = inner_ty.to_view_type_with_pragmas(&field.pragmas);
-
-                    if is_fixed {
-                        let size = size_expr.unwrap();
-                        if bitvector_offset > 0 {
-                            quote! {
-                                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                    let bitvector_offset = #bitvector_offset;
-                                    let offset = bitvector_offset + #offset_expr;
-                                    let end = offset + #size;
-                                    if end > self.bytes.len() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: self.bytes.len(),
-                                            expected: end,
-                                        });
-                                    }
-                                    let bytes = &self.bytes[offset..end];
-                                    if bytes.is_empty() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: 0,
-                                            expected: 1,
-                                        });
-                                    }
-                                    let selector = bytes[0];
-                                    match selector {
-                                        0 => Ok(None),
-                                        1 => {
-                                            let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
-                                            Ok(Some(inner))
-                                        }
-                                        _ => Err(ssz::DecodeError::BytesInvalid(
-                                            format!("Invalid union selector for Option: {}", selector)
-                                        ))
-                                    }
-                                }
-                            }
-                        } else {
-                            quote! {
-                                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                    let offset = #offset_expr;
-                                    let end = offset + #size;
-                                    if end > self.bytes.len() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: self.bytes.len(),
-                                            expected: end,
-                                        });
-                                    }
-                                    let bytes = &self.bytes[offset..end];
-                                    if bytes.is_empty() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: 0,
-                                            expected: 1,
-                                        });
-                                    }
-                                    let selector = bytes[0];
-                                    match selector {
-                                        0 => Ok(None),
-                                        1 => {
-                                            let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
-                                            Ok(Some(inner))
-                                        }
-                                        _ => Err(ssz::DecodeError::BytesInvalid(
-                                            format!("Invalid union selector for Option: {}", selector)
-                                        ))
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        // Variable-length Option field
-                        let mut variable_index = 0usize;
-                        for (i, f) in self.fields.iter().enumerate() {
-                            if i == idx {
-                                break;
-                            }
-                            if !f.ty.is_fixed_size() {
-                                variable_index += 1;
-                            }
-                        }
-                        let next_variable_index = variable_index + 1;
-
-                        if bitvector_offset > 0 {
-                            quote! {
-                                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                    let bitvector_offset = #bitvector_offset;
-                                    let container_bytes = &self.bytes[bitvector_offset..];
-                                    let start = ssz::layout::read_variable_offset(
-                                        container_bytes,
-                                        #fixed_portion_size,
-                                        #num_variable_fields,
-                                        #variable_index
-                                    )?;
-                                    let end = ssz::layout::read_variable_offset_or_end(
-                                        container_bytes,
-                                        #fixed_portion_size,
-                                        #num_variable_fields,
-                                        #next_variable_index
-                                    )?;
-                                    if start > end || end > container_bytes.len() {
-                                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                                    }
-                                    let bytes = &container_bytes[start..end];
-                                    if bytes.is_empty() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: 0,
-                                            expected: 1,
-                                        });
-                                    }
-                                    let selector = bytes[0];
-                                    match selector {
-                                        0 => Ok(None),
-                                        1 => {
-                                            let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
-                                            Ok(Some(inner))
-                                        }
-                                        _ => Err(ssz::DecodeError::BytesInvalid(
-                                            format!("Invalid union selector for Option: {}", selector)
-                                        ))
-                                    }
-                                }
-                            }
-                        } else {
-                            quote! {
-                                pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                    let start = ssz::layout::read_variable_offset(
-                                        self.bytes,
-                                        #fixed_portion_size,
-                                        #num_variable_fields,
-                                        #variable_index
-                                    )?;
-                                    let end = ssz::layout::read_variable_offset_or_end(
-                                        self.bytes,
-                                        #fixed_portion_size,
-                                        #num_variable_fields,
-                                        #next_variable_index
-                                    )?;
-                                    if start > end || end > self.bytes.len() {
-                                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                                    }
-                                    let bytes = &self.bytes[start..end];
-                                    if bytes.is_empty() {
-                                        return Err(ssz::DecodeError::InvalidByteLength {
-                                            len: 0,
-                                            expected: 1,
-                                        });
-                                    }
-                                    let selector = bytes[0];
-                                    match selector {
-                                        0 => Ok(None),
-                                        1 => {
-                                            let inner = <#inner_view_ty as ssz::view::DecodeView>::from_ssz_bytes(&bytes[1..])?;
-                                            Ok(Some(inner))
-                                        }
-                                        _ => Err(ssz::DecodeError::BytesInvalid(
-                                            format!("Invalid union selector for Option: {}", selector)
-                                        ))
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else if is_fixed {
-                    let size = size_expr.unwrap();
-                    if bitvector_offset > 0 {
-                        // Account for bitvector at start
-                        quote! {
-                            pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                let bitvector_offset = #bitvector_offset;
-                                let offset = bitvector_offset + #offset_expr;
-                                let end = offset + #size;
-                                if end > self.bytes.len() {
-                                    return Err(ssz::DecodeError::InvalidByteLength {
-                                        len: self.bytes.len(),
-                                        expected: end,
-                                    });
-                                }
-                                let bytes = &self.bytes[offset..end];
-                                ssz::view::DecodeView::from_ssz_bytes(bytes)
-                            }
-                        }
-                    } else {
-                        quote! {
-                            pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                let offset = #offset_expr;
-                                let end = offset + #size;
-                                if end > self.bytes.len() {
-                                    return Err(ssz::DecodeError::InvalidByteLength {
-                                        len: self.bytes.len(),
-                                        expected: end,
-                                    });
-                                }
-                                let bytes = &self.bytes[offset..end];
-                                ssz::view::DecodeView::from_ssz_bytes(bytes)
-                            }
-                        }
-                    }
-                } else {
-                    // Variable-length field
-                    let mut variable_index = 0usize;
-                    for (i, f) in self.fields.iter().enumerate() {
-                        if i == idx {
-                            break;
-                        }
-                        if !f.ty.is_fixed_size() {
-                            variable_index += 1;
-                        }
-                    }
-                    let next_variable_index = variable_index + 1;
-
-                    if bitvector_offset > 0 {
-                        // Account for bitvector at start
-                        quote! {
-                            pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                let bitvector_offset = #bitvector_offset;
-                                let container_bytes = &self.bytes[bitvector_offset..];
-                                let start = ssz::layout::read_variable_offset(
-                                    container_bytes,
-                                    #fixed_portion_size,
-                                    #num_variable_fields,
-                                    #variable_index
-                                )?;
-                                let end = ssz::layout::read_variable_offset_or_end(
-                                    container_bytes,
-                                    #fixed_portion_size,
-                                    #num_variable_fields,
-                                    #next_variable_index
-                                )?;
-                                if start > end || end > container_bytes.len() {
-                                    return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                                }
-                                let bytes = &container_bytes[start..end];
-                                ssz::view::DecodeView::from_ssz_bytes(bytes)
-                            }
-                        }
-                    } else {
-                        quote! {
-                            pub fn #field_name(&self) -> Result<#view_ty, ssz::DecodeError> {
-                                let start = ssz::layout::read_variable_offset(
-                                    self.bytes,
-                                    #fixed_portion_size,
-                                    #num_variable_fields,
-                                    #variable_index
-                                )?;
-                                let end = ssz::layout::read_variable_offset_or_end(
-                                    self.bytes,
-                                    #fixed_portion_size,
-                                    #num_variable_fields,
-                                    #next_variable_index
-                                )?;
-                                if start > end || end > self.bytes.len() {
-                                    return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                                }
-                                let bytes = &self.bytes[start..end];
-                                ssz::view::DecodeView::from_ssz_bytes(bytes)
-                            }
-                        }
-                    }
-                }
-            })
+            .map(|(idx, field)| self.stable_view_getter(idx, field))
             .collect();
 
         quote! {
@@ -2149,108 +1969,37 @@ impl ClassDef {
             }
             BaseClass::StableContainer(Some(max_fields))
             | BaseClass::Profile(Some((_, max_fields))) => {
-                let max_fields_usize = max_fields as usize;
+                let preamble = self.active_layout_preamble(quote! { bytes });
 
-                // Count Optional fields for bitvector
-                let optional_count = self
-                    .fields
-                    .iter()
-                    .filter(|f| matches!(f.ty.resolution, TypeResolutionKind::Optional(_)))
-                    .count();
-
-                let bitvector_length = if optional_count == 0 {
-                    0
-                } else {
-                    max_fields_usize.div_ceil(8)
-                };
-
-                // Generate validation for StableContainer/Profile
-                let validation = if bitvector_length == 0 {
-                    // No Optional fields - validate like a regular container
-                    let (fixed_portion_size, fixed_size, num_variable_fields) =
-                        self.compute_layout();
-
-                    if let Some(expected_size) = fixed_size {
-                        quote! {
-                            if bytes.len() != #expected_size {
-                                return Err(ssz::DecodeError::InvalidByteLength {
-                                    len: bytes.len(),
-                                    expected: #expected_size,
-                                });
-                            }
-                        }
-                    } else {
-                        quote! {
-                            if bytes.len() < #fixed_portion_size {
-                                return Err(ssz::DecodeError::InvalidByteLength {
-                                    len: bytes.len(),
-                                    expected: #fixed_portion_size,
-                                });
-                            }
-
-                            // Validate offset table
-                            let mut prev_offset: Option<usize> = None;
-                            for i in 0..#num_variable_fields {
-                                let offset = ssz::layout::read_variable_offset(
-                                    bytes,
-                                    #fixed_portion_size,
-                                    #num_variable_fields,
-                                    i
-                                )?;
-
-                                if i == 0 && offset != #fixed_portion_size {
-                                    return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                                }
-
-                                if let Some(prev) = prev_offset && offset < prev {
-                                    return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                                }
-
-                                if offset > bytes.len() {
-                                    return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                                }
-
-                                prev_offset = Some(offset);
-                            }
-                        }
-                    }
-                } else {
-                    // Has Optional fields - parse bitvector and validate
+                // Mirror the owned decode: a StableContainer rejects active
+                // bits set beyond its declared field count.
+                let extra_bits_check = if self.base.is_stable_container() {
+                    let max_fields_usize = max_fields as usize;
+                    let num_fields = self.fields.len();
                     quote! {
-                        // Import Decode trait for BitVector::from_ssz_bytes
-                        use ssz::Decode;
-
-                        // Parse bitvector
-                        let bitvector_length = #bitvector_length;
-                        if bytes.len() < bitvector_length {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: bitvector_length,
-                            });
-                        }
-
-                        // Validate bitvector structure (don't need to store it)
-                        let _bitvector = ssz_types::BitVector::<#max_fields_usize>::from_ssz_bytes(
-                            &bytes[0..bitvector_length]
-                        )?;
-
-                        // Validate the container portion after the bitvector
-                        // Note: More specific offset table validation based on active fields
-                        // could be added here as a future optimization, but current validation
-                        // is sufficient - getters will validate offsets when fields are accessed.
-                        if bytes.len() < bitvector_length {
-                            return Err(ssz::DecodeError::InvalidByteLength {
-                                len: bytes.len(),
-                                expected: bitvector_length,
-                            });
+                        for index in #num_fields..#max_fields_usize {
+                            if bitvector.get(index).unwrap_or(false) {
+                                return Err(ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ));
+                            }
                         }
                     }
+                } else {
+                    quote! {}
                 };
 
                 quote! {
                     impl<'a> ssz::view::DecodeView<'a> for #ref_ident<'a> {
                         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                            #validation
+                            #preamble
+                            #extra_bits_check
+                            ssz::layout::validate_active_container(
+                                body,
+                                field_layout,
+                                |i| field_active[i],
+                            )?;
                             Ok(Self { bytes })
                         }
                     }
@@ -2303,35 +2052,40 @@ impl ClassDef {
             };
         }
 
-        let (_, fixed_size, _) = self.compute_layout();
+        // A StableContainer is always variable-size (EIP-7495), as is a
+        // Profile with optional fields (the presence bitvector makes the
+        // length depend on runtime values). A Profile without optional
+        // fields derives fixedness from the fields' owned encoding, like a
+        // plain container.
+        if self.base.is_profile() && self.optional_field_count() == 0 {
+            let fixed_portion_expr = self.fixed_portion_size_expr();
+            let num_variable_expr = self.num_variable_fields_expr();
 
-        match fixed_size {
-            Some(size) => {
-                // Fixed-size container
-                quote! {
-                    impl<'a> ssz::view::SszTypeInfo for #ref_ident<'a> {
-                        fn is_ssz_fixed_len() -> bool {
-                            true
-                        }
-
-                        fn ssz_fixed_len() -> usize {
-                            #size
-                        }
+            return quote! {
+                impl<'a> ssz::view::SszTypeInfo for #ref_ident<'a> {
+                    fn is_ssz_fixed_len() -> bool {
+                        #num_variable_expr == 0
                     }
-                }
-            }
-            None => {
-                // Variable-size container
-                quote! {
-                    impl<'a> ssz::view::SszTypeInfo for #ref_ident<'a> {
-                        fn is_ssz_fixed_len() -> bool {
-                            false
-                        }
 
-                        fn ssz_fixed_len() -> usize {
+                    fn ssz_fixed_len() -> usize {
+                        if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                            #fixed_portion_expr
+                        } else {
                             0
                         }
                     }
+                }
+            };
+        }
+
+        quote! {
+            impl<'a> ssz::view::SszTypeInfo for #ref_ident<'a> {
+                fn is_ssz_fixed_len() -> bool {
+                    false
+                }
+
+                fn ssz_fixed_len() -> usize {
+                    0
                 }
             }
         }
@@ -2393,9 +2147,9 @@ impl ClassDef {
                 let field_name = Ident::new(&field.name, Span::call_site());
                 let is_optional = matches!(field.ty.resolution, TypeResolutionKind::Optional(_));
 
-                // Plain-container `#[ssz(with = ...)]` getters already decode
-                // to the owned field type, so no view conversion is needed.
-                if !is_stable_container && field.ssz_with_module().is_some() {
+                // `#[ssz(with = ...)]` getters already decode to the owned
+                // field type, so no view conversion is needed.
+                if field.ssz_with_module().is_some() {
                     return quote! {
                         #field_name: self.#field_name().expect("valid view")
                     };

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1972,10 +1972,13 @@ impl ClassDef {
                 let preamble = self.active_layout_preamble(quote! { bytes });
 
                 // Mirror the owned decode: a StableContainer rejects active
-                // bits set beyond its declared field count.
-                let extra_bits_check = if self.base.is_stable_container() {
-                    let max_fields_usize = max_fields as usize;
-                    let num_fields = self.fields.len();
+                // bits set beyond its declared field count. Skipped when the
+                // declared fields fill every slot (the range would be empty).
+                let max_fields_usize = max_fields as usize;
+                let num_fields = self.fields.len();
+                let extra_bits_check = if self.base.is_stable_container()
+                    && num_fields < max_fields_usize
+                {
                     quote! {
                         for index in #num_fields..#max_fields_usize {
                             if bitvector.get(index).unwrap_or(false) {

--- a/crates/ssz_codegen/tests/bitvector_length_test.rs
+++ b/crates/ssz_codegen/tests/bitvector_length_test.rs
@@ -20,7 +20,11 @@ fn test_view_bitvector_length_uses_max_fields() {
         fs::read_to_string("tests/output/test_bitvector_len.rs").expect("Failed to read output");
 
     assert!(
-        actual_output.contains("let bitvector_length = 2usize;"),
-        "Expected bitvector_length to use max_fields (9 -> 2 bytes)"
+        actual_output.contains(".get(..2usize)"),
+        "Expected bitvector length to use max_fields (9 -> 2 bytes)"
+    );
+    assert!(
+        actual_output.contains("&self.bytes[2usize..]"),
+        "Expected container body to start after the max_fields bitvector"
     );
 }

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1644,48 +1644,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1741,22 +1791,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2083,90 +2160,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2246,22 +2461,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2387,48 +2639,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2484,22 +2790,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3549,134 +3884,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3780,22 +4407,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4167,46 +4845,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4262,22 +4980,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -1644,48 +1644,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1741,22 +1791,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2083,90 +2160,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2246,22 +2461,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2387,48 +2639,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2484,22 +2790,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3549,134 +3884,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3780,22 +4407,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4167,46 +4845,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4262,22 +4980,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -91,48 +91,93 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(
                     &self,
                 ) -> Result<Optional<BitListRef<'a, 32usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitListRef<
+                        'a,
+                        32usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
@@ -188,22 +233,47 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..2usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -349,92 +419,246 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
                         4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
                         16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerBaseRef<'a> {
@@ -514,22 +738,63 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerBaseRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..8usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -685,84 +950,243 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
-                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        4usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
-                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile1Ref<'a> {
@@ -778,18 +1202,10 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -844,22 +1260,53 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile1Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -998,59 +1445,145 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        10usize,
-                        2usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        10usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(&self) -> Result<BytesRef<'a, 4usize>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        10usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        10usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 8usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile2Ref<'a> {
@@ -1066,15 +1599,9 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     if x.is_some() {
                         active_fields
@@ -1112,22 +1639,43 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile2Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1241,40 +1789,90 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn b(
                     &self,
                 ) -> Result<Optional<BitListRef<'a, 32usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        5usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitListRef<
+                        'a,
+                        32usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for AlphaProfileRef<'a> {
@@ -1290,12 +1888,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let a = self.a().expect("valid view");
-                    }
-                    {
-                        let b = self.b().expect("valid view");
-                    }
+                    let a = self.a().expect("valid view");
+                    let b = self.b().expect("valid view");
                     let mut active_fields = BitVector::<2usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -1328,22 +1922,37 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for AlphaProfileRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        2usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1447,23 +2056,24 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
                 pub fn w(&self) -> Result<AlphaProfileRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        4usize,
-                        1usize,
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile3Ref<'a> {
@@ -1479,9 +2089,7 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(3usize, true)
@@ -1502,40 +2110,32 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile3Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile3Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AlphaProfile as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AlphaProfile as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1632,35 +2232,58 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
                 pub fn y(&self) -> Result<BytesRef<'a, 4usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        6usize,
-                        1usize,
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        6usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile4Ref<'a> {
@@ -1676,12 +2299,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(1usize, true)
@@ -1707,40 +2326,45 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile4Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 6usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 6usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            6usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 6usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile4Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<u8, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<16usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1844,47 +2468,88 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn w(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile5Ref<'a> {
@@ -1900,15 +2565,9 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let z = self.z().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -1939,40 +2598,45 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile5Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile5Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<16usize> as ssz::Encode>::ssz_fixed_len()
+                            + <Alpha as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2077,46 +2741,83 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<AlphaProfileRef<'a>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for ProfileProfileRef<'a> {
@@ -2132,12 +2833,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     if x.is_some() {
                         active_fields
@@ -2170,22 +2867,35 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ProfileProfileRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2376,176 +3086,642 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {
                 pub fn x(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        4usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn c(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         6usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        7usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn d(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         7usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        8usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ContainerContainerRef<'a> {
@@ -2673,22 +3849,83 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ContainerContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 8usize..8usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -259,16 +259,6 @@ pub mod tests {
                             <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
                         ),
                     ];
-                    for index in 2usize..2usize {
-                        if bitvector.get(index).unwrap_or(false) {
-                            return Err(
-                                ssz::DecodeError::BytesInvalid(
-                                    "StableContainer has active_fields bits set beyond field count"
-                                        .to_string(),
-                                ),
-                            );
-                        }
-                    }
                     ssz::layout::validate_active_container(
                         body,
                         field_layout,
@@ -3911,16 +3901,6 @@ pub mod tests {
                             <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
                         ),
                     ];
-                    for index in 8usize..8usize {
-                        if bitvector.get(index).unwrap_or(false) {
-                            return Err(
-                                ssz::DecodeError::BytesInvalid(
-                                    "StableContainer has active_fields bits set beyond field count"
-                                        .to_string(),
-                                ),
-                            );
-                        }
-                    }
                     ssz::layout::validate_active_container(
                         body,
                         field_layout,

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -91,48 +91,93 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(
                     &self,
                 ) -> Result<Optional<BitListRef<'a, 32usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitListRef<
+                        'a,
+                        32usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
@@ -188,22 +233,47 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for AlphaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         2usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..2usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -349,92 +419,246 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
                         4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
                         16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerBaseRef<'a> {
@@ -514,22 +738,63 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerBaseRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..8usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -685,84 +950,243 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
-                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        4usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
-                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        13usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         3usize,
-                        2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        13usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile1Ref<'a> {
@@ -778,18 +1202,10 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -844,22 +1260,53 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile1Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        3usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -998,59 +1445,145 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        10usize,
-                        2usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        10usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(&self) -> Result<BytesRef<'a, 4usize>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        10usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        10usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 8usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile2Ref<'a> {
@@ -1066,15 +1599,9 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     if x.is_some() {
                         active_fields
@@ -1112,22 +1639,43 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile2Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1241,40 +1789,90 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn b(
                     &self,
                 ) -> Result<Optional<BitListRef<'a, 32usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        5usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitListRef<
+                        'a,
+                        32usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for AlphaProfileRef<'a> {
@@ -1290,12 +1888,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let a = self.a().expect("valid view");
-                    }
-                    {
-                        let b = self.b().expect("valid view");
-                    }
+                    let a = self.a().expect("valid view");
+                    let b = self.b().expect("valid view");
                     let mut active_fields = BitVector::<2usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -1328,22 +1922,37 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for AlphaProfileRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        2usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitList<32usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -1447,23 +2056,24 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
                 pub fn w(&self) -> Result<AlphaProfileRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        4usize,
-                        1usize,
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile3Ref<'a> {
@@ -1479,9 +2089,7 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(3usize, true)
@@ -1502,40 +2110,32 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile3Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 4usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 4usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            4usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 4usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile3Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<AlphaProfile as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <AlphaProfile as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1632,35 +2232,58 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
                 pub fn y(&self) -> Result<BytesRef<'a, 4usize>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        6usize,
-                        1usize,
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        6usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let offset = 4usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile4Ref<'a> {
@@ -1676,12 +2299,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let y = self.y().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
+                    let y = self.y().expect("valid view");
+                    let z = self.z().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(1usize, true)
@@ -1707,40 +2326,45 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile4Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 6usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 6usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            6usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 6usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <VariableList<
+                                u8,
+                                4usize,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile4Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(
+                        !<VariableList<u8, 4usize> as ssz::Encode>::is_ssz_fixed_len(),
+                    )
+                        + usize::from(
+                            !<BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <VariableList<u8, 4usize> as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<16usize> as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -1844,47 +2468,88 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
                 pub fn x(&self) -> Result<u8, ssz::DecodeError> {
-                    let offset = 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn z(&self) -> Result<BitVectorRef<'a, 16usize>, ssz::DecodeError> {
-                    let offset = 1usize;
-                    let end = offset + 2usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn w(&self) -> Result<AlphaRef<'a>, ssz::DecodeError> {
-                    let start = ssz::layout::read_variable_offset(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        self.bytes,
-                        7usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > self.bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &self.bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    let body = self.bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for InnerProfile5Ref<'a> {
@@ -1900,15 +2565,9 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let z = self.z().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let z = self.z().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -1939,40 +2598,45 @@ pub mod tests {
             }
             impl<'a> ssz::view::DecodeView<'a> for InnerProfile5Ref<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
-                    if bytes.len() < 7usize {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: 7usize,
-                        });
-                    }
-                    let mut prev_offset: Option<usize> = None;
-                    for i in 0..1usize {
-                        let offset = ssz::layout::read_variable_offset(
-                            bytes,
-                            7usize,
-                            1usize,
-                            i,
-                        )?;
-                        if i == 0 && offset != 7usize {
-                            return Err(ssz::DecodeError::OffsetIntoFixedPortion(offset));
-                        }
-                        if let Some(prev) = prev_offset && offset < prev {
-                            return Err(ssz::DecodeError::OffsetsAreDecreasing(offset));
-                        }
-                        if offset > bytes.len() {
-                            return Err(ssz::DecodeError::OffsetOutOfBounds(offset));
-                        }
-                        prev_offset = Some(offset);
-                    }
+                    let body = bytes;
+                    let field_active: &[bool] = &[true, true, true];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                            <BitVector<16usize> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Alpha as ssz::Encode>::is_ssz_fixed_len(),
+                            <Alpha as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
             impl<'a> ssz::view::SszTypeInfo for InnerProfile5Ref<'a> {
                 fn is_ssz_fixed_len() -> bool {
-                    false
+                    usize::from(!<u8 as ssz::Encode>::is_ssz_fixed_len())
+                        + usize::from(
+                            !<BitVector<16usize> as ssz::Encode>::is_ssz_fixed_len(),
+                        ) + usize::from(!<Alpha as ssz::Encode>::is_ssz_fixed_len()) == 0
                 }
                 fn ssz_fixed_len() -> usize {
-                    0
+                    if <Self as ssz::view::SszTypeInfo>::is_ssz_fixed_len() {
+                        <u8 as ssz::Encode>::ssz_fixed_len()
+                            + <BitVector<16usize> as ssz::Encode>::ssz_fixed_len()
+                            + <Alpha as ssz::Encode>::ssz_fixed_len()
+                    } else {
+                        0
+                    }
                 }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -2077,46 +2741,83 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<AlphaProfileRef<'a>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
             }
             impl<'a> tree_hash::TreeHash for ProfileProfileRef<'a> {
@@ -2132,12 +2833,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let x = self.x().expect("valid view");
-                    }
-                    {
-                        let w = self.w().expect("valid view");
-                    }
+                    let x = self.x().expect("valid view");
+                    let w = self.w().expect("valid view");
                     let mut active_fields = BitVector::<8usize>::new();
                     if x.is_some() {
                         active_fields
@@ -2170,22 +2867,35 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ProfileProfileRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        true,
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <AlphaProfile as ssz::Encode>::is_ssz_fixed_len(),
+                            <AlphaProfile as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2376,176 +3086,642 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {
                 pub fn x(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn y(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 4usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        4usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn z(
                     &self,
                 ) -> Result<Optional<BitVectorRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BitVectorRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn w(&self) -> Result<Optional<AlphaRef<'a>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <AlphaRef<
+                        'a,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn c(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         6usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        7usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn d(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        32usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         7usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        32usize,
-                        8usize,
-                        8usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ContainerContainerRef<'a> {
@@ -2673,22 +3849,83 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ContainerContainerRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         8usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                        bitvector.get(6usize).unwrap_or(false),
+                        bitvector.get(7usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<u8, 4usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                BitVector<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Alpha> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Alpha> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 8usize..8usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -259,16 +259,6 @@ pub mod tests {
                             <Optional<BitList<32usize>> as ssz::Encode>::ssz_fixed_len(),
                         ),
                     ];
-                    for index in 2usize..2usize {
-                        if bitvector.get(index).unwrap_or(false) {
-                            return Err(
-                                ssz::DecodeError::BytesInvalid(
-                                    "StableContainer has active_fields bits set beyond field count"
-                                        .to_string(),
-                                ),
-                            );
-                        }
-                    }
                     ssz::layout::validate_active_container(
                         body,
                         field_layout,
@@ -3911,16 +3901,6 @@ pub mod tests {
                             <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
                         ),
                     ];
-                    for index in 8usize..8usize {
-                        if bitvector.get(index).unwrap_or(false) {
-                            return Err(
-                                ssz::DecodeError::BytesInvalid(
-                                    "StableContainer has active_fields bits set beyond field count"
-                                        .to_string(),
-                                ),
-                            );
-                        }
-                    }
                     ssz::layout::validate_active_container(
                         body,
                         field_layout,

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
@@ -91,46 +91,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 2usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        9usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 2usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        9usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for BitvectorLenTestRef<'a> {
@@ -186,22 +226,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for BitvectorLenTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 2usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         9usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..9usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
@@ -91,46 +91,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 2usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        9usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 2usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        9usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for BitvectorLenTestRef<'a> {
@@ -186,22 +226,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for BitvectorLenTestRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 2usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..2usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 2usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         9usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[2usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..9usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -1441,46 +1441,94 @@ pub struct GammaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
             8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1524,22 +1572,45 @@ impl<'a> tree_hash::TreeHash for GammaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -1823,88 +1894,220 @@ pub struct EpsilonRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -1962,22 +2165,55 @@ impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 4usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -2083,46 +2319,88 @@ pub struct ZetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     pub fn u(&self) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <FixedBytesRef<
+            'a,
+            16usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn v(&self) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <BytesRef<
+            'a,
+            5usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2166,22 +2444,41 @@ impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 16usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             128usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..128usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3112,130 +3409,414 @@ pub struct IotaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn r(&self) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             4usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            5usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            2usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             5usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            6usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3307,22 +3888,69 @@ impl<'a> tree_hash::TreeHash for IotaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 6usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3657,46 +4285,78 @@ pub struct LambdaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -3740,22 +4400,39 @@ impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 1usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..4usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
-        let _bitvector = ssz_types::BitVector::<
-            4usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -1644,48 +1644,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1741,22 +1791,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2083,90 +2160,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2246,22 +2461,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2387,48 +2639,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2484,22 +2790,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3549,134 +3884,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3780,22 +4407,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4167,46 +4845,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4262,22 +4980,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -1644,48 +1644,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1741,22 +1791,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2083,90 +2160,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2246,22 +2461,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2387,48 +2639,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2484,22 +2790,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3549,134 +3884,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3780,22 +4407,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4167,46 +4845,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4262,22 +4980,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -1605,48 +1605,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1702,22 +1752,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2018,90 +2095,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2181,22 +2396,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2309,48 +2561,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2406,22 +2712,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3419,134 +3754,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3650,22 +4277,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4011,46 +4689,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4106,22 +4824,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -1441,46 +1441,94 @@ pub struct GammaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
             8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1524,22 +1572,45 @@ impl<'a> tree_hash::TreeHash for GammaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -1823,88 +1894,220 @@ pub struct EpsilonRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -1962,22 +2165,55 @@ impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 4usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -2083,46 +2319,88 @@ pub struct ZetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     pub fn u(&self) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <FixedBytesRef<
+            'a,
+            16usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn v(&self) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <BytesRef<
+            'a,
+            5usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2166,22 +2444,41 @@ impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 16usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             128usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..128usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3112,130 +3409,414 @@ pub struct IotaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn r(&self) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             4usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            5usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            2usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             5usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            6usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3307,22 +3888,69 @@ impl<'a> tree_hash::TreeHash for IotaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 6usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3657,46 +4285,78 @@ pub struct LambdaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -3740,22 +4400,39 @@ impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 1usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..4usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
-        let _bitvector = ssz_types::BitVector::<
-            4usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -1644,48 +1644,98 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
                         8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1741,22 +1791,49 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2083,90 +2160,228 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        16usize,
-                        4usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        16usize,
-                        4usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -2246,22 +2461,59 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 4usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -2387,48 +2639,102 @@ pub mod tests {
                 pub fn u(
                     &self,
                 ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <FixedBytesRef<
+                        'a,
+                        16usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn v(
                     &self,
                 ) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 16usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        128usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <BytesRef<
+                        'a,
+                        5usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2484,22 +2790,51 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 16usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..16usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 16usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         128usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[16usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                FixedBytes<16usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                AliasListAlias,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..128usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -3549,134 +3884,426 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn h(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        8usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         3usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        4usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn r(
                     &self,
                 ) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         4usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        5usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <ListRef<
+                        'a,
+                        u16,
+                        2usize,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 6usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        24usize,
-                        6usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        42usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         5usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        24usize,
-                        6usize,
-                        6usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3780,22 +4407,73 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 6usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..6usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 6usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         42usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[6usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                        bitvector.get(3usize).unwrap_or(false),
+                        bitvector.get(4usize).unwrap_or(false),
+                        bitvector.get(5usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasUintAlias, 8usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                VariableList<AliasNested, 2usize>,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 6usize..42usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -4167,46 +4845,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        4usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -4262,22 +4980,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         4usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..4usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1457,46 +1457,94 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> GammaRef<'a> {
         pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 0usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                8usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 1usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <ListRef<
+                'a,
+                u16,
                 8usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
     }
     impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1540,22 +1588,49 @@ pub mod test_1 {
     impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
             use ssz::Decode;
-            let bitvector_length = 6usize;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
+            let bitvector_bytes = bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
-                    expected: bitvector_length,
-                });
-            }
-            let _bitvector = ssz_types::BitVector::<
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
                 42usize,
-            >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: bitvector_length,
-                });
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            for index in 2usize..42usize {
+                if bitvector.get(index).unwrap_or(false) {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            "StableContainer has active_fields bits set beyond field count"
+                                .to_string(),
+                        ),
+                    );
+                }
             }
+            ssz::layout::validate_active_container(
+                body,
+                field_layout,
+                |i| field_active[i],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -1840,88 +1915,220 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EpsilonRef<'a> {
         pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                16usize,
-                4usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 0usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                16usize,
-                4usize,
-                1usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                16usize,
-                4usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 1usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                16usize,
-                4usize,
-                2usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <ListRef<
+                'a,
+                u16,
+                8usize,
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                16usize,
-                4usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 2usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                16usize,
-                4usize,
-                3usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                16usize,
-                4usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 3usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                16usize,
-                4usize,
-                4usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
     }
     impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -1979,22 +2186,59 @@ pub mod test_1 {
     impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
             use ssz::Decode;
-            let bitvector_length = 6usize;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
+            let bitvector_bytes = bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
-                    expected: bitvector_length,
-                });
-            }
-            let _bitvector = ssz_types::BitVector::<
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
                 42usize,
-            >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: bitvector_length,
-                });
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            for index in 4usize..42usize {
+                if bitvector.get(index).unwrap_or(false) {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            "StableContainer has active_fields bits set beyond field count"
+                                .to_string(),
+                        ),
+                    );
+                }
             }
+            ssz::layout::validate_active_container(
+                body,
+                field_layout,
+                |i| field_active[i],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -2102,46 +2346,88 @@ pub mod test_1 {
         pub fn u(
             &self,
         ) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-            let bitvector_offset = 16usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..16usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 16usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                128usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[16usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 0usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                8usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <FixedBytesRef<
+                'a,
+                16usize,
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn v(&self) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-            let bitvector_offset = 16usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..16usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 16usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                128usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[16usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 1usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                8usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <BytesRef<
+                'a,
+                5usize,
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
     }
     impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2185,22 +2471,45 @@ pub mod test_1 {
     impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
             use ssz::Decode;
-            let bitvector_length = 16usize;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
+            let bitvector_bytes = bytes
+                .get(..16usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
-                    expected: bitvector_length,
-                });
-            }
-            let _bitvector = ssz_types::BitVector::<
+                    expected: 16usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
                 128usize,
-            >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: bitvector_length,
-                });
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &bytes[16usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            for index in 2usize..128usize {
+                if bitvector.get(index).unwrap_or(false) {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            "StableContainer has active_fields bits set beyond field count"
+                                .to_string(),
+                        ),
+                    );
+                }
             }
+            ssz::layout::validate_active_container(
+                body,
+                field_layout,
+                |i| field_active[i],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -3138,130 +3447,414 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> IotaRef<'a> {
         pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 0usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                1usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 1usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                2usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <ListRef<
+                'a,
+                u16,
+                8usize,
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 2usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                3usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 3usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                4usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn r(&self) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 4usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                5usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <ListRef<
+                'a,
+                u16,
+                2usize,
+            > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 6usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                24usize,
-                6usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                42usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 5usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                24usize,
-                6usize,
-                6usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
     }
     impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3333,22 +3926,73 @@ pub mod test_1 {
     impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
             use ssz::Decode;
-            let bitvector_length = 6usize;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
+            let bitvector_bytes = bytes
+                .get(..6usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
-                    expected: bitvector_length,
-                });
-            }
-            let _bitvector = ssz_types::BitVector::<
+                    expected: 6usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
                 42usize,
-            >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: bitvector_length,
-                });
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &bytes[6usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+                bitvector.get(2usize).unwrap_or(false),
+                bitvector.get(3usize).unwrap_or(false),
+                bitvector.get(4usize).unwrap_or(false),
+                bitvector.get(5usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasUintAlias, 8usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<
+                        VariableList<AliasNested, 2usize>,
+                    > as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            for index in 6usize..42usize {
+                if bitvector.get(index).unwrap_or(false) {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            "StableContainer has active_fields bits set beyond field count"
+                                .to_string(),
+                        ),
+                    );
+                }
             }
+            ssz::layout::validate_active_container(
+                body,
+                field_layout,
+                |i| field_active[i],
+            )?;
             Ok(Self { bytes })
         }
     }
@@ -3684,46 +4328,82 @@ pub mod test_1 {
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> LambdaRef<'a> {
         pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-            let bitvector_offset = 1usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..1usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 1usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                4usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[1usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 0usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                8usize,
-                2usize,
-                1usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
         pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-            let bitvector_offset = 1usize;
-            let container_bytes = &self.bytes[bitvector_offset..];
-            let start = ssz::layout::read_variable_offset(
-                container_bytes,
-                8usize,
-                2usize,
+            use ssz::Decode;
+            let bitvector_bytes = self
+                .bytes
+                .get(..1usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
+                    len: self.bytes.len(),
+                    expected: 1usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
+                4usize,
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &self.bytes[1usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            let field_bytes = match ssz::layout::read_active_field_bytes(
+                body,
+                field_layout,
+                |i| field_active[i],
                 1usize,
-            )?;
-            let end = ssz::layout::read_variable_offset_or_end(
-                container_bytes,
-                8usize,
-                2usize,
-                2usize,
-            )?;
-            if start > end || end > container_bytes.len() {
-                return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-            }
-            let bytes = &container_bytes[start..end];
-            ssz::view::DecodeView::from_ssz_bytes(bytes)
+            )? {
+                Some(bytes) => bytes,
+                None => return Ok(ssz_types::Optional::None),
+            };
+            let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+            Ok(ssz_types::Optional::Some(inner))
         }
     }
     impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -3767,22 +4447,45 @@ pub mod test_1 {
     impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
             use ssz::Decode;
-            let bitvector_length = 1usize;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
+            let bitvector_bytes = bytes
+                .get(..1usize)
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
-                    expected: bitvector_length,
-                });
-            }
-            let _bitvector = ssz_types::BitVector::<
+                    expected: 1usize,
+                })?;
+            let bitvector = ssz_types::BitVector::<
                 4usize,
-            >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-            if bytes.len() < bitvector_length {
-                return Err(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: bitvector_length,
-                });
+            >::from_ssz_bytes(bitvector_bytes)?;
+            let body = &bytes[1usize..];
+            let field_active: &[bool] = &[
+                bitvector.get(0usize).unwrap_or(false),
+                bitvector.get(1usize).unwrap_or(false),
+            ];
+            let field_layout: &[ssz::layout::FieldInfo] = &[
+                (
+                    <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                ),
+                (
+                    <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                    <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                ),
+            ];
+            for index in 2usize..4usize {
+                if bitvector.get(index).unwrap_or(false) {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            "StableContainer has active_fields bits set beyond field count"
+                                .to_string(),
+                        ),
+                    );
+                }
             }
+            ssz::layout::validate_active_container(
+                body,
+                field_layout,
+                |i| field_active[i],
+            )?;
             Ok(Self { bytes })
         }
     }

--- a/crates/ssz_codegen/tests/expected_output/test_import.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_import.rs
@@ -232,46 +232,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasUnion> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasUnion> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<Option<u8>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasUnion> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasUnion> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <Option<
+                        u8,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for StableContainerClassRef<'a> {
@@ -327,22 +367,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for StableContainerClassRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         5usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<AliasUnion> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<AliasUnion> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..5usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -642,25 +705,44 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        4usize,
-                        1usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                crate::tests::input::test_common::AliasUint8,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                crate::tests::input::test_common::AliasUint8,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        4usize,
-                        1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for StableContainerClassRef<'a> {
@@ -704,22 +786,44 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for StableContainerClassRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         5usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<
+                                crate::tests::input::test_common::AliasUint8,
+                            > as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<
+                                crate::tests::input::test_common::AliasUint8,
+                            > as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 1usize..5usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -838,38 +942,83 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileInehritanceRef<'a> {
                 pub fn a(&self) -> Result<u8, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let offset = bitvector_offset + 0usize;
-                    let end = offset + 1usize;
-                    if end > self.bytes.len() {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: self.bytes.len(),
-                            expected: end,
-                        });
-                    }
-                    let bytes = &self.bytes[offset..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Option<u8>> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Option<u8>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                        0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => unreachable!("required field is always active"),
+                    };
+                    ssz::view::DecodeView::from_ssz_bytes(field_bytes)
                 }
                 pub fn b(&self) -> Result<Optional<Option<u8>>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        5usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         1usize,
-                        0usize,
-                    )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Option<u8>> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Option<u8>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <Option<
+                        u8,
+                    > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ProfileInehritanceRef<'a> {
@@ -885,12 +1034,8 @@ pub mod tests {
                 fn tree_hash_root<H: tree_hash::TreeHashDigest>(&self) -> H::Output {
                     use tree_hash::TreeHash;
                     use ssz_types::BitVector;
-                    {
-                        let a = self.a().expect("valid view");
-                    }
-                    {
-                        let b = self.b().expect("valid view");
-                    }
+                    let a = self.a().expect("valid view");
+                    let b = self.b().expect("valid view");
                     let mut active_fields = BitVector::<5usize>::new();
                     active_fields
                         .set(0usize, true)
@@ -923,22 +1068,35 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ProfileInehritanceRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
-                        5usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        1usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        true,
+                        bitvector.get(0usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <u8 as ssz::Encode>::is_ssz_fixed_len(),
+                            <u8 as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<Option<u8>> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<Option<u8>> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
@@ -94,46 +94,86 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ParentRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        8usize,
-                        2usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        8usize,
-                        2usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ParentRef<'a> {
@@ -189,22 +229,45 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ParentRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         5usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 2usize..5usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }
@@ -334,67 +397,142 @@ pub mod tests {
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ChildRef<'a> {
                 pub fn a(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        12usize,
-                        3usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         0usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        12usize,
-                        3usize,
-                        1usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn b(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        12usize,
-                        3usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         1usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        12usize,
-                        3usize,
-                        2usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
                 pub fn c(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-                    let bitvector_offset = 1usize;
-                    let container_bytes = &self.bytes[bitvector_offset..];
-                    let start = ssz::layout::read_variable_offset(
-                        container_bytes,
-                        12usize,
-                        3usize,
+                    use ssz::Decode;
+                    let bitvector_bytes = self
+                        .bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
+                            len: self.bytes.len(),
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
+                        5usize,
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &self.bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    let field_bytes = match ssz::layout::read_active_field_bytes(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
                         2usize,
+                    )? {
+                        Some(bytes) => bytes,
+                        None => return Ok(ssz_types::Optional::None),
+                    };
+                    let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(
+                        field_bytes,
                     )?;
-                    let end = ssz::layout::read_variable_offset_or_end(
-                        container_bytes,
-                        12usize,
-                        3usize,
-                        3usize,
-                    )?;
-                    if start > end || end > container_bytes.len() {
-                        return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-                    }
-                    let bytes = &container_bytes[start..end];
-                    ssz::view::DecodeView::from_ssz_bytes(bytes)
+                    Ok(ssz_types::Optional::Some(inner))
                 }
             }
             impl<'a> tree_hash::TreeHash for ChildRef<'a> {
@@ -462,22 +600,50 @@ pub mod tests {
             impl<'a> ssz::view::DecodeView<'a> for ChildRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
                     use ssz::Decode;
-                    let bitvector_length = 1usize;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
+                    let bitvector_bytes = bytes
+                        .get(..1usize)
+                        .ok_or(ssz::DecodeError::InvalidByteLength {
                             len: bytes.len(),
-                            expected: bitvector_length,
-                        });
-                    }
-                    let _bitvector = ssz_types::BitVector::<
+                            expected: 1usize,
+                        })?;
+                    let bitvector = ssz_types::BitVector::<
                         5usize,
-                    >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-                    if bytes.len() < bitvector_length {
-                        return Err(ssz::DecodeError::InvalidByteLength {
-                            len: bytes.len(),
-                            expected: bitvector_length,
-                        });
+                    >::from_ssz_bytes(bitvector_bytes)?;
+                    let body = &bytes[1usize..];
+                    let field_active: &[bool] = &[
+                        bitvector.get(0usize).unwrap_or(false),
+                        bitvector.get(1usize).unwrap_or(false),
+                        bitvector.get(2usize).unwrap_or(false),
+                    ];
+                    let field_layout: &[ssz::layout::FieldInfo] = &[
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                        (
+                            <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                            <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+                        ),
+                    ];
+                    for index in 3usize..5usize {
+                        if bitvector.get(index).unwrap_or(false) {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    "StableContainer has active_fields bits set beyond field count"
+                                        .to_string(),
+                                ),
+                            );
+                        }
                     }
+                    ssz::layout::validate_active_container(
+                        body,
+                        field_layout,
+                        |i| field_active[i],
+                    )?;
                     Ok(Self { bytes })
                 }
             }

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1441,46 +1441,94 @@ pub struct GammaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
             8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for GammaRef<'a> {
@@ -1524,22 +1572,45 @@ impl<'a> tree_hash::TreeHash for GammaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for GammaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -1823,88 +1894,220 @@ pub struct EpsilonRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            16usize,
-            4usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            16usize,
-            4usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
@@ -1962,22 +2165,55 @@ impl<'a> tree_hash::TreeHash for EpsilonRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for EpsilonRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 4usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -2083,46 +2319,88 @@ pub struct ZetaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     pub fn u(&self) -> Result<Optional<FixedBytesRef<'a, 16usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <FixedBytesRef<
+            'a,
+            16usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn v(&self) -> Result<Optional<BytesRef<'a, 5usize>>, ssz::DecodeError> {
-        let bitvector_offset = 16usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            128usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <BytesRef<
+            'a,
+            5usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
@@ -2166,22 +2444,41 @@ impl<'a> tree_hash::TreeHash for ZetaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for ZetaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 16usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..16usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 16usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             128usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[16usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<FixedBytes<16usize>> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasListAlias> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasListAlias> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..128usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3112,130 +3409,414 @@ pub struct IotaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     pub fn g(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn h(&self) -> Result<Optional<ListRef<'a, u16, 8usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            8usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn i(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             2usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            3usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn j(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             3usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            4usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn r(&self) -> Result<Optional<ListRef<'a, u16, 2usize>>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             4usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            5usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <ListRef<
+            'a,
+            u16,
+            2usize,
+        > as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn s(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 6usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            24usize,
-            6usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
+            42usize,
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             5usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            24usize,
-            6usize,
-            6usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for IotaRef<'a> {
@@ -3307,22 +3888,69 @@ impl<'a> tree_hash::TreeHash for IotaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for IotaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 6usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..6usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
-        let _bitvector = ssz_types::BitVector::<
+                expected: 6usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<
             42usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
+        >::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[6usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+            bitvector.get(2usize).unwrap_or(false),
+            bitvector.get(3usize).unwrap_or(false),
+            bitvector.get(4usize).unwrap_or(false),
+            bitvector.get(5usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasUintAlias, 8usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<AliasNested> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<AliasNested> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<
+                    VariableList<AliasNested, 2usize>,
+                > as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 6usize..42usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }
@@ -3657,46 +4285,78 @@ pub struct LambdaRef<'a> {
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     pub fn w(&self) -> Result<Optional<u16>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             0usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            1usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u16 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
     pub fn x(&self) -> Result<Optional<u8>, ssz::DecodeError> {
-        let bitvector_offset = 1usize;
-        let container_bytes = &self.bytes[bitvector_offset..];
-        let start = ssz::layout::read_variable_offset(
-            container_bytes,
-            8usize,
-            2usize,
+        use ssz::Decode;
+        let bitvector_bytes = self
+            .bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
+                len: self.bytes.len(),
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &self.bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        let field_bytes = match ssz::layout::read_active_field_bytes(
+            body,
+            field_layout,
+            |i| field_active[i],
             1usize,
-        )?;
-        let end = ssz::layout::read_variable_offset_or_end(
-            container_bytes,
-            8usize,
-            2usize,
-            2usize,
-        )?;
-        if start > end || end > container_bytes.len() {
-            return Err(ssz::DecodeError::OffsetsAreDecreasing(end));
-        }
-        let bytes = &container_bytes[start..end];
-        ssz::view::DecodeView::from_ssz_bytes(bytes)
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(ssz_types::Optional::None),
+        };
+        let inner = <u8 as ssz::view::DecodeView>::from_ssz_bytes(field_bytes)?;
+        Ok(ssz_types::Optional::Some(inner))
     }
 }
 impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
@@ -3740,22 +4400,39 @@ impl<'a> tree_hash::TreeHash for LambdaRef<'a> {
 impl<'a> ssz::view::DecodeView<'a> for LambdaRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
         use ssz::Decode;
-        let bitvector_length = 1usize;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
+        let bitvector_bytes = bytes
+            .get(..1usize)
+            .ok_or(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: bitvector_length,
-            });
+                expected: 1usize,
+            })?;
+        let bitvector = ssz_types::BitVector::<4usize>::from_ssz_bytes(bitvector_bytes)?;
+        let body = &bytes[1usize..];
+        let field_active: &[bool] = &[
+            bitvector.get(0usize).unwrap_or(false),
+            bitvector.get(1usize).unwrap_or(false),
+        ];
+        let field_layout: &[ssz::layout::FieldInfo] = &[
+            (
+                <Optional<u16> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u16> as ssz::Encode>::ssz_fixed_len(),
+            ),
+            (
+                <Optional<u8> as ssz::Encode>::is_ssz_fixed_len(),
+                <Optional<u8> as ssz::Encode>::ssz_fixed_len(),
+            ),
+        ];
+        for index in 2usize..4usize {
+            if bitvector.get(index).unwrap_or(false) {
+                return Err(
+                    ssz::DecodeError::BytesInvalid(
+                        "StableContainer has active_fields bits set beyond field count"
+                            .to_string(),
+                    ),
+                );
+            }
         }
-        let _bitvector = ssz_types::BitVector::<
-            4usize,
-        >::from_ssz_bytes(&bytes[0..bitvector_length])?;
-        if bytes.len() < bitvector_length {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: bitvector_length,
-            });
-        }
+        ssz::layout::validate_active_container(body, field_layout, |i| field_active[i])?;
         Ok(Self { bytes })
     }
 }

--- a/crates/ssz_codegen/tests/stable_container_profile_view.rs
+++ b/crates/ssz_codegen/tests/stable_container_profile_view.rs
@@ -219,3 +219,44 @@ fn profile_view_all_some() {
     let view = InnerProfile1Ref::from_ssz_bytes(&bytes).expect("view decode");
     assert_eq!(view.to_owned(), owned);
 }
+
+/// An active optional whose inner encoding is zero-length (`Some` of an
+/// empty list) must stay `Some`: the presence bit, not the slice length,
+/// decides activeness.
+#[test]
+fn profile_active_optional_with_empty_inner() {
+    let owned = InnerProfile1 {
+        x: 3,
+        y: Optional::Some(VariableList::new(vec![]).expect("within bound")),
+        z: Optional::None,
+        w: Optional::None,
+    };
+    assert_agreement!(InnerProfile1, InnerProfile1Ref, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerProfile1Ref::from_ssz_bytes(&bytes).expect("view decode");
+    match view.y().expect("y") {
+        Optional::Some(v) => assert_eq!(v.to_owned(), Vec::<u8>::new()),
+        Optional::None => panic!("active empty list decoded as None"),
+    }
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn stable_container_active_optional_with_empty_inner() {
+    let owned = InnerBase {
+        x: Optional::None,
+        y: Optional::Some(VariableList::new(vec![]).expect("within bound")),
+        z: Optional::None,
+        w: Optional::None,
+    };
+    assert_agreement!(InnerBase, InnerBaseRef, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerBaseRef::from_ssz_bytes(&bytes).expect("view decode");
+    match view.y().expect("y") {
+        Optional::Some(v) => assert_eq!(v.to_owned(), Vec::<u8>::new()),
+        Optional::None => panic!("active empty list decoded as None"),
+    }
+    assert_eq!(view.to_owned(), owned);
+}

--- a/crates/ssz_codegen/tests/stable_container_profile_view.rs
+++ b/crates/ssz_codegen/tests/stable_container_profile_view.rs
@@ -1,0 +1,221 @@
+//! Regression tests: StableContainer/Profile views against the owned
+//! encoding.
+//!
+//! The owned `ssz_derive` encoding serializes only the *active* fields after
+//! the leading bitvector (EIP-7495): a `None` field contributes neither data
+//! nor an offset slot. Views used to compute one static layout at codegen
+//! time (assuming every field present and every `Optional` variable-size)
+//! and read offsets from an end-packed table, which broke StableContainers
+//! with inactive or fixed-size fields and Profiles mixing required
+//! fixed-size fields after variable-size ones. Views now parse the
+//! bitvector and derive the layout from the fields' owned encoding, so they
+//! must agree with owned encode/decode and tree hashing.
+
+#![allow(dead_code)]
+#![allow(unused_crate_dependencies)]
+#![allow(missing_docs)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use ssz_derive as _;
+use ssz_primitives as _;
+use tree_hash_derive as _;
+
+// Include generated code
+include!("expected_output/test_2.rs");
+
+use ssz::{
+    Decode, Encode,
+    view::{DecodeView, SszTypeInfo},
+};
+use ssz_types::{BitList, BitVector, Optional, VariableList};
+use tests::input::test_2::{
+    Alpha, InnerBase, InnerBaseRef, InnerProfile1, InnerProfile1Ref, InnerProfile2,
+    InnerProfile2Ref,
+};
+use tree_hash::TreeHash;
+
+fn sample_alpha() -> Alpha {
+    let mut bits = BitList::<32>::with_capacity(3).expect("within bound");
+    bits.set(1, true).expect("within bound");
+    Alpha {
+        a: Optional::Some(7),
+        b: Optional::Some(bits),
+    }
+}
+
+/// Asserts the owned encoding round-trips and the view's tree hash agrees
+/// with the owned one.
+macro_rules! assert_agreement {
+    ($owned_ty:ident, $ref_ty:ident, $owned:expr) => {{
+        let owned = $owned;
+        let bytes = owned.as_ssz_bytes();
+
+        let decoded = $owned_ty::from_ssz_bytes(&bytes).expect("owned decode");
+        assert_eq!(&decoded, owned, "owned round-trip");
+
+        let view = $ref_ty::from_ssz_bytes(&bytes).expect("view decode");
+        assert_eq!(
+            view.tree_hash_root::<tree_hash::Sha256Hasher>(),
+            owned.tree_hash_root::<tree_hash::Sha256Hasher>(),
+            "view tree hash agrees with owned"
+        );
+    }};
+}
+
+#[test]
+fn stable_container_view_all_some() {
+    let mut z = BitVector::<16>::new();
+    z.set(3, true).expect("within bound");
+    let owned = InnerBase {
+        x: Optional::Some(1),
+        y: Optional::Some(VariableList::new(vec![2, 3]).expect("within bound")),
+        z: Optional::Some(z),
+        w: Optional::Some(sample_alpha()),
+    };
+    assert_agreement!(InnerBase, InnerBaseRef, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerBaseRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), Optional::Some(1));
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// Inactive fields shift every later field's position: `x` and `z` are
+/// absent, so `y`'s offset slot sits at position 0 of the body and `w`'s
+/// right after it.
+#[test]
+fn stable_container_view_skips_inactive_fields() {
+    let owned = InnerBase {
+        x: Optional::None,
+        y: Optional::Some(VariableList::new(vec![9]).expect("within bound")),
+        z: Optional::None,
+        w: Optional::Some(sample_alpha()),
+    };
+    assert_agreement!(InnerBase, InnerBaseRef, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerBaseRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), Optional::None);
+    assert_eq!(view.z().expect("z"), Optional::None);
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// An active `Optional[uint8]`/`Optional[Bitvector]` is inlined in the fixed
+/// portion by the owned encoding (no offset slot); the old static layout
+/// treated every `Optional` as variable-size.
+#[test]
+fn stable_container_view_inlines_fixed_size_fields() {
+    let owned = InnerBase {
+        x: Optional::Some(0xAB),
+        y: Optional::None,
+        z: Optional::Some(BitVector::<16>::new()),
+        w: Optional::None,
+    };
+    assert_agreement!(InnerBase, InnerBaseRef, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerBaseRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), Optional::Some(0xAB));
+    assert_eq!(view.y().expect("y"), Optional::None);
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn stable_container_view_all_none() {
+    let owned = InnerBase {
+        x: Optional::None,
+        y: Optional::None,
+        z: Optional::None,
+        w: Optional::None,
+    };
+    assert_agreement!(InnerBase, InnerBaseRef, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerBaseRef::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.w().expect("w"), Optional::None);
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn stable_container_view_rejects_bits_beyond_field_count() {
+    // InnerBase declares 4 fields in a StableContainer[8]; bit 5 set.
+    let bytes = [0b0010_0000u8];
+    assert!(InnerBase::from_ssz_bytes(&bytes).is_err());
+    assert!(InnerBaseRef::from_ssz_bytes(&bytes).is_err());
+}
+
+#[test]
+fn stable_container_view_is_variable_size() {
+    assert!(!<InnerBaseRef<'_> as SszTypeInfo>::is_ssz_fixed_len());
+}
+
+/// Regression test for reading offsets from the field's own slot: `y` is a
+/// required variable-size field followed by the required fixed-size `z`, so
+/// `y`'s offset entry sits *before* `z` in the fixed portion, not at its
+/// end.
+#[test]
+fn profile_view_fixed_field_after_variable() {
+    let owned = InnerProfile2 {
+        x: Optional::Some(9),
+        y: VariableList::new(vec![4, 5, 6]).expect("within bound"),
+        z: BitVector::<16>::new(),
+    };
+    assert_agreement!(InnerProfile2, InnerProfile2Ref, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerProfile2Ref::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), Optional::Some(9));
+    assert_eq!(view.y().expect("y").to_owned(), vec![4, 5, 6]);
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn profile_view_with_inactive_optional() {
+    let owned = InnerProfile2 {
+        x: Optional::None,
+        y: VariableList::new(vec![4, 5]).expect("within bound"),
+        z: BitVector::<16>::new(),
+    };
+    assert_agreement!(InnerProfile2, InnerProfile2Ref, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerProfile2Ref::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), Optional::None);
+    assert_eq!(view.y().expect("y").to_owned(), vec![4, 5]);
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn profile_view_mixed_required_and_optional() {
+    let mut z = BitVector::<16>::new();
+    z.set(15, true).expect("within bound");
+    let owned = InnerProfile1 {
+        x: 3,
+        y: Optional::None,
+        z: Optional::Some(z),
+        w: Optional::None,
+    };
+    assert_agreement!(InnerProfile1, InnerProfile1Ref, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerProfile1Ref::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.x().expect("x"), 3);
+    assert_eq!(view.y().expect("y"), Optional::None);
+    assert_eq!(view.to_owned(), owned);
+}
+
+#[test]
+fn profile_view_all_some() {
+    let owned = InnerProfile1 {
+        x: 3,
+        y: Optional::Some(VariableList::new(vec![1]).expect("within bound")),
+        z: Optional::Some(BitVector::<16>::new()),
+        w: Optional::Some(sample_alpha()),
+    };
+    assert_agreement!(InnerProfile1, InnerProfile1Ref, &owned);
+
+    let bytes = owned.as_ssz_bytes();
+    let view = InnerProfile1Ref::from_ssz_bytes(&bytes).expect("view decode");
+    assert_eq!(view.to_owned(), owned);
+}

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -1133,12 +1133,12 @@ fn test_stable_container_optional_bitvector_length() {
         .expect("Failed to read actual output");
 
     assert!(
-        actual_output.contains("let bitvector_length = 2usize;"),
+        actual_output.contains(".get(..2usize)"),
         "Expected bitvector length based on max_fields"
     );
     assert!(
-        actual_output.contains("let bitvector_offset = 2usize;"),
-        "Expected bitvector offset based on max_fields"
+        actual_output.contains("&self.bytes[2usize..]"),
+        "Expected container body to start after the max_fields bitvector"
     );
 }
 

--- a/crates/ssz_derive/src/lib.rs
+++ b/crates/ssz_derive/src/lib.rs
@@ -636,6 +636,10 @@ fn ssz_encode_derive_stable_container(
 }
 
 /// Derive ssz::Encode for a struct as a Profile[B] as per EIP-7495.
+///
+/// A `true` bit in the leading bitvector indicates the corresponding
+/// `Optional` field is `Some`; a `None` field contributes neither data nor an
+/// offset slot to the container body, mirroring `StableContainer`.
 fn ssz_encode_derive_profile_container(
     derive_input: &DeriveInput,
     struct_data: &DataStruct,
@@ -645,10 +649,11 @@ fn ssz_encode_derive_profile_container(
 
     let field_is_ssz_fixed_len = &mut vec![];
     let field_fixed_len = &mut vec![];
-    let field_ssz_bytes_len = &mut vec![];
-    let field_encoder_append = &mut vec![];
+    let fixed_portion_terms = &mut vec![];
+    let bytes_len_terms = &mut vec![];
+    let encoder_appends = &mut vec![];
+    let set_bitvector_bits = &mut vec![];
 
-    let mut optional_field_names: Vec<&Ident> = vec![];
     let mut optional_count: usize = 0;
 
     for (ty, ident, field_opts) in parse_ssz_fields(struct_data) {
@@ -663,41 +668,123 @@ fn ssz_encode_derive_profile_container(
             }
         };
 
-        // Check if field is an Option;
-        if ty_inner_type("Option", ty).is_some() {
-            optional_field_names.push(ident);
-            optional_count += 1;
-        }
+        let is_optional = ty_inner_type("Optional", ty).is_some();
 
+        let is_fixed_expr;
+        let fixed_len_expr;
+        let bytes_len_expr;
+        let append_expr;
         if let Some(module) = field_opts.with {
             let module = quote! { #module::encode };
-            field_is_ssz_fixed_len.push(quote! { #module::is_ssz_fixed_len() });
-            field_fixed_len.push(quote! { #module::ssz_fixed_len() });
-            field_ssz_bytes_len.push(quote! { #module::ssz_bytes_len(&self.#ident) });
-            field_encoder_append.push(quote! {
+            is_fixed_expr = quote! { #module::is_ssz_fixed_len() };
+            fixed_len_expr = quote! { #module::ssz_fixed_len() };
+            bytes_len_expr = quote! { #module::ssz_bytes_len(&self.#ident) };
+            append_expr = quote! {
                 encoder.append_parameterized(
                     #module::is_ssz_fixed_len(),
                     |buf| #module::ssz_append(&self.#ident, buf)
                 )
-            });
+            };
         } else {
-            field_is_ssz_fixed_len.push(quote! { <#ty as ssz::Encode>::is_ssz_fixed_len() });
-            field_fixed_len.push(quote! { <#ty as ssz::Encode>::ssz_fixed_len() });
-            field_ssz_bytes_len.push(quote! { self.#ident.ssz_bytes_len() });
-            field_encoder_append.push(quote! { encoder.append(&self.#ident) });
+            is_fixed_expr = quote! { <#ty as ssz::Encode>::is_ssz_fixed_len() };
+            fixed_len_expr = quote! { <#ty as ssz::Encode>::ssz_fixed_len() };
+            bytes_len_expr = quote! { self.#ident.ssz_bytes_len() };
+            append_expr = quote! { encoder.append(&self.#ident) };
         }
+
+        // A variable-size field's `ssz_fixed_len` is `BYTES_PER_LENGTH_OFFSET`
+        // - the offset slot it occupies in the fixed portion - so summing
+        // `ssz_fixed_len` over the serialized fields yields the fixed-portion
+        // size.
+        let fixed_portion_term = quote! {
+            offset = offset
+                .checked_add(#fixed_len_expr)
+                .expect("encode ssz_append offset overflow");
+        };
+        let bytes_len_term = quote! {
+            if #is_fixed_expr {
+                len = len
+                    .checked_add(#fixed_len_expr)
+                    .expect("encode ssz_bytes_len length overflow");
+            } else {
+                len = len
+                    .checked_add(ssz::BYTES_PER_LENGTH_OFFSET)
+                    .expect("encode ssz_bytes_len length overflow for offset");
+                len = len
+                    .checked_add(#bytes_len_expr)
+                    .expect("encode ssz_bytes_len length overflow for bytes");
+            }
+        };
+
+        if is_optional {
+            let bit_index = optional_count;
+            set_bitvector_bits.push(quote! {
+                if self.#ident.is_some() {
+                    optional_fields
+                        .set(#bit_index, true)
+                        .expect("Should not be out of bounds");
+                }
+            });
+            fixed_portion_terms.push(quote! {
+                if self.#ident.is_some() {
+                    #fixed_portion_term
+                }
+            });
+            bytes_len_terms.push(quote! {
+                if self.#ident.is_some() {
+                    #bytes_len_term
+                }
+            });
+            encoder_appends.push(quote! {
+                if self.#ident.is_some() {
+                    #append_expr;
+                }
+            });
+            optional_count += 1;
+        } else {
+            fixed_portion_terms.push(fixed_portion_term);
+            bytes_len_terms.push(bytes_len_term);
+            encoder_appends.push(quote! { #append_expr; });
+        }
+
+        field_is_ssz_fixed_len.push(is_fixed_expr);
+        field_fixed_len.push(fixed_len_expr);
     }
 
-    // We can infer the constant required for the BitVector from the number of optional fields.
-    let max_optional_fields: usize = optional_count;
+    let bitvector_len_bytes: usize = optional_count.div_ceil(8);
+
+    // The presence bitvector makes the encoding length depend on runtime
+    // values, so a Profile with optional fields is always variable-size.
+    let is_fixed_len_body = if optional_count == 0 {
+        quote! {
+            #(
+                #field_is_ssz_fixed_len &&
+            )*
+                true
+        }
+    } else {
+        quote! { false }
+    };
+
+    let append_bitvector = if optional_count == 0 {
+        quote! {}
+    } else {
+        quote! {
+            // Construct the BitVector. This should only contain the bits of
+            // Optional values. A `true` value indicates the Optional is
+            // `Some`; a `false` value indicates the Optional is `None`.
+            let mut optional_fields = ssz_types::BitVector::<#optional_count>::new();
+            #(
+                #set_bitvector_bits
+            )*
+            buf.extend_from_slice(&optional_fields.as_ssz_bytes());
+        }
+    };
 
     let output = quote! {
         impl #impl_generics ssz::Encode for #name #ty_generics #where_clause {
             fn is_ssz_fixed_len() -> bool {
-                #(
-                    #field_is_ssz_fixed_len &&
-                )*
-                    true
+                #is_fixed_len_body
             }
 
             fn ssz_fixed_len() -> usize {
@@ -718,20 +805,9 @@ fn ssz_encode_derive_profile_container(
                 if <Self as ssz::Encode>::is_ssz_fixed_len() {
                     <Self as ssz::Encode>::ssz_fixed_len()
                 } else {
-                    let mut len: usize = 0;
+                    let mut len: usize = #bitvector_len_bytes;
                     #(
-                        if #field_is_ssz_fixed_len {
-                            len = len
-                                .checked_add(#field_fixed_len)
-                                .expect("encode ssz_bytes_len length overflow");
-                        } else {
-                            len = len
-                                .checked_add(ssz::BYTES_PER_LENGTH_OFFSET)
-                                .expect("encode ssz_bytes_len length overflow for offset");
-                            len = len
-                                .checked_add(#field_ssz_bytes_len)
-                                .expect("encode ssz_bytes_len length overflow for bytes");
-                        }
+                        #bytes_len_terms
                     )*
 
                     len
@@ -739,58 +815,18 @@ fn ssz_encode_derive_profile_container(
             }
 
             fn ssz_append(&self, buf: &mut Vec<u8>) {
-                if #optional_count == 0 {
-                    let mut offset: usize = 0;
-
-                    #(
-                        offset = offset
-                            .checked_add(#field_fixed_len)
-                            .expect("encode ssz_append offset overflow");
-                    )*
-
-                    let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-                    #(
-                        #field_encoder_append;
-                    )*
-
-                    encoder.finalize();
-                    return;
-                }
-
-                // Construct the BitVector. This should only contain the bits of Optional values. A
-                // `true` value indicates the Optional is `Some`. A `false ` value indicates the
-                // Optional is `None`.
-                let mut optional_fields = ssz_types::BitVector::<#max_optional_fields>::new();
-
-                // Iterate through the list of optional fields and check if they are Some.
-                // If it is, set the appropriate bit in the bitvector to true.
-                // Otherwise it is None and therefore stays false.
-                // This assumes the field names in `optional_field_names` are in order.
-                let mut working_index: usize = 0;
-
-                #(
-                    if self.#optional_field_names.is_some() {
-                        optional_fields.set(working_index, true).expect("Should not be out of bounds");
-                    }
-                    working_index += 1;
-                )*
-
-                // Append bitvector to output
-                buf.extend_from_slice(&optional_fields.as_ssz_bytes());
+                #append_bitvector
 
                 let mut offset: usize = 0;
 
                 #(
-                    offset = offset
-                        .checked_add(#field_fixed_len)
-                        .expect("encode ssz_append offset overflow");
+                    #fixed_portion_terms
                 )*
 
                 let mut encoder = ssz::SszEncoder::container(buf, offset);
 
                 #(
-                    #field_encoder_append;
+                    #encoder_appends
                 )*
 
                 encoder.finalize();
@@ -1430,11 +1466,19 @@ fn ssz_decode_derive_stable_container(
             ssz_fixed_len = quote! { #module::ssz_fixed_len() };
             from_ssz_bytes = quote! { #module::from_ssz_bytes(slice) };
 
+            // The encode side only serializes `Some` fields, so an inactive
+            // field's type must not be registered with the decoder.
             register_types.push(quote! {
-                builder.register_type_parameterized(#is_ssz_fixed_len, #ssz_fixed_len)?;
+                if bitvector.get(#working_index).unwrap_or(false) {
+                    builder.register_type_parameterized(#is_ssz_fixed_len, #ssz_fixed_len)?;
+                }
             });
             decodes.push(quote! {
-                let #ident = decoder.decode_next_with(|slice| #module::from_ssz_bytes(slice))?;
+                let #ident = if bitvector.get(#working_index).unwrap_or(false) {
+                    decoder.decode_next_with(|slice| #module::from_ssz_bytes(slice))?
+                } else {
+                    <_>::default()
+                };
             });
         } else {
             let inner_ty =
@@ -1620,29 +1664,53 @@ fn ssz_decode_derive_profile_container(
             ssz_fixed_len = quote! { #module::ssz_fixed_len() };
             from_ssz_bytes = quote! { #module::from_ssz_bytes(slice) };
 
-            register_types.push(quote! {
-                builder.register_type_parameterized(#is_ssz_fixed_len, #ssz_fixed_len)?;
-            });
-            decodes.push(quote! {
-                let #ident = decoder.decode_next_with(|slice| #module::from_ssz_bytes(slice))?;
-            });
+            // An inactive optional field is not serialized at all, so its
+            // type must not be registered with the decoder.
+            if is_optional {
+                register_types.push(quote! {
+                    if bitvector.get(#working_optional_index).unwrap_or(false) {
+                        builder.register_type_parameterized(#is_ssz_fixed_len, #ssz_fixed_len)?;
+                    }
+                });
+                decodes.push(quote! {
+                    let #ident = if bitvector.get(#working_optional_index).unwrap_or(false) {
+                        decoder.decode_next_with(|slice| #module::from_ssz_bytes(slice))?
+                    } else {
+                        <_>::default()
+                    };
+                });
+            } else {
+                register_types.push(quote! {
+                    builder.register_type_parameterized(#is_ssz_fixed_len, #ssz_fixed_len)?;
+                });
+                decodes.push(quote! {
+                    let #ident = decoder.decode_next_with(|slice| #module::from_ssz_bytes(slice))?;
+                });
+            }
         } else {
             is_ssz_fixed_len = quote! { <#ty as ssz::Decode>::is_ssz_fixed_len() };
             ssz_fixed_len = quote! { <#ty as ssz::Decode>::ssz_fixed_len() };
             from_ssz_bytes = quote! { <#ty as ssz::Decode>::from_ssz_bytes(slice) };
 
-            register_types.push(quote! {
-                builder.register_type::<#ty>()?;
-            });
             if is_optional {
+                // An inactive optional field is not serialized at all, so its
+                // type must not be registered with the decoder.
+                register_types.push(quote! {
+                    if bitvector.get(#working_optional_index).unwrap_or(false) {
+                        builder.register_type::<#ty>()?;
+                    }
+                });
                 decodes.push(quote! {
-                    let #ident = if bitvector.get(#working_optional_index).unwrap() {
+                    let #ident = if bitvector.get(#working_optional_index).unwrap_or(false) {
                         decoder.decode_next()?
                     } else {
                         <_>::default()
                     };
                 });
             } else {
+                register_types.push(quote! {
+                    builder.register_type::<#ty>()?;
+                });
                 decodes.push(quote! {
                     let #ident = decoder.decode_next()?;
                 });
@@ -1704,13 +1772,23 @@ fn ssz_decode_derive_profile_container(
     // We can infer the constant required for the BitVector from the number of optional fields.
     let max_optional_fields: usize = working_optional_index;
 
+    // The presence bitvector makes the encoding length depend on runtime
+    // values, so a Profile with optional fields is always variable-size.
+    let is_fixed_len_body = if max_optional_fields == 0 {
+        quote! {
+            #(
+                #is_fixed_lens &&
+            )*
+                true
+        }
+    } else {
+        quote! { false }
+    };
+
     let output = quote! {
         impl #impl_generics ssz::Decode for #name #ty_generics #where_clause {
             fn is_ssz_fixed_len() -> bool {
-                #(
-                    #is_fixed_lens &&
-                )*
-                    true
+                #is_fixed_len_body
             }
 
             fn ssz_fixed_len() -> usize {
@@ -1730,10 +1808,16 @@ fn ssz_decode_derive_profile_container(
             fn from_ssz_bytes(bytes: &[u8]) -> std::result::Result<Self, ssz::DecodeError> {
                 // Decode the leading BitVector first.
                 let bitvector_length: usize = #max_optional_fields.div_ceil(8);
+                if bytes.len() < bitvector_length {
+                    return Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: bitvector_length,
+                    });
+                }
                 let bitvector = if bitvector_length == 0 {
                     ssz_types::BitVector::<#max_optional_fields>::new()
                 } else {
-                    ssz_types::BitVector::<#max_optional_fields>::from_ssz_bytes(&bytes[0..bitvector_length]).unwrap()
+                    ssz_types::BitVector::<#max_optional_fields>::from_ssz_bytes(&bytes[0..bitvector_length])?
                 };
 
                 let bytes = &bytes[bitvector_length..];

--- a/crates/ssz_derive/src/lib.rs
+++ b/crates/ssz_derive/src/lib.rs
@@ -1694,17 +1694,22 @@ fn ssz_decode_derive_profile_container(
 
             if is_optional {
                 // An inactive optional field is not serialized at all, so its
-                // type must not be registered with the decoder.
+                // type must not be registered with the decoder. An active one
+                // is serialized as its inner type, so decode that and wrap it
+                // (like StableContainer): decoding `Optional<T>` directly
+                // would turn a zero-length inner encoding, e.g. `Some` of an
+                // empty list, back into `None`.
+                let inner_ty = inner_ty.expect("optional Profile fields use Optional<T>");
                 register_types.push(quote! {
                     if bitvector.get(#working_optional_index).unwrap_or(false) {
-                        builder.register_type::<#ty>()?;
+                        builder.register_type::<#inner_ty>()?;
                     }
                 });
                 decodes.push(quote! {
                     let #ident = if bitvector.get(#working_optional_index).unwrap_or(false) {
-                        decoder.decode_next()?
+                        Optional::Some(decoder.decode_next()?)
                     } else {
-                        <_>::default()
+                        Optional::None
                     };
                 });
             } else {

--- a/crates/ssz_types/src/lib.rs
+++ b/crates/ssz_types/src/lib.rs
@@ -39,6 +39,12 @@
 //! assert_eq!(&example.fixed_vector[..], &[2, 3, 0, 0, 0, 0, 0, 0]);
 //! ```
 
+#![feature(generic_const_exprs)]
+#![allow(
+    incomplete_features,
+    reason = "we need generic const exprs for BitVectorRef"
+)]
+
 #[macro_use]
 mod fixed_vector;
 mod optional;

--- a/crates/ssz_types/src/view.rs
+++ b/crates/ssz_types/src/view.rs
@@ -195,6 +195,21 @@ impl<'a, const N: usize> ToOwnedSsz<VariableList<u8, N>> for ssz::view::BytesRef
     }
 }
 
+impl<'a, const N: usize> ToOwnedSsz<crate::BitList<N>> for ssz::view::BitListRef<'a, N> {
+    fn to_owned(&self) -> crate::BitList<N> {
+        ssz::view::BitListRef::to_owned(self)
+    }
+}
+
+impl<'a, const N: usize> ToOwnedSsz<crate::BitVector<N>> for ssz::view::BitVectorRef<'a, N>
+where
+    [(); ssz::view::bytes_for_bits(N)]:,
+{
+    fn to_owned(&self) -> crate::BitVector<N> {
+        ssz::view::BitVectorRef::to_owned(self)
+    }
+}
+
 impl<'a, TRef, T, const N: usize> ToOwnedSsz<VariableList<T, N>> for ssz::view::ListRef<'a, TRef, N>
 where
     TRef: DecodeView<'a> + SszTypeInfo + ToOwnedSsz<T>,


### PR DESCRIPTION
## Description

Follow-up to #92, resolving the FIXME it left on `generate_field_layout` / `read_variable_offset`: generated StableContainer/Profile views still computed one static layout at codegen time (every field assumed present, every `Optional` assumed variable-size), read offsets from an end-packed table, and ignored `#[ssz(with = ...)]` overrides.

Views now parse the leading bitvector and slice each field with new active-field-aware layout helpers (`ssz::layout::read_active_field_bytes` / `validate_active_container`), with per-field layout facts taken from the fields' owned encoding — the same construction plain containers use since #92. Only active fields occupy space in the body (EIP-7495), fixed-size `Optional` inners are inlined, offset entries stay interleaved at their field's own slot, and inactive fields decode to `Optional::None`.

Proving the fix at runtime surfaced that this whole path had never actually run, and the PR fixes what that uncovered:

- The generated view code for these schemas **never compiled**: the Profile view `TreeHash` bound each field inside its own block scope and then used the names, and `to_owned` required `ToOwnedSsz` impls that didn't exist for `BitListRef`/`BitVectorRef`.
- Owned Profile serialization **never round-tripped with `Optional` fields**: the encode derive detected optionals by matching the type name `Option`, but generated profiles use `Optional<T>`, so encode wrote no presence bitvector while decode expected one (and registered inactive fields it never consumed). The derive now implements the EIP-7495 semantics on both sides, and a Profile with optional fields reports itself variable-size.
- The view side also used `max_fields` for the Profile bitvector length where the owned encoding uses `optional_count`, and Profile view `SszTypeInfo` guessed fixedness per kind instead of deriving it from the owned encoding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This PR was created with Claude Code 2.1.201 (model: Claude Fable 5).

Review entry points: `ssz::layout::read_active_field_bytes` for the layout model, then `ClassDef::active_layout_preamble`/`stable_view_getter` in `ssz_codegen` for how generated code uses it. The regenerated `tests/expected_output/*.rs` are mechanical; `tests/expected_output/test_2.rs` is the representative one to skim, and `tests/stable_container_profile_view.rs` shows the resulting behavior end-to-end (owned round-trip, view getters, `to_owned`, tree-hash agreement, mixed active sets, required-fixed-after-variable Profile).

Wire-format note: the `ssz_derive` commit changes the owned Profile encoding when `Optional` fields are present. The old format could not be decoded by its own decoder, so nothing functional can regress, but bytes persisted in the old broken format (if any exist) will not decode with the new code.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Follow-up to #92 (resolves the FIXMEs it introduced).
