### PR TITLE
Support fallible SSZ view materialization and SszHasView codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sizzle-parser"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "thiserror",
 ]
@@ -761,7 +761,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "ssz"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arbitrary",
  "hex",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_derive"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "darling",
  "quote",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_primitives"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -930,7 +930,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tree_hash"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "digest",
  "rand 0.8.5",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "darling",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 authors = [
   "Trey Del Bonis <trey@alpenlabs.io>",

--- a/crates/ssz_codegen/src/codegen.rs
+++ b/crates/ssz_codegen/src/codegen.rs
@@ -207,6 +207,10 @@ impl<'a> CircleBufferCodegen<'a> {
             self.tokens
                 .push(parent_class_def.to_view_to_owned_ssz_impl(&ident));
 
+            // Link the owned type to its view so generic code can name it
+            self.tokens
+                .push(parent_class_def.to_owned_has_view_impl(&ident));
+
             // Generate to_owned implementation (uses getters)
             self.tokens
                 .push(parent_class_def.to_view_to_owned_impl(&ident));

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -2118,13 +2118,18 @@ impl ClassDef {
                 fn to_owned(&self) -> #ident {
                     <#ref_ident<'a>>::to_owned(self)
                 }
+
+                fn try_to_owned(&self) -> Result<#ident, ssz::DecodeError> {
+                    <#ref_ident<'a>>::try_to_owned(self)
+                }
             }
         }
     }
 
-    /// Generates the to_owned implementation for converting view to owned
+    /// Generates owned conversion methods for a generated view.
     ///
-    /// Now uses getter methods instead of direct field access.
+    /// `try_to_owned` propagates getter and materialization errors; `to_owned`
+    /// delegates to it and panics on failure.
     ///
     /// # Arguments
     ///
@@ -2132,11 +2137,11 @@ impl ClassDef {
     ///
     /// # Returns
     ///
-    /// A [`TokenStream`] containing the `to_owned` method implementation.
+    /// A [`TokenStream`] containing the owned conversion methods.
     pub fn to_view_to_owned_impl(&self, ident: &Ident) -> TokenStream {
         let ref_ident = Ident::new(&format!("{}Ref", ident), Span::call_site());
 
-        // Check if this is a StableContainer
+        // StableContainer and Profile use `ssz_types::Optional<T>` for optional fields.
         let is_stable_container = matches!(
             self.base,
             BaseClass::StableContainer(_) | BaseClass::Profile(_)
@@ -2154,13 +2159,11 @@ impl ClassDef {
                 // field type, so no view conversion is needed.
                 if field.ssz_with_module().is_some() {
                     return quote! {
-                        #field_name: self.#field_name().expect("valid view")
+                        #field_name: self.#field_name()?
                     };
                 }
 
-                // For StableContainer, fields are wrapped in ssz_types::Optional<T>
-                // Getter returns Result<Optional<TRef>, Error>
-                // We need to convert Optional<TRef> to Optional<T>
+                // Optional getters for StableContainer and Profile return Optional<TRef>; convert inner views as needed.
                 if is_stable_container && is_optional {
                     let inner_resolution = match &field.ty.resolution {
                         TypeResolutionKind::Optional(inner) => &inner.resolution,
@@ -2170,7 +2173,7 @@ impl ClassDef {
                         TypeResolutionKind::Boolean | TypeResolutionKind::UInt(_) => {
                             // Primitives: Optional<T> -> Optional<T> (just copy)
                             quote! {
-                                #field_name: self.#field_name().expect("valid view")
+                                #field_name: self.#field_name()?
                             }
                         }
                         TypeResolutionKind::Union(_, _) => {
@@ -2178,8 +2181,8 @@ impl ClassDef {
                             // Need to map the Optional and convert UnionRef to Union
                             // Use ToOwnedSsz trait method for proper type resolution with external types
                             quote! {
-                                #field_name: match self.#field_name().expect("valid view") {
-                                    ssz_types::Optional::Some(inner) => ssz_types::Optional::Some(ssz_types::view::ToOwnedSsz::to_owned(&inner)),
+                                #field_name: match self.#field_name()? {
+                                    ssz_types::Optional::Some(inner) => ssz_types::Optional::Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
                                     ssz_types::Optional::None => ssz_types::Optional::None,
                                 }
                             }
@@ -2189,8 +2192,8 @@ impl ClassDef {
                             // Use match to convert inner TRef to T
                             // Use ToOwnedSsz trait method for proper type resolution with external types
                             quote! {
-                                #field_name: match self.#field_name().expect("valid view") {
-                                    ssz_types::Optional::Some(inner) => ssz_types::Optional::Some(ssz_types::view::ToOwnedSsz::to_owned(&inner)),
+                                #field_name: match self.#field_name()? {
+                                    ssz_types::Optional::Some(inner) => ssz_types::Optional::Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
                                     ssz_types::Optional::None => ssz_types::Optional::None,
                                 }
                             }
@@ -2204,13 +2207,16 @@ impl ClassDef {
                             // Need to convert Option<TRef> to Option<T> by calling to_owned() on inner if Some
                             // Use ToOwnedSsz trait method for proper type resolution with external types
                             quote! {
-                                #field_name: self.#field_name().expect("valid view").map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner))
+                                #field_name: match self.#field_name()? {
+                                    Some(inner) => Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
+                                    None => None,
+                                }
                             }
                         }
                         TypeResolutionKind::Boolean | TypeResolutionKind::UInt(_) => {
                             // Primitives can be copied directly from getter
                             quote! {
-                                #field_name: self.#field_name().expect("valid view")
+                                #field_name: self.#field_name()?
                             }
                         }
                         TypeResolutionKind::List(ty, _size) => {
@@ -2218,22 +2224,22 @@ impl ClassDef {
                             if matches!(inner.resolution, TypeResolutionKind::UInt(8)) {
                                 quote! {
                                     #field_name: ssz_types::VariableList::new(
-                                        self.#field_name().expect("valid view").to_owned(),
+                                        self.#field_name()?.to_owned(),
                                     )
-                                    .expect("valid view")
+                                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
                                 }
                             } else {
                                 quote! {
                                     #field_name: {
-                                        let view = self.#field_name().expect("valid view");
-                                        let items: Result<Vec<_>, _> = view
+                                        let view = self.#field_name()?;
+                                        let items = view
                                             .iter()
                                             .map(|item_result| {
-                                                item_result.map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                                ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                             })
-                                            .collect();
-                                        let items = items.expect("valid view");
-                                        ssz_types::VariableList::new(items).expect("valid view")
+                                            .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                                        ssz_types::VariableList::new(items)
+                                            .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
                                     }
                                 }
                             }
@@ -2244,25 +2250,25 @@ impl ClassDef {
                             if matches!(inner.resolution, TypeResolutionKind::UInt(8)) {
                                 // FixedBytesRef::to_owned() returns [u8; N], need to wrap in FixedBytes<N>
                                 quote! {
-                                    #field_name: ssz_types::FixedBytes(self.#field_name().expect("valid view").to_owned())
+                                    #field_name: ssz_types::FixedBytes(self.#field_name()?.to_owned())
                                 }
                             } else {
-                                // FixedVectorRef::to_owned() returns Result<FixedVector<T, N>, Error>
+                                // Use fallible vector conversion so element materialization errors propagate.
                                 quote! {
-                                    #field_name: self.#field_name().expect("valid view").to_owned().expect("valid view")
+                                    #field_name: self.#field_name()?.try_to_owned()?
                                 }
                             }
                         }
                         TypeResolutionKind::Bitlist(_) | TypeResolutionKind::Bitvector(_) => {
                             // BitListRef/BitVectorRef have inherent to_owned() methods
                             quote! {
-                                #field_name: self.#field_name().expect("valid view").to_owned()
+                                #field_name: self.#field_name()?.to_owned()
                             }
                         }
                         TypeResolutionKind::Bytes(_) => {
                             // FixedBytesRef has inherent to_owned() method
                             quote! {
-                                #field_name: ssz_types::FixedBytes(self.#field_name().expect("valid view").to_owned())
+                                #field_name: ssz_types::FixedBytes(self.#field_name()?.to_owned())
                             }
                         }
                         TypeResolutionKind::Class(_)
@@ -2272,15 +2278,15 @@ impl ClassDef {
                             // for proper type resolution with external types
                             quote! {
                                 #field_name: {
-                                    let view = self.#field_name().expect("valid view");
-                                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                                    let view = self.#field_name()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                                 }
                             }
                         }
                         _ => {
                             // Fallback for any other types - use inherent to_owned()
                             quote! {
-                                #field_name: self.#field_name().expect("valid view").to_owned()
+                                #field_name: self.#field_name()?.to_owned()
                             }
                         }
                     }
@@ -2293,9 +2299,14 @@ impl ClassDef {
             impl<'a> #ref_ident<'a> {
                 #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
                 pub fn to_owned(&self) -> #ident {
-                    #ident {
+                    <#ref_ident<'a>>::try_to_owned(self).expect("valid view")
+                }
+
+                #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+                pub fn try_to_owned(&self) -> Result<#ident, ssz::DecodeError> {
+                    Ok(#ident {
                         #(#field_conversions),*
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -1397,7 +1397,7 @@ impl ClassDef {
                 quote! {
                     impl<'a> tree_hash::TreeHash for #ref_ident<'a> {
                         fn tree_hash_type() -> tree_hash::TreeHashType {
-                            tree_hash::TreeHashType::StableContainer
+                            tree_hash::TreeHashType::Container
                         }
 
                         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
@@ -1537,7 +1537,7 @@ impl ClassDef {
                 quote! {
                     impl<'a> tree_hash::TreeHash for #ref_ident<'a> {
                         fn tree_hash_type() -> tree_hash::TreeHashType {
-                            tree_hash::TreeHashType::Container
+                            tree_hash::TreeHashType::StableContainer
                         }
 
                         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {

--- a/crates/ssz_codegen/src/types/mod.rs
+++ b/crates/ssz_codegen/src/types/mod.rs
@@ -2126,6 +2126,26 @@ impl ClassDef {
         }
     }
 
+    /// Generates the [`SszHasView`](ssz_types::view::SszHasView) implementation
+    /// linking the owned type to its generated view.
+    ///
+    /// # Arguments
+    ///
+    /// * `ident` - The base identifier for the class
+    ///
+    /// # Returns
+    ///
+    /// A [`TokenStream`] containing the `SszHasView` implementation.
+    pub fn to_owned_has_view_impl(&self, ident: &Ident) -> TokenStream {
+        let ref_ident = Ident::new(&format!("{}Ref", ident), Span::call_site());
+
+        quote! {
+            impl ssz_types::view::SszHasView for #ident {
+                type Ref<'a> = #ref_ident<'a>;
+            }
+        }
+    }
+
     /// Generates owned conversion methods for a generated view.
     ///
     /// `try_to_owned` propagates getter and materialization errors; `to_owned`

--- a/crates/ssz_codegen/src/types/resolver.rs
+++ b/crates/ssz_codegen/src/types/resolver.rs
@@ -1387,6 +1387,10 @@ impl<'a> TypeResolver<'a> {
                 }
             }
 
+            impl ssz_types::view::SszHasView for #union_ident {
+                type Ref<'a> = #ref_ident<'a>;
+            }
+
             impl<'a> tree_hash::TreeHash for #ref_ident<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector

--- a/crates/ssz_codegen/src/types/resolver.rs
+++ b/crates/ssz_codegen/src/types/resolver.rs
@@ -626,6 +626,8 @@ impl<'a> TypeResolver<'a> {
                         .collect();
                     let to_owned_arms =
                         self.generate_union_to_owned_arms(&ident, &args, &variant_names);
+                    let try_to_owned_arms =
+                        self.generate_union_try_to_owned_arms(&ident, &args, &variant_names);
 
                     let tree_hash_arms = self.generate_union_tree_hash_arms(&args);
 
@@ -635,6 +637,7 @@ impl<'a> TypeResolver<'a> {
                         view_type_aliases,
                         selector_methods,
                         to_owned_arms,
+                        try_to_owned_arms,
                         tree_hash_arms,
                     );
 
@@ -1231,6 +1234,8 @@ impl<'a> TypeResolver<'a> {
             self.generate_union_selector_methods(union_name, args, &variant_view_types);
 
         let to_owned_arms = self.generate_union_to_owned_arms(union_ident, args, variant_names);
+        let try_to_owned_arms =
+            self.generate_union_try_to_owned_arms(union_ident, args, variant_names);
 
         let tree_hash_arms = self.generate_union_tree_hash_arms(args);
 
@@ -1240,6 +1245,7 @@ impl<'a> TypeResolver<'a> {
             view_type_aliases,
             selector_methods,
             to_owned_arms,
+            try_to_owned_arms,
             tree_hash_arms,
         )
     }
@@ -1302,6 +1308,10 @@ impl<'a> TypeResolver<'a> {
         }
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "each argument is a distinct token stream spliced into the emitted view"
+    )]
     fn generate_union_view_struct_impl(
         &self,
         ref_ident: Ident,
@@ -1309,6 +1319,7 @@ impl<'a> TypeResolver<'a> {
         view_type_aliases: Vec<TokenStream>,
         selector_methods: Vec<TokenStream>,
         to_owned_arms: Vec<TokenStream>,
+        try_to_owned_arms: Vec<TokenStream>,
         tree_hash_arms: Vec<TokenStream>,
     ) -> TokenStream {
         quote! {
@@ -1326,11 +1337,26 @@ impl<'a> TypeResolver<'a> {
 
                 #(#selector_methods)*
 
+                #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
                 pub fn to_owned(&self) -> #union_ident {
                     match self.selector() {
                         #(#to_owned_arms,)*
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+
+                #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+                pub fn try_to_owned(&self) -> Result<#union_ident, ssz::DecodeError> {
+                    Ok(match self.selector() {
+                        #(#try_to_owned_arms,)*
+                        other => {
+                            return Err(
+                                ssz::DecodeError::BytesInvalid(
+                                    format!("Invalid union selector: {}", other),
+                                ),
+                            );
+                        }
+                    })
                 }
             }
 
@@ -1354,6 +1380,10 @@ impl<'a> TypeResolver<'a> {
             impl<'a> ssz_types::view::ToOwnedSsz<#union_ident> for #ref_ident<'a> {
                 fn to_owned(&self) -> #union_ident {
                     <#ref_ident<'a>>::to_owned(self)
+                }
+
+                fn try_to_owned(&self) -> Result<#union_ident, ssz::DecodeError> {
+                    <#ref_ident<'a>>::try_to_owned(self)
                 }
             }
 
@@ -1531,6 +1561,51 @@ impl<'a> TypeResolver<'a> {
                             #selector_value => #union_ident::#variant_ident({
                                 let view = self.#method_name().expect("valid selector");
                                 ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            })
+                        }
+                    }
+                }
+            })
+            .collect()
+    }
+
+    /// Generates match arms for a union view's fallible owned conversion.
+    pub fn generate_union_try_to_owned_arms(
+        &self,
+        union_ident: &Ident,
+        args: &[TypeResolution],
+        variant_names: &[String],
+    ) -> Vec<TokenStream> {
+        args.iter()
+            .enumerate()
+            .map(|(i, ty)| {
+                let selector_value = i as u8;
+                let variant_name = variant_names
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_else(|| format!("Selector{i}"));
+                let variant_ident = Ident::new(&variant_name, Span::call_site());
+                let method_name = Ident::new(&format!("as_selector{i}"), Span::call_site());
+
+                match ty.resolution {
+                    TypeResolutionKind::None => {
+                        quote! {
+                            #selector_value => {
+                                self.#method_name()?;
+                                #union_ident::#variant_ident
+                            }
+                        }
+                    }
+                    TypeResolutionKind::Boolean | TypeResolutionKind::UInt(_) => {
+                        quote! {
+                            #selector_value => #union_ident::#variant_ident(self.#method_name()?)
+                        }
+                    }
+                    _ => {
+                        quote! {
+                            #selector_value => #union_ident::#variant_ident({
+                                let view = self.#method_name()?;
+                                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                             })
                         }
                     }

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1700,7 +1700,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2237,7 +2237,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3435,7 +3435,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3726,7 +3726,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3980,7 +3980,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5014,7 +5014,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5531,7 +5531,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5848,7 +5848,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1521,6 +1542,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1763,6 +1787,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2082,6 +2109,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2279,6 +2309,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2782,6 +2815,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3112,6 +3148,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3515,6 +3554,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3771,6 +3813,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -4021,6 +4066,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4791,6 +4839,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -5050,6 +5101,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5356,6 +5410,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5546,6 +5603,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5895,6 +5955,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1311,6 +1517,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1319,13 +1528,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -1546,6 +1760,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1554,14 +1771,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(
@@ -1854,6 +2078,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1862,17 +2089,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2042,6 +2276,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2050,10 +2287,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(
@@ -2534,6 +2778,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2542,19 +2789,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(
@@ -2855,6 +3109,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2863,24 +3120,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3247,6 +3511,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3255,24 +3522,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(
@@ -3492,6 +3767,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3500,20 +3778,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3733,6 +4018,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3741,19 +4029,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -4494,6 +4787,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4502,28 +4798,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(
@@ -4744,6 +5047,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4752,17 +5058,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -5039,6 +5352,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -5047,10 +5363,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -5220,6 +5543,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5228,16 +5554,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5559,6 +5892,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5567,22 +5903,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1700,7 +1700,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2237,7 +2237,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3435,7 +3435,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3726,7 +3726,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3980,7 +3980,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5014,7 +5014,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5531,7 +5531,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5848,7 +5848,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1521,6 +1542,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1763,6 +1787,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2082,6 +2109,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2279,6 +2309,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2782,6 +2815,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3112,6 +3148,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3515,6 +3554,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3771,6 +3813,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -4021,6 +4066,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4791,6 +4839,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -5050,6 +5101,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5356,6 +5410,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5546,6 +5603,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5895,6 +5955,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_1_view_hash.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1311,6 +1517,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1319,13 +1528,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -1546,6 +1760,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1554,14 +1771,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(
@@ -1854,6 +2078,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1862,17 +2089,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2042,6 +2276,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2050,10 +2287,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(
@@ -2534,6 +2778,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2542,19 +2789,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(
@@ -2855,6 +3109,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2863,24 +3120,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3247,6 +3511,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3255,24 +3522,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(
@@ -3492,6 +3767,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3500,20 +3778,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3733,6 +4018,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3741,19 +4029,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -4494,6 +4787,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4502,28 +4798,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(
@@ -4744,6 +5047,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4752,17 +5058,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -5039,6 +5352,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -5047,10 +5363,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -5220,6 +5543,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5228,16 +5554,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5559,6 +5892,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5567,22 +5903,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -1207,7 +1207,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile1Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -1617,7 +1617,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile2Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -1919,7 +1919,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaProfileRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2133,7 +2133,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile3Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2356,7 +2356,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile4Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2635,7 +2635,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile5Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2916,7 +2916,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ProfileProfileRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -288,6 +288,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -819,6 +822,9 @@ pub mod tests {
                     <InnerBaseRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerBase {
+                type Ref<'a> = InnerBaseRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
                 #[allow(
@@ -1342,6 +1348,9 @@ pub mod tests {
                     <InnerProfile1Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile1 {
+                type Ref<'a> = InnerProfile1Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
                 #[allow(
@@ -1721,6 +1730,9 @@ pub mod tests {
                     <InnerProfile2Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile2 {
+                type Ref<'a> = InnerProfile2Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
                 #[allow(
@@ -2007,6 +2019,9 @@ pub mod tests {
                     <AlphaProfileRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AlphaProfile {
+                type Ref<'a> = AlphaProfileRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
                 #[allow(
@@ -2191,6 +2206,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
                     <InnerProfile3Ref<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for InnerProfile3 {
+                type Ref<'a> = InnerProfile3Ref<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
@@ -2430,6 +2448,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
                     <InnerProfile4Ref<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for InnerProfile4 {
+                type Ref<'a> = InnerProfile4Ref<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
@@ -2713,6 +2734,9 @@ pub mod tests {
                     <InnerProfile5Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile5 {
+                type Ref<'a> = InnerProfile5Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
                 #[allow(
@@ -2990,6 +3014,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
                     <ProfileProfileRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ProfileProfile {
+                type Ref<'a> = ProfileProfileRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
@@ -4020,6 +4047,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ContainerContainer, ssz::DecodeError> {
                     <ContainerContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerContainer {
+                type Ref<'a> = ContainerContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2.rs
@@ -284,6 +284,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -292,17 +295,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -805,6 +815,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerBase {
                     <InnerBaseRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerBase, ssz::DecodeError> {
+                    <InnerBaseRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
@@ -813,33 +826,40 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerBase {
-                    InnerBase {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <InnerBaseRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerBase, ssz::DecodeError> {
+                    Ok(InnerBase {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -1318,6 +1338,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile1 {
                     <InnerProfile1Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile1, ssz::DecodeError> {
+                    <InnerProfile1Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
@@ -1326,33 +1349,40 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile1 {
-                    InnerProfile1 {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <InnerProfile1Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile1, ssz::DecodeError> {
+                    Ok(InnerProfile1 {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -1687,6 +1717,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile2 {
                     <InnerProfile2Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile2, ssz::DecodeError> {
+                    <InnerProfile2Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
@@ -1695,14 +1728,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile2 {
-                    InnerProfile2 {
-                        x: self.x().expect("valid view"),
-                        y: ssz_types::VariableList::new(
-                                self.y().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
-                    }
+                    <InnerProfile2Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile2, ssz::DecodeError> {
+                    Ok(InnerProfile2 {
+                        x: self.x()?,
+                        y: ssz_types::VariableList::new(self.y()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        z: self.z()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -1963,6 +2003,9 @@ pub mod tests {
                 fn to_owned(&self) -> AlphaProfile {
                     <AlphaProfileRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<AlphaProfile, ssz::DecodeError> {
+                    <AlphaProfileRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
@@ -1971,17 +2014,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> AlphaProfile {
-                    AlphaProfile {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <AlphaProfileRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AlphaProfile, ssz::DecodeError> {
+                    Ok(AlphaProfile {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2138,6 +2188,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile3 {
                     <InnerProfile3Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
+                    <InnerProfile3Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
@@ -2146,12 +2199,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile3 {
-                    InnerProfile3 {
+                    <InnerProfile3Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
+                    Ok(InnerProfile3 {
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2367,6 +2427,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile4 {
                     <InnerProfile4Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
+                    <InnerProfile4Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
@@ -2375,13 +2438,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile4 {
-                    InnerProfile4 {
-                        y: ssz_types::VariableList::new(
-                                self.y().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
-                    }
+                    <InnerProfile4Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
+                    Ok(InnerProfile4 {
+                        y: ssz_types::VariableList::new(self.y()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        z: self.z()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -2639,6 +2709,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile5 {
                     <InnerProfile5Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile5, ssz::DecodeError> {
+                    <InnerProfile5Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
@@ -2647,14 +2720,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile5 {
-                    InnerProfile5 {
-                        x: self.x().expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
+                    <InnerProfile5Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile5, ssz::DecodeError> {
+                    Ok(InnerProfile5 {
+                        x: self.x()?,
+                        z: self.z()?.to_owned(),
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2907,6 +2987,9 @@ pub mod tests {
                 fn to_owned(&self) -> ProfileProfile {
                     <ProfileProfileRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
+                    <ProfileProfileRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
@@ -2915,13 +2998,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ProfileProfile {
-                    ProfileProfile {
-                        x: self.x().expect("valid view"),
+                    <ProfileProfileRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
+                    Ok(ProfileProfile {
+                        x: self.x()?,
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3927,6 +4017,9 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerContainer {
                     <ContainerContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ContainerContainer, ssz::DecodeError> {
+                    <ContainerContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {
@@ -3935,37 +4028,46 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerContainer {
-                    ContainerContainer {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <ContainerContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerContainer, ssz::DecodeError> {
+                    Ok(ContainerContainer {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view"),
-                        d: self.d().expect("valid view"),
-                    }
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: self.c()?,
+                        d: self.d()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -1207,7 +1207,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile1Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -1617,7 +1617,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile2Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -1919,7 +1919,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaProfileRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2133,7 +2133,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile3Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2356,7 +2356,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile4Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2635,7 +2635,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerProfile5Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")
@@ -2916,7 +2916,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ProfileProfileRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -288,6 +288,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -819,6 +822,9 @@ pub mod tests {
                     <InnerBaseRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerBase {
+                type Ref<'a> = InnerBaseRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
                 #[allow(
@@ -1342,6 +1348,9 @@ pub mod tests {
                     <InnerProfile1Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile1 {
+                type Ref<'a> = InnerProfile1Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
                 #[allow(
@@ -1721,6 +1730,9 @@ pub mod tests {
                     <InnerProfile2Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile2 {
+                type Ref<'a> = InnerProfile2Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
                 #[allow(
@@ -2007,6 +2019,9 @@ pub mod tests {
                     <AlphaProfileRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AlphaProfile {
+                type Ref<'a> = AlphaProfileRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
                 #[allow(
@@ -2191,6 +2206,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
                     <InnerProfile3Ref<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for InnerProfile3 {
+                type Ref<'a> = InnerProfile3Ref<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
@@ -2430,6 +2448,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
                     <InnerProfile4Ref<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for InnerProfile4 {
+                type Ref<'a> = InnerProfile4Ref<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
@@ -2713,6 +2734,9 @@ pub mod tests {
                     <InnerProfile5Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerProfile5 {
+                type Ref<'a> = InnerProfile5Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
                 #[allow(
@@ -2990,6 +3014,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
                     <ProfileProfileRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ProfileProfile {
+                type Ref<'a> = ProfileProfileRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
@@ -4020,6 +4047,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ContainerContainer, ssz::DecodeError> {
                     <ContainerContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerContainer {
+                type Ref<'a> = ContainerContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_2_view_hash.rs
@@ -284,6 +284,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -292,17 +295,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -805,6 +815,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerBase {
                     <InnerBaseRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerBase, ssz::DecodeError> {
+                    <InnerBaseRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerBaseRef<'a> {
@@ -813,33 +826,40 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerBase {
-                    InnerBase {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <InnerBaseRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerBase, ssz::DecodeError> {
+                    Ok(InnerBase {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -1318,6 +1338,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile1 {
                     <InnerProfile1Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile1, ssz::DecodeError> {
+                    <InnerProfile1Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile1Ref<'a> {
@@ -1326,33 +1349,40 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile1 {
-                    InnerProfile1 {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <InnerProfile1Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile1, ssz::DecodeError> {
+                    Ok(InnerProfile1 {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -1687,6 +1717,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile2 {
                     <InnerProfile2Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile2, ssz::DecodeError> {
+                    <InnerProfile2Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile2Ref<'a> {
@@ -1695,14 +1728,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile2 {
-                    InnerProfile2 {
-                        x: self.x().expect("valid view"),
-                        y: ssz_types::VariableList::new(
-                                self.y().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
-                    }
+                    <InnerProfile2Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile2, ssz::DecodeError> {
+                    Ok(InnerProfile2 {
+                        x: self.x()?,
+                        y: ssz_types::VariableList::new(self.y()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        z: self.z()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -1963,6 +2003,9 @@ pub mod tests {
                 fn to_owned(&self) -> AlphaProfile {
                     <AlphaProfileRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<AlphaProfile, ssz::DecodeError> {
+                    <AlphaProfileRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaProfileRef<'a> {
@@ -1971,17 +2014,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> AlphaProfile {
-                    AlphaProfile {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <AlphaProfileRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AlphaProfile, ssz::DecodeError> {
+                    Ok(AlphaProfile {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2138,6 +2188,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile3 {
                     <InnerProfile3Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
+                    <InnerProfile3Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile3Ref<'a> {
@@ -2146,12 +2199,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile3 {
-                    InnerProfile3 {
+                    <InnerProfile3Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile3, ssz::DecodeError> {
+                    Ok(InnerProfile3 {
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2367,6 +2427,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile4 {
                     <InnerProfile4Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
+                    <InnerProfile4Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile4Ref<'a> {
@@ -2375,13 +2438,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile4 {
-                    InnerProfile4 {
-                        y: ssz_types::VariableList::new(
-                                self.y().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
-                    }
+                    <InnerProfile4Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile4, ssz::DecodeError> {
+                    Ok(InnerProfile4 {
+                        y: ssz_types::VariableList::new(self.y()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        z: self.z()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -2639,6 +2709,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerProfile5 {
                     <InnerProfile5Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerProfile5, ssz::DecodeError> {
+                    <InnerProfile5Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerProfile5Ref<'a> {
@@ -2647,14 +2720,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerProfile5 {
-                    InnerProfile5 {
-                        x: self.x().expect("valid view"),
-                        z: self.z().expect("valid view").to_owned(),
+                    <InnerProfile5Ref<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerProfile5, ssz::DecodeError> {
+                    Ok(InnerProfile5 {
+                        x: self.x()?,
+                        z: self.z()?.to_owned(),
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2907,6 +2987,9 @@ pub mod tests {
                 fn to_owned(&self) -> ProfileProfile {
                     <ProfileProfileRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
+                    <ProfileProfileRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileProfileRef<'a> {
@@ -2915,13 +2998,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ProfileProfile {
-                    ProfileProfile {
-                        x: self.x().expect("valid view"),
+                    <ProfileProfileRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ProfileProfile, ssz::DecodeError> {
+                    Ok(ProfileProfile {
+                        x: self.x()?,
                         w: {
-                            let view = self.w().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.w()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3927,6 +4017,9 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerContainer {
                     <ContainerContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ContainerContainer, ssz::DecodeError> {
+                    <ContainerContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerContainerRef<'a> {
@@ -3935,37 +4028,46 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerContainer {
-                    ContainerContainer {
-                        x: self.x().expect("valid view"),
-                        y: match self.y().expect("valid view") {
+                    <ContainerContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerContainer, ssz::DecodeError> {
+                    Ok(ContainerContainer {
+                        x: self.x()?,
+                        y: match self.y()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        z: match self.z().expect("valid view") {
+                        z: match self.z()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        w: match self.w().expect("valid view") {
+                        w: match self.w()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view"),
-                        d: self.d().expect("valid view"),
-                    }
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: self.c()?,
+                        d: self.d()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -339,7 +339,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BitfieldContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -473,6 +473,9 @@ pub mod tests {
                     <BitfieldContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BitfieldContainer {
+                type Ref<'a> = BitfieldContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitfieldContainerRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitfields.rs
@@ -469,6 +469,9 @@ pub mod tests {
                 fn to_owned(&self) -> BitfieldContainer {
                     <BitfieldContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BitfieldContainer, ssz::DecodeError> {
+                    <BitfieldContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitfieldContainerRef<'a> {
@@ -477,14 +480,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BitfieldContainer {
-                    BitfieldContainer {
-                        tiny_list: self.tiny_list().expect("valid view").to_owned(),
-                        std_list: self.std_list().expect("valid view").to_owned(),
-                        large_list: self.large_list().expect("valid view").to_owned(),
-                        tiny_vec: self.tiny_vec().expect("valid view").to_owned(),
-                        std_vec: self.std_vec().expect("valid view").to_owned(),
-                        large_vec: self.large_vec().expect("valid view").to_owned(),
-                    }
+                    <BitfieldContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<BitfieldContainer, ssz::DecodeError> {
+                    Ok(BitfieldContainer {
+                        tiny_list: self.tiny_list()?.to_owned(),
+                        std_list: self.std_list()?.to_owned(),
+                        large_list: self.large_list()?.to_owned(),
+                        tiny_vec: self.tiny_vec()?.to_owned(),
+                        std_vec: self.std_vec()?.to_owned(),
+                        large_vec: self.large_vec()?.to_owned(),
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
@@ -286,6 +286,9 @@ pub mod tests {
                 fn to_owned(&self) -> BitvectorLenTest {
                     <BitvectorLenTestRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BitvectorLenTest, ssz::DecodeError> {
+                    <BitvectorLenTestRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
@@ -294,10 +297,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BitvectorLenTest {
-                    BitvectorLenTest {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                    }
+                    <BitvectorLenTestRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<BitvectorLenTest, ssz::DecodeError> {
+                    Ok(BitvectorLenTest {
+                        a: self.a()?,
+                        b: self.b()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len.rs
@@ -290,6 +290,9 @@ pub mod tests {
                     <BitvectorLenTestRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BitvectorLenTest {
+                type Ref<'a> = BitvectorLenTestRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
@@ -286,6 +286,9 @@ pub mod tests {
                 fn to_owned(&self) -> BitvectorLenTest {
                     <BitvectorLenTestRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BitvectorLenTest, ssz::DecodeError> {
+                    <BitvectorLenTestRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
@@ -294,10 +297,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BitvectorLenTest {
-                    BitvectorLenTest {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                    }
+                    <BitvectorLenTestRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<BitvectorLenTest, ssz::DecodeError> {
+                    Ok(BitvectorLenTest {
+                        a: self.a()?,
+                        b: self.b()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_bitvector_len_optional.rs
@@ -290,6 +290,9 @@ pub mod tests {
                     <BitvectorLenTestRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BitvectorLenTest {
+                type Ref<'a> = BitvectorLenTestRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BitvectorLenTestRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_comments.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_comments.rs
@@ -148,7 +148,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for PointRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -359,7 +359,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for CoordinateContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_comments.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_comments.rs
@@ -230,6 +230,9 @@ pub mod tests {
                 fn to_owned(&self) -> Point {
                     <PointRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Point, ssz::DecodeError> {
+                    <PointRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointRef<'a> {
@@ -238,11 +241,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Point {
-                    Point {
-                        x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view"),
-                        z: self.z().expect("valid view"),
-                    }
+                    <PointRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Point, ssz::DecodeError> {
+                    Ok(Point {
+                        x: self.x()?,
+                        y: self.y()?,
+                        z: self.z()?,
+                    })
                 }
             }
             /// A container for coordinates
@@ -416,6 +426,9 @@ pub mod tests {
                 fn to_owned(&self) -> CoordinateContainer {
                     <CoordinateContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<CoordinateContainer, ssz::DecodeError> {
+                    <CoordinateContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CoordinateContainerRef<'a> {
@@ -424,10 +437,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> CoordinateContainer {
-                    CoordinateContainer {
-                        lat: self.lat().expect("valid view"),
-                        lon: self.lon().expect("valid view"),
-                    }
+                    <CoordinateContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<CoordinateContainer, ssz::DecodeError> {
+                    Ok(CoordinateContainer {
+                        lat: self.lat()?,
+                        lon: self.lon()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_comments.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_comments.rs
@@ -234,6 +234,9 @@ pub mod tests {
                     <PointRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Point {
+                type Ref<'a> = PointRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointRef<'a> {
                 #[allow(
@@ -429,6 +432,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<CoordinateContainer, ssz::DecodeError> {
                     <CoordinateContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for CoordinateContainer {
+                type Ref<'a> = CoordinateContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CoordinateContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -65,6 +65,7 @@ impl<'a> AliasOptionUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> AliasOptionUnion {
         match self.selector() {
             0u8 => {
@@ -78,6 +79,27 @@ impl<'a> AliasOptionUnionRef<'a> {
             }
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                1u8 => {
+                    AliasOptionUnion::Selector1({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -97,6 +119,9 @@ impl<'a> ssz::view::SszTypeInfo for AliasOptionUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'a> {
     fn to_owned(&self) -> AliasOptionUnion {
         <AliasOptionUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -188,12 +213,29 @@ impl<'a> FirstUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> FirstUnion {
         match self.selector() {
             0u8 => FirstUnion::Selector0(self.as_selector0().expect("valid selector")),
             1u8 => FirstUnion::Selector1(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -213,6 +255,9 @@ impl<'a> ssz::view::SszTypeInfo for FirstUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn to_owned(&self) -> FirstUnion {
         <FirstUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        <FirstUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -320,6 +365,7 @@ impl<'a> TestUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestUnion {
         match self.selector() {
             0u8 => {
@@ -330,6 +376,26 @@ impl<'a> TestUnionRef<'a> {
             2u8 => TestUnion::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => {
+                    self.as_selector0()?;
+                    TestUnion::Selector0
+                }
+                1u8 => TestUnion::Selector1(self.as_selector1()?),
+                2u8 => TestUnion::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -349,6 +415,9 @@ impl<'a> ssz::view::SszTypeInfo for TestUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
     fn to_owned(&self) -> TestUnion {
         <TestUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -461,6 +530,7 @@ impl<'a> UnionARef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionA {
         match self.selector() {
             0u8 => UnionA::Selector0(self.as_selector0().expect("valid selector")),
@@ -468,6 +538,23 @@ impl<'a> UnionARef<'a> {
             2u8 => UnionA::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionA::Selector0(self.as_selector0()?),
+                1u8 => UnionA::Selector1(self.as_selector1()?),
+                2u8 => UnionA::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
@@ -487,6 +574,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionARef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn to_owned(&self) -> UnionA {
         <UnionARef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        <UnionARef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -617,6 +707,7 @@ impl<'a> UnionBRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionB {
         match self.selector() {
             0u8 => UnionB::Selector0(self.as_selector0().expect("valid selector")),
@@ -636,6 +727,34 @@ impl<'a> UnionBRef<'a> {
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionB::Selector0(self.as_selector0()?),
+                1u8 => {
+                    UnionB::UnionA({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                2u8 => UnionB::Selector2(self.as_selector2()?),
+                3u8 => {
+                    UnionB::Selector3({
+                        let view = self.as_selector3()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
+    }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -654,6 +773,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionBRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
     fn to_owned(&self) -> UnionB {
         <UnionBRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        <UnionBRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -759,12 +881,29 @@ impl<'a> UnionCRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionC {
         match self.selector() {
             0u8 => UnionC::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionC::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -784,6 +923,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionCRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
     fn to_owned(&self) -> UnionC {
         <UnionCRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        <UnionCRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -875,12 +1017,29 @@ impl<'a> UnionDRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionD {
         match self.selector() {
             0u8 => UnionD::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionD::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -900,6 +1059,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionDRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn to_owned(&self) -> UnionD {
         <UnionDRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        <UnionDRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1146,16 +1308,23 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
     fn to_owned(&self) -> Alpha {
         <AlphaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        <AlphaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Alpha {
-        Alpha {
-            a: self.a().expect("valid view"),
-            b: self.b().expect("valid view"),
-            c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
-        }
+        <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        Ok(Alpha {
+            a: self.a()?,
+            b: self.b()?,
+            c: ssz_types::FixedBytes(self.c()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -1360,17 +1529,24 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn to_owned(&self) -> Beta {
         <BetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        <BetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
-        Beta {
-            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
-                .expect("valid view"),
-            e: self.e().expect("valid view"),
-            f: self.f().expect("valid view"),
-        }
+        <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        Ok(Beta {
+            d: ssz_types::VariableList::new(self.d()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+            e: self.e()?,
+            f: self.f()?,
+        })
     }
 }
 #[derive(
@@ -1628,22 +1804,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
     fn to_owned(&self) -> Gamma {
         <GammaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        <GammaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Gamma {
-        Gamma {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        Ok(Gamma {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -1801,15 +1984,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn to_owned(&self) -> Delta {
         <DeltaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        <DeltaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Delta {
-        Delta {
-            z: self.z().expect("valid view"),
-            w: self.w().expect("valid view"),
-        }
+        <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        Ok(Delta {
+            z: self.z()?,
+            w: self.w()?,
+        })
     }
 }
 #[derive(
@@ -2231,24 +2421,31 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
     fn to_owned(&self) -> Epsilon {
         <EpsilonRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        <EpsilonRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Epsilon {
-        Epsilon {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        Ok(Epsilon {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-        }
+            i: self.i()?,
+            j: self.j()?,
+        })
     }
 }
 #[derive(
@@ -2496,29 +2693,36 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn to_owned(&self) -> Zeta {
         <ZetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        <ZetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Zeta {
-        Zeta {
-            u: match self.u().expect("valid view") {
+        <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        Ok(Zeta {
+            u: match self.u()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            v: match self.v().expect("valid view") {
+            v: match self.v()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -2845,29 +3049,35 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
     fn to_owned(&self) -> TestType {
         <TestTypeRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        <TestTypeRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestType {
-        TestType {
-            ccc: self.ccc().expect("valid view"),
-            ddd: self.ddd().expect("valid view"),
+        <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        Ok(TestType {
+            ccc: self.ccc()?,
+            ddd: self.ddd()?,
             eee: {
-                let view = self.eee().expect("valid view");
-                let items: Result<Vec<_>, _> = view
+                let view = self.eee()?;
+                let items = view
                     .iter()
                     .map(|item_result| {
-                        item_result
-                            .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                     })
-                    .collect();
-                let items = items.expect("valid view");
-                ssz_types::VariableList::new(items).expect("valid view")
+                    .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                ssz_types::VariableList::new(items)
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
             },
-            large_int_128: self.large_int_128().expect("valid view"),
-            large_int_256: self.large_int_256().expect("valid view"),
-        }
+            large_int_128: self.large_int_128()?,
+            large_int_256: self.large_int_256()?,
+        })
     }
 }
 #[derive(
@@ -3072,25 +3282,32 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
     fn to_owned(&self) -> Eta {
         <EtaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        <EtaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Eta {
-        Eta {
+        <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        Ok(Eta {
             l: {
-                let view = self.l().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.l()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             m: {
-                let view = self.m().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.m()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             n: {
-                let view = self.n().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.n()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 #[derive(
@@ -3295,22 +3512,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn to_owned(&self) -> Theta {
         <ThetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        <ThetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Theta {
-        Theta {
+        <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        Ok(Theta {
             o: {
-                let view = self.o().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.o()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             p: {
-                let view = self.p().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.p()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
-        }
+            q: ssz_types::FixedBytes(self.q()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -3968,33 +4192,40 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
     fn to_owned(&self) -> Iota {
         <IotaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        <IotaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Iota {
-        Iota {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        Ok(Iota {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-            r: match self.r().expect("valid view") {
+            i: self.i()?,
+            j: self.j()?,
+            r: match self.r()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            s: self.s().expect("valid view"),
-        }
+            s: self.s()?,
+        })
     }
 }
 #[derive(
@@ -4199,22 +4430,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn to_owned(&self) -> Kappa {
         <KappaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        <KappaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Kappa {
-        Kappa {
+        <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        Ok(Kappa {
             t: {
-                let view = self.t().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.t()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             u: {
-                let view = self.u().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.u()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            v: self.v().expect("valid view").to_owned(),
-        }
+            v: self.v()?.to_owned(),
+        })
     }
 }
 #[derive(
@@ -4450,15 +4688,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
     fn to_owned(&self) -> Lambda {
         <LambdaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        <LambdaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Lambda {
-        Lambda {
-            w: self.w().expect("valid view"),
-            x: self.x().expect("valid view"),
-        }
+        <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        Ok(Lambda {
+            w: self.w()?,
+            x: self.x()?,
+        })
     }
 }
 #[derive(
@@ -4617,21 +4862,28 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn to_owned(&self) -> Mu {
         <MuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        <MuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Mu {
-        Mu {
+        <MuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        Ok(Mu {
             y: {
-                let view = self.y().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.y()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             z: {
-                let view = self.z().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.z()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 pub type AliasMu = Mu;
@@ -4914,22 +5166,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn to_owned(&self) -> Nu {
         <NuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        <NuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Nu {
-        Nu {
+        <NuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        Ok(Nu {
             zz: {
-                let view = self.zz().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.zz()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            aaa: self.aaa().expect("valid view").to_owned().expect("valid view"),
-            bbb: self.bbb().expect("valid view").to_owned(),
-            test: self
-                .test()
-                .expect("valid view")
-                .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-        }
+            aaa: self.aaa()?.try_to_owned()?,
+            bbb: self.bbb()?.to_owned(),
+            test: match self.test()? {
+                Some(inner) => Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
+                None => None,
+            },
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -124,6 +124,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'
         <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for AliasOptionUnion {
+    type Ref<'a> = AliasOptionUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -259,6 +262,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
         <FirstUnionRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for FirstUnion {
+    type Ref<'a> = FirstUnionRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -420,6 +426,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
         <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestUnion {
+    type Ref<'a> = TestUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -578,6 +587,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
         <UnionARef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionA {
+    type Ref<'a> = UnionARef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -778,6 +790,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
         <UnionBRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionB {
+    type Ref<'a> = UnionBRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -928,6 +943,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
         <UnionCRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionC {
+    type Ref<'a> = UnionCRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -1063,6 +1081,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
         <UnionDRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionD {
+    type Ref<'a> = UnionDRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1312,6 +1333,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
         <AlphaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Alpha {
+    type Ref<'a> = AlphaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1532,6 +1556,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
         <BetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Beta {
+    type Ref<'a> = BetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
@@ -1808,6 +1835,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
         <GammaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Gamma {
+    type Ref<'a> = GammaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1987,6 +2017,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
         <DeltaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Delta {
+    type Ref<'a> = DeltaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
@@ -2425,6 +2458,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
         <EpsilonRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Epsilon {
+    type Ref<'a> = EpsilonRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -2696,6 +2732,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
         <ZetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Zeta {
+    type Ref<'a> = ZetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
@@ -3053,6 +3092,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
         <TestTypeRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestType {
+    type Ref<'a> = TestTypeRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3286,6 +3328,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
         <EtaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Eta {
+    type Ref<'a> = EtaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3515,6 +3560,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
         <ThetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Theta {
+    type Ref<'a> = ThetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
@@ -4196,6 +4244,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
         <IotaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Iota {
+    type Ref<'a> = IotaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4433,6 +4484,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
         <KappaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Kappa {
+    type Ref<'a> = KappaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
@@ -4692,6 +4746,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
         <LambdaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Lambda {
+    type Ref<'a> = LambdaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4865,6 +4922,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
         <MuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Mu {
+    type Ref<'a> = MuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
@@ -5169,6 +5229,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
         <NuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Nu {
+    type Ref<'a> = NuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_constants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_constants.rs
@@ -1251,7 +1251,7 @@ impl<'a> AlphaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1474,7 +1474,7 @@ impl<'a> BetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for BetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1949,7 +1949,7 @@ impl<'a> DeltaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -2983,7 +2983,7 @@ impl<'a> TestTypeRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3245,7 +3245,7 @@ impl<'a> EtaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for EtaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3478,7 +3478,7 @@ impl<'a> ThetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4402,7 +4402,7 @@ impl<'a> KappaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for KappaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4853,7 +4853,7 @@ impl<'a> MuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for MuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -5133,7 +5133,7 @@ impl<'a> NuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for NuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -161,15 +161,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportEntry> for ExportEntryRef<'a> {
     fn to_owned(&self) -> ExportEntry {
         <ExportEntryRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+        <ExportEntryRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ExportEntry {
-        ExportEntry {
-            value: self.value().expect("valid view"),
-            data: self.data().expect("valid view"),
-        }
+        <ExportEntryRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+        Ok(ExportEntry {
+            value: self.value()?,
+            data: self.data()?,
+        })
     }
 }
 #[derive(
@@ -351,25 +358,31 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportContainer> for ExportContainerRef<'a>
     fn to_owned(&self) -> ExportContainer {
         <ExportContainerRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ExportContainer, ssz::DecodeError> {
+        <ExportContainerRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportContainerRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ExportContainer {
-        ExportContainer {
+        <ExportContainerRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ExportContainer, ssz::DecodeError> {
+        Ok(ExportContainer {
             entries: {
-                let view = self.entries().expect("valid view");
-                let items: Result<Vec<_>, _> = view
+                let view = self.entries()?;
+                let items = view
                     .iter()
                     .map(|item_result| {
-                        item_result
-                            .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                     })
-                    .collect();
-                let items = items.expect("valid view");
-                ssz_types::VariableList::new(items).expect("valid view")
+                    .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                ssz_types::VariableList::new(items)
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
             },
-            name: self.name().expect("valid view"),
-        }
+            name: self.name()?,
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -96,7 +96,7 @@ impl<'a> ExportEntryRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -288,7 +288,7 @@ impl<'a> ExportContainerRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ExportContainerRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_container_in_list.rs
@@ -165,6 +165,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportEntry> for ExportEntryRef<'a> {
         <ExportEntryRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for ExportEntry {
+    type Ref<'a> = ExportEntryRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -361,6 +364,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportContainer> for ExportContainerRef<'a>
     fn try_to_owned(&self) -> Result<ExportContainer, ssz::DecodeError> {
         <ExportContainerRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for ExportContainer {
+    type Ref<'a> = ExportContainerRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -170,15 +170,22 @@ pub mod test_cross_entry_state {
         fn to_owned(&self) -> State {
             <StateRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+            <StateRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> StateRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> State {
-            State {
-                data: ssz_types::FixedBytes(self.data().expect("valid view").to_owned()),
-                counter: self.counter().expect("valid view"),
-            }
+            <StateRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+            Ok(State {
+                data: ssz_types::FixedBytes(self.data()?.to_owned()),
+                counter: self.counter()?,
+            })
         }
     }
 }
@@ -411,22 +418,27 @@ pub mod test_cross_entry_update {
         fn to_owned(&self) -> Update {
             <UpdateRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+            <UpdateRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> UpdateRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Update {
-            Update {
+            <UpdateRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+            Ok(Update {
                 state: {
-                    let view = self.state().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.state()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-                timestamp: self.timestamp().expect("valid view"),
-                updates: ssz_types::VariableList::new(
-                        self.updates().expect("valid view").to_owned(),
-                    )
-                    .expect("valid view"),
-            }
+                timestamp: self.timestamp()?,
+                updates: ssz_types::VariableList::new(self.updates()?.to_owned())
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+            })
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -174,6 +174,9 @@ pub mod test_cross_entry_state {
             <StateRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for State {
+        type Ref<'a> = StateRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> StateRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -421,6 +424,9 @@ pub mod test_cross_entry_update {
         fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
             <UpdateRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Update {
+        type Ref<'a> = UpdateRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> UpdateRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_flat.rs
@@ -104,7 +104,7 @@ pub mod test_cross_entry_state {
     }
     impl<'a> tree_hash::TreeHash for StateRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -339,7 +339,7 @@ pub mod test_cross_entry_update {
     }
     impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -137,6 +137,9 @@ pub mod tests {
                 fn to_owned(&self) -> CommonTypeA {
                     <CommonTypeARef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<CommonTypeA, ssz::DecodeError> {
+                    <CommonTypeARef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeARef<'a> {
@@ -145,9 +148,16 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> CommonTypeA {
-                    CommonTypeA {
-                        value: self.value().expect("valid view"),
-                    }
+                    <CommonTypeARef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<CommonTypeA, ssz::DecodeError> {
+                    Ok(CommonTypeA {
+                        value: self.value()?,
+                    })
                 }
             }
             #[derive(
@@ -276,6 +286,9 @@ pub mod tests {
                 fn to_owned(&self) -> CommonTypeB {
                     <CommonTypeBRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<CommonTypeB, ssz::DecodeError> {
+                    <CommonTypeBRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeBRef<'a> {
@@ -284,9 +297,16 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> CommonTypeB {
-                    CommonTypeB {
-                        value: self.value().expect("valid view"),
-                    }
+                    <CommonTypeBRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<CommonTypeB, ssz::DecodeError> {
+                    Ok(CommonTypeB {
+                        value: self.value()?,
+                    })
                 }
             }
         }
@@ -511,6 +531,9 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerA {
                     <ContainerARef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ContainerA, ssz::DecodeError> {
+                    <ContainerARef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerARef<'a> {
@@ -519,24 +542,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerA {
-                    ContainerA {
+                    <ContainerARef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ContainerA, ssz::DecodeError> {
+                    Ok(ContainerA {
                         field: {
-                            let view = self.field().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.field()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         list: {
-                            let view = self.list().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.list()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -81,7 +81,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for CommonTypeARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -233,7 +233,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for CommonTypeBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -452,7 +452,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_local.rs
@@ -141,6 +141,9 @@ pub mod tests {
                     <CommonTypeARef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for CommonTypeA {
+                type Ref<'a> = CommonTypeARef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeARef<'a> {
                 #[allow(
@@ -289,6 +292,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<CommonTypeB, ssz::DecodeError> {
                     <CommonTypeBRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for CommonTypeB {
+                type Ref<'a> = CommonTypeBRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> CommonTypeBRef<'a> {
@@ -534,6 +540,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ContainerA, ssz::DecodeError> {
                     <ContainerARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerA {
+                type Ref<'a> = ContainerARef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerARef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -185,6 +185,9 @@ pub mod tests {
                 fn to_owned(&self) -> State {
                     <StateRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+                    <StateRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StateRef<'a> {
@@ -193,12 +196,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> State {
-                    State {
-                        data: ssz_types::FixedBytes(
-                            self.data().expect("valid view").to_owned(),
-                        ),
-                        counter: self.counter().expect("valid view"),
-                    }
+                    <StateRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+                    Ok(State {
+                        data: ssz_types::FixedBytes(self.data()?.to_owned()),
+                        counter: self.counter()?,
+                    })
                 }
             }
         }
@@ -458,6 +466,9 @@ pub mod tests {
                 fn to_owned(&self) -> Update {
                     <UpdateRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+                    <UpdateRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UpdateRef<'a> {
@@ -466,17 +477,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Update {
-                    Update {
+                    <UpdateRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+                    Ok(Update {
                         state: {
-                            let view = self.state().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.state()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        timestamp: self.timestamp().expect("valid view"),
-                        updates: ssz_types::VariableList::new(
-                                self.updates().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                    }
+                        timestamp: self.timestamp()?,
+                        updates: ssz_types::VariableList::new(self.updates()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -189,6 +189,9 @@ pub mod tests {
                     <StateRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for State {
+                type Ref<'a> = StateRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StateRef<'a> {
                 #[allow(
@@ -469,6 +472,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
                     <UpdateRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Update {
+                type Ref<'a> = UpdateRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UpdateRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_nested.rs
@@ -115,7 +115,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for StateRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -378,7 +378,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -100,7 +100,7 @@ impl<'a> StateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for StateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -321,7 +321,7 @@ impl<'a> UpdateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -170,6 +170,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
         <StateRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for State {
+    type Ref<'a> = StateRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -403,6 +406,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
         <UpdateRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Update {
+    type Ref<'a> = UpdateRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_cross_entry_single.rs
@@ -166,15 +166,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
     fn to_owned(&self) -> State {
         <StateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        <StateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> State {
-        State {
-            data: ssz_types::FixedBytes(self.data().expect("valid view").to_owned()),
-            counter: self.counter().expect("valid view"),
-        }
+        <StateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        Ok(State {
+            data: ssz_types::FixedBytes(self.data()?.to_owned()),
+            counter: self.counter()?,
+        })
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -393,21 +400,26 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn to_owned(&self) -> Update {
         <UpdateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        <UpdateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Update {
-        Update {
+        <UpdateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        Ok(Update {
             state: {
-                let view = self.state().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.state()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            timestamp: self.timestamp().expect("valid view"),
-            updates: ssz_types::VariableList::new(
-                    self.updates().expect("valid view").to_owned(),
-                )
-                .expect("valid view"),
-        }
+            timestamp: self.timestamp()?,
+            updates: ssz_types::VariableList::new(self.updates()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
@@ -182,6 +182,9 @@ pub mod tests {
                 fn to_owned(&self) -> InnerData {
                     <InnerDataRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<InnerData, ssz::DecodeError> {
+                    <InnerDataRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerDataRef<'a> {
@@ -190,12 +193,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> InnerData {
-                    InnerData {
-                        value: self.value().expect("valid view"),
-                        hash: ssz_types::FixedBytes(
-                            self.hash().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <InnerDataRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<InnerData, ssz::DecodeError> {
+                    Ok(InnerData {
+                        value: self.value()?,
+                        hash: ssz_types::FixedBytes(self.hash()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -394,6 +402,9 @@ pub mod tests {
                 fn to_owned(&self) -> OuterContainer {
                     <OuterContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<OuterContainer, ssz::DecodeError> {
+                    <OuterContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OuterContainerRef<'a> {
@@ -402,24 +413,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> OuterContainer {
-                    OuterContainer {
+                    <OuterContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<OuterContainer, ssz::DecodeError> {
+                    Ok(OuterContainer {
                         inner: {
-                            let view = self.inner().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.inner()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         items: {
-                            let view = self.items().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.items()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
@@ -186,6 +186,9 @@ pub mod tests {
                     <InnerDataRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for InnerData {
+                type Ref<'a> = InnerDataRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InnerDataRef<'a> {
                 #[allow(
@@ -405,6 +408,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<OuterContainer, ssz::DecodeError> {
                     <OuterContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for OuterContainer {
+                type Ref<'a> = OuterContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OuterContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_custom_to_owned.rs
@@ -111,7 +111,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InnerDataRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -321,7 +321,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for OuterContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1700,7 +1700,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2237,7 +2237,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3435,7 +3435,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3726,7 +3726,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3980,7 +3980,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5014,7 +5014,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5531,7 +5531,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5848,7 +5848,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1521,6 +1542,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1763,6 +1787,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2082,6 +2109,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2279,6 +2309,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2782,6 +2815,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3112,6 +3148,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3515,6 +3554,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3771,6 +3813,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -4021,6 +4066,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4791,6 +4839,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -5050,6 +5101,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5356,6 +5410,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5546,6 +5603,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5895,6 +5955,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_default_nested.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1311,6 +1517,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1319,13 +1528,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -1546,6 +1760,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1554,14 +1771,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(
@@ -1854,6 +2078,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1862,17 +2089,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2042,6 +2276,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2050,10 +2287,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(
@@ -2534,6 +2778,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2542,19 +2789,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(
@@ -2855,6 +3109,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2863,24 +3120,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3247,6 +3511,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3255,24 +3522,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(
@@ -3492,6 +3767,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3500,20 +3778,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3733,6 +4018,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3741,19 +4029,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -4494,6 +4787,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4502,28 +4798,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(
@@ -4744,6 +5047,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4752,17 +5058,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -5039,6 +5352,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -5047,10 +5363,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -5220,6 +5543,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5228,16 +5554,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5559,6 +5892,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5567,22 +5903,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1700,7 +1700,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2237,7 +2237,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3435,7 +3435,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3726,7 +3726,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3980,7 +3980,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5014,7 +5014,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5531,7 +5531,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5848,7 +5848,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1521,6 +1542,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1763,6 +1787,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2082,6 +2109,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2279,6 +2309,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2782,6 +2815,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3112,6 +3148,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3515,6 +3554,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3771,6 +3813,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -4021,6 +4066,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4791,6 +4839,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -5050,6 +5101,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5356,6 +5410,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5546,6 +5603,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5895,6 +5955,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_default.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1311,6 +1517,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1319,13 +1528,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -1546,6 +1760,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1554,14 +1771,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(
@@ -1854,6 +2078,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1862,17 +2089,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2042,6 +2276,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2050,10 +2287,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(
@@ -2534,6 +2778,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2542,19 +2789,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(
@@ -2855,6 +3109,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2863,24 +3120,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3247,6 +3511,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3255,24 +3522,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(
@@ -3492,6 +3767,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3500,20 +3778,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3733,6 +4018,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3741,19 +4029,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -4494,6 +4787,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4502,28 +4798,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(
@@ -4744,6 +5047,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4752,17 +5058,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -5039,6 +5352,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -5047,10 +5363,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -5220,6 +5543,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5228,16 +5554,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5559,6 +5892,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5567,22 +5903,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1508,6 +1529,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1737,6 +1761,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2043,6 +2070,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2227,6 +2257,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2717,6 +2750,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3034,6 +3070,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3424,6 +3463,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3667,6 +3709,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -3904,6 +3949,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4661,6 +4709,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -4907,6 +4958,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5200,6 +5254,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5377,6 +5434,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5713,6 +5773,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1298,6 +1504,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1306,13 +1515,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -1520,6 +1734,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1528,14 +1745,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -1815,6 +2039,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1823,17 +2050,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -1990,6 +2224,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -1998,10 +2235,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -2469,6 +2713,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2477,19 +2724,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -2777,6 +3031,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2785,24 +3042,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -3156,6 +3420,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3164,24 +3431,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -3388,6 +3663,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3396,20 +3674,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -3616,6 +3901,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3624,19 +3912,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -4364,6 +4657,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4372,28 +4668,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -4601,6 +4904,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4609,17 +4915,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -4883,6 +5196,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -4891,10 +5207,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(Debug, std::clone::Clone, ssz_derive::Encode, ssz_derive::Decode)]
@@ -5051,6 +5374,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5059,16 +5385,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5377,6 +5710,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5385,22 +5721,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_derives_toml.rs
@@ -1442,7 +1442,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1674,7 +1674,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2185,7 +2185,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3344,7 +3344,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3622,7 +3622,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3863,7 +3863,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -4871,7 +4871,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5362,7 +5362,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5666,7 +5666,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -185,6 +185,9 @@ pub mod tests {
                 fn to_owned(&self) -> TypeA {
                     <TypeARef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TypeA, ssz::DecodeError> {
+                    <TypeARef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TypeARef<'a> {
@@ -193,13 +196,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TypeA {
-                    TypeA {
+                    <TypeARef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TypeA, ssz::DecodeError> {
+                    Ok(TypeA {
                         base: {
-                            let view = self.base().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.base()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        data: self.data().expect("valid view"),
-                    }
+                        data: self.data()?,
+                    })
                 }
             }
         }
@@ -442,6 +452,9 @@ pub mod tests {
                 fn to_owned(&self) -> TypeB {
                     <TypeBRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TypeB, ssz::DecodeError> {
+                    <TypeBRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TypeBRef<'a> {
@@ -450,17 +463,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TypeB {
-                    TypeB {
+                    <TypeBRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TypeB, ssz::DecodeError> {
+                    Ok(TypeB {
                         base: {
-                            let view = self.base().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.base()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         type_a: {
-                            let view = self.type_a().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.type_a()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        extra: self.extra().expect("valid view"),
-                    }
+                        extra: self.extra()?,
+                    })
                 }
             }
         }
@@ -600,6 +620,9 @@ pub mod tests {
                 fn to_owned(&self) -> BaseType {
                     <BaseTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BaseType, ssz::DecodeError> {
+                    <BaseTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BaseTypeRef<'a> {
@@ -608,9 +631,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BaseType {
-                    BaseType {
-                        value: self.value().expect("valid view"),
-                    }
+                    <BaseTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BaseType, ssz::DecodeError> {
+                    Ok(BaseType { value: self.value()? })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -115,7 +115,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TypeARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -370,7 +370,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TypeBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -570,7 +570,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BaseTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_diamond_dependency.rs
@@ -189,6 +189,9 @@ pub mod tests {
                     <TypeARef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TypeA {
+                type Ref<'a> = TypeARef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TypeARef<'a> {
                 #[allow(
@@ -456,6 +459,9 @@ pub mod tests {
                     <TypeBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TypeB {
+                type Ref<'a> = TypeBRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TypeBRef<'a> {
                 #[allow(
@@ -623,6 +629,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<BaseType, ssz::DecodeError> {
                     <BaseTypeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for BaseType {
+                type Ref<'a> = BaseTypeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BaseTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
@@ -105,6 +105,9 @@ pub mod tests {
                     <FooRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Foo {
+                type Ref<'a> = FooRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FooRef<'a> {
                 #[allow(
@@ -299,6 +302,9 @@ pub mod tests {
                     <PointWithBothRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for PointWithBoth {
+                type Ref<'a> = PointWithBothRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointWithBothRef<'a> {
                 #[allow(
@@ -451,6 +457,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestMerge, ssz::DecodeError> {
                     <TestMergeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestMerge {
+                type Ref<'a> = TestMergeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestMergeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
@@ -60,7 +60,7 @@ pub mod tests {
             impl<'a> FooRef<'a> {}
             impl<'a> tree_hash::TreeHash for FooRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -228,7 +228,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for PointWithBothRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -398,7 +398,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestMergeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_docstrings.rs
@@ -101,6 +101,9 @@ pub mod tests {
                 fn to_owned(&self) -> Foo {
                     <FooRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Foo, ssz::DecodeError> {
+                    <FooRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FooRef<'a> {
@@ -109,7 +112,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Foo {
-                    Foo {}
+                    <FooRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Foo, ssz::DecodeError> {
+                    Ok(Foo {})
                 }
             }
             /// This is a docstring that should come first.
@@ -285,6 +295,9 @@ pub mod tests {
                 fn to_owned(&self) -> PointWithBoth {
                     <PointWithBothRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<PointWithBoth, ssz::DecodeError> {
+                    <PointWithBothRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> PointWithBothRef<'a> {
@@ -293,10 +306,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> PointWithBoth {
-                    PointWithBoth {
-                        x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view"),
-                    }
+                    <PointWithBothRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<PointWithBoth, ssz::DecodeError> {
+                    Ok(PointWithBoth {
+                        x: self.x()?,
+                        y: self.y()?,
+                    })
                 }
             }
             /// First comes the docstring. It has multiple lines.
@@ -428,6 +448,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestMerge {
                     <TestMergeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestMerge, ssz::DecodeError> {
+                    <TestMergeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestMergeRef<'a> {
@@ -436,9 +459,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestMerge {
-                    TestMerge {
-                        field: self.field().expect("valid view"),
-                    }
+                    <TestMergeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestMerge, ssz::DecodeError> {
+                    Ok(TestMerge { field: self.field()? })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -65,6 +65,7 @@ impl<'a> AliasOptionUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> AliasOptionUnion {
         match self.selector() {
             0u8 => {
@@ -78,6 +79,27 @@ impl<'a> AliasOptionUnionRef<'a> {
             }
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                1u8 => {
+                    AliasOptionUnion::Selector1({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -97,6 +119,9 @@ impl<'a> ssz::view::SszTypeInfo for AliasOptionUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'a> {
     fn to_owned(&self) -> AliasOptionUnion {
         <AliasOptionUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -188,12 +213,29 @@ impl<'a> FirstUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> FirstUnion {
         match self.selector() {
             0u8 => FirstUnion::Selector0(self.as_selector0().expect("valid selector")),
             1u8 => FirstUnion::Selector1(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -213,6 +255,9 @@ impl<'a> ssz::view::SszTypeInfo for FirstUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn to_owned(&self) -> FirstUnion {
         <FirstUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        <FirstUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -320,6 +365,7 @@ impl<'a> TestUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestUnion {
         match self.selector() {
             0u8 => {
@@ -330,6 +376,26 @@ impl<'a> TestUnionRef<'a> {
             2u8 => TestUnion::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => {
+                    self.as_selector0()?;
+                    TestUnion::Selector0
+                }
+                1u8 => TestUnion::Selector1(self.as_selector1()?),
+                2u8 => TestUnion::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -349,6 +415,9 @@ impl<'a> ssz::view::SszTypeInfo for TestUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
     fn to_owned(&self) -> TestUnion {
         <TestUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -461,6 +530,7 @@ impl<'a> UnionARef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionA {
         match self.selector() {
             0u8 => UnionA::Selector0(self.as_selector0().expect("valid selector")),
@@ -468,6 +538,23 @@ impl<'a> UnionARef<'a> {
             2u8 => UnionA::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionA::Selector0(self.as_selector0()?),
+                1u8 => UnionA::Selector1(self.as_selector1()?),
+                2u8 => UnionA::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
@@ -487,6 +574,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionARef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn to_owned(&self) -> UnionA {
         <UnionARef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        <UnionARef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -617,6 +707,7 @@ impl<'a> UnionBRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionB {
         match self.selector() {
             0u8 => UnionB::Selector0(self.as_selector0().expect("valid selector")),
@@ -636,6 +727,34 @@ impl<'a> UnionBRef<'a> {
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionB::Selector0(self.as_selector0()?),
+                1u8 => {
+                    UnionB::UnionA({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                2u8 => UnionB::Selector2(self.as_selector2()?),
+                3u8 => {
+                    UnionB::Selector3({
+                        let view = self.as_selector3()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
+    }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -654,6 +773,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionBRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
     fn to_owned(&self) -> UnionB {
         <UnionBRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        <UnionBRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -759,12 +881,29 @@ impl<'a> UnionCRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionC {
         match self.selector() {
             0u8 => UnionC::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionC::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -784,6 +923,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionCRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
     fn to_owned(&self) -> UnionC {
         <UnionCRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        <UnionCRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -875,12 +1017,29 @@ impl<'a> UnionDRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionD {
         match self.selector() {
             0u8 => UnionD::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionD::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -900,6 +1059,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionDRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn to_owned(&self) -> UnionD {
         <UnionDRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        <UnionDRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1146,16 +1308,23 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
     fn to_owned(&self) -> Alpha {
         <AlphaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        <AlphaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Alpha {
-        Alpha {
-            a: self.a().expect("valid view"),
-            b: self.b().expect("valid view"),
-            c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
-        }
+        <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        Ok(Alpha {
+            a: self.a()?,
+            b: self.b()?,
+            c: ssz_types::FixedBytes(self.c()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -1360,17 +1529,24 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn to_owned(&self) -> Beta {
         <BetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        <BetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
-        Beta {
-            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
-                .expect("valid view"),
-            e: self.e().expect("valid view"),
-            f: self.f().expect("valid view"),
-        }
+        <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        Ok(Beta {
+            d: ssz_types::VariableList::new(self.d()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+            e: self.e()?,
+            f: self.f()?,
+        })
     }
 }
 #[derive(
@@ -1628,22 +1804,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
     fn to_owned(&self) -> Gamma {
         <GammaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        <GammaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Gamma {
-        Gamma {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        Ok(Gamma {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -1801,15 +1984,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn to_owned(&self) -> Delta {
         <DeltaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        <DeltaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Delta {
-        Delta {
-            z: self.z().expect("valid view"),
-            w: self.w().expect("valid view"),
-        }
+        <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        Ok(Delta {
+            z: self.z()?,
+            w: self.w()?,
+        })
     }
 }
 #[derive(
@@ -2231,24 +2421,31 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
     fn to_owned(&self) -> Epsilon {
         <EpsilonRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        <EpsilonRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Epsilon {
-        Epsilon {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        Ok(Epsilon {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-        }
+            i: self.i()?,
+            j: self.j()?,
+        })
     }
 }
 #[derive(
@@ -2496,29 +2693,36 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn to_owned(&self) -> Zeta {
         <ZetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        <ZetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Zeta {
-        Zeta {
-            u: match self.u().expect("valid view") {
+        <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        Ok(Zeta {
+            u: match self.u()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            v: match self.v().expect("valid view") {
+            v: match self.v()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -2845,29 +3049,35 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
     fn to_owned(&self) -> TestType {
         <TestTypeRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        <TestTypeRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestType {
-        TestType {
-            ccc: self.ccc().expect("valid view"),
-            ddd: self.ddd().expect("valid view"),
+        <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        Ok(TestType {
+            ccc: self.ccc()?,
+            ddd: self.ddd()?,
             eee: {
-                let view = self.eee().expect("valid view");
-                let items: Result<Vec<_>, _> = view
+                let view = self.eee()?;
+                let items = view
                     .iter()
                     .map(|item_result| {
-                        item_result
-                            .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                     })
-                    .collect();
-                let items = items.expect("valid view");
-                ssz_types::VariableList::new(items).expect("valid view")
+                    .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                ssz_types::VariableList::new(items)
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
             },
-            large_int_128: self.large_int_128().expect("valid view"),
-            large_int_256: self.large_int_256().expect("valid view"),
-        }
+            large_int_128: self.large_int_128()?,
+            large_int_256: self.large_int_256()?,
+        })
     }
 }
 #[derive(
@@ -3072,25 +3282,32 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
     fn to_owned(&self) -> Eta {
         <EtaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        <EtaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Eta {
-        Eta {
+        <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        Ok(Eta {
             l: {
-                let view = self.l().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.l()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             m: {
-                let view = self.m().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.m()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             n: {
-                let view = self.n().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.n()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 #[derive(
@@ -3295,22 +3512,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn to_owned(&self) -> Theta {
         <ThetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        <ThetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Theta {
-        Theta {
+        <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        Ok(Theta {
             o: {
-                let view = self.o().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.o()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             p: {
-                let view = self.p().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.p()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
-        }
+            q: ssz_types::FixedBytes(self.q()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -3968,33 +4192,40 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
     fn to_owned(&self) -> Iota {
         <IotaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        <IotaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Iota {
-        Iota {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        Ok(Iota {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-            r: match self.r().expect("valid view") {
+            i: self.i()?,
+            j: self.j()?,
+            r: match self.r()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            s: self.s().expect("valid view"),
-        }
+            s: self.s()?,
+        })
     }
 }
 #[derive(
@@ -4199,22 +4430,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn to_owned(&self) -> Kappa {
         <KappaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        <KappaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Kappa {
-        Kappa {
+        <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        Ok(Kappa {
             t: {
-                let view = self.t().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.t()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             u: {
-                let view = self.u().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.u()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            v: self.v().expect("valid view").to_owned(),
-        }
+            v: self.v()?.to_owned(),
+        })
     }
 }
 #[derive(
@@ -4450,15 +4688,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
     fn to_owned(&self) -> Lambda {
         <LambdaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        <LambdaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Lambda {
-        Lambda {
-            w: self.w().expect("valid view"),
-            x: self.x().expect("valid view"),
-        }
+        <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        Ok(Lambda {
+            w: self.w()?,
+            x: self.x()?,
+        })
     }
 }
 #[derive(
@@ -4617,21 +4862,28 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn to_owned(&self) -> Mu {
         <MuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        <MuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Mu {
-        Mu {
+        <MuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        Ok(Mu {
             y: {
-                let view = self.y().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.y()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             z: {
-                let view = self.z().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.z()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 pub type AliasMu = Mu;
@@ -4914,22 +5166,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn to_owned(&self) -> Nu {
         <NuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        <NuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Nu {
-        Nu {
+        <NuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        Ok(Nu {
             zz: {
-                let view = self.zz().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.zz()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            aaa: self.aaa().expect("valid view").to_owned().expect("valid view"),
-            bbb: self.bbb().expect("valid view").to_owned(),
-            test: self
-                .test()
-                .expect("valid view")
-                .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-        }
+            aaa: self.aaa()?.try_to_owned()?,
+            bbb: self.bbb()?.to_owned(),
+            test: match self.test()? {
+                Some(inner) => Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
+                None => None,
+            },
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -124,6 +124,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'
         <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for AliasOptionUnion {
+    type Ref<'a> = AliasOptionUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -259,6 +262,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
         <FirstUnionRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for FirstUnion {
+    type Ref<'a> = FirstUnionRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -420,6 +426,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
         <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestUnion {
+    type Ref<'a> = TestUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -578,6 +587,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
         <UnionARef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionA {
+    type Ref<'a> = UnionARef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -778,6 +790,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
         <UnionBRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionB {
+    type Ref<'a> = UnionBRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -928,6 +943,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
         <UnionCRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionC {
+    type Ref<'a> = UnionCRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -1063,6 +1081,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
         <UnionDRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionD {
+    type Ref<'a> = UnionDRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1312,6 +1333,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
         <AlphaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Alpha {
+    type Ref<'a> = AlphaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1532,6 +1556,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
         <BetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Beta {
+    type Ref<'a> = BetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
@@ -1808,6 +1835,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
         <GammaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Gamma {
+    type Ref<'a> = GammaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1987,6 +2017,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
         <DeltaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Delta {
+    type Ref<'a> = DeltaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
@@ -2425,6 +2458,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
         <EpsilonRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Epsilon {
+    type Ref<'a> = EpsilonRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -2696,6 +2732,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
         <ZetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Zeta {
+    type Ref<'a> = ZetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
@@ -3053,6 +3092,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
         <TestTypeRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestType {
+    type Ref<'a> = TestTypeRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3286,6 +3328,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
         <EtaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Eta {
+    type Ref<'a> = EtaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3515,6 +3560,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
         <ThetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Theta {
+    type Ref<'a> = ThetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
@@ -4196,6 +4244,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
         <IotaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Iota {
+    type Ref<'a> = IotaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4433,6 +4484,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
         <KappaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Kappa {
+    type Ref<'a> = KappaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
@@ -4692,6 +4746,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
         <LambdaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Lambda {
+    type Ref<'a> = LambdaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4865,6 +4922,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
         <MuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Mu {
+    type Ref<'a> = MuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
@@ -5169,6 +5229,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
         <NuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Nu {
+    type Ref<'a> = NuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_duplicate_entry.rs
@@ -1251,7 +1251,7 @@ impl<'a> AlphaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1474,7 +1474,7 @@ impl<'a> BetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for BetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1949,7 +1949,7 @@ impl<'a> DeltaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -2983,7 +2983,7 @@ impl<'a> TestTypeRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3245,7 +3245,7 @@ impl<'a> EtaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for EtaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3478,7 +3478,7 @@ impl<'a> ThetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4402,7 +4402,7 @@ impl<'a> KappaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for KappaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4853,7 +4853,7 @@ impl<'a> MuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for MuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -5133,7 +5133,7 @@ impl<'a> NuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for NuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -197,6 +197,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestExistingModule {
                     <TestExistingModuleRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestExistingModule, ssz::DecodeError> {
+                    <TestExistingModuleRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestExistingModuleRef<'a> {
@@ -205,13 +208,22 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestExistingModule {
-                    TestExistingModule {
+                    <TestExistingModuleRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<TestExistingModule, ssz::DecodeError> {
+                    Ok(TestExistingModule {
                         existing_field: {
-                            let view = self.existing_field().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.existing_field()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        slot: self.slot().expect("valid view"),
-                    }
+                        slot: self.slot()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -126,7 +126,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestExistingModuleRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_existing_rust_module.rs
@@ -201,6 +201,9 @@ pub mod tests {
                     <TestExistingModuleRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestExistingModule {
+                type Ref<'a> = TestExistingModuleRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestExistingModuleRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1700,7 +1700,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -2237,7 +2237,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3435,7 +3435,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3726,7 +3726,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EtaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -3980,7 +3980,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5014,7 +5014,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for KappaRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5531,7 +5531,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -5848,7 +5848,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NuRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -146,6 +146,9 @@ pub mod tests {
                     <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasOptionUnion {
+                type Ref<'a> = AliasOptionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -305,6 +308,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
                     <FirstUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FirstUnion {
+                type Ref<'a> = FirstUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -489,6 +495,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -678,6 +687,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
                     <UnionARef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionA {
+                type Ref<'a> = UnionARef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -911,6 +923,9 @@ pub mod tests {
                     <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionB {
+                type Ref<'a> = UnionBRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1091,6 +1106,9 @@ pub mod tests {
                     <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionC {
+                type Ref<'a> = UnionCRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -1250,6 +1268,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
                     <UnionDRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionD {
+                type Ref<'a> = UnionDRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1521,6 +1542,9 @@ pub mod tests {
                     <AlphaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Alpha {
+                type Ref<'a> = AlphaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
                 #[allow(
@@ -1763,6 +1787,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
                     <BetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Beta {
+                type Ref<'a> = BetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -2082,6 +2109,9 @@ pub mod tests {
                     <GammaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Gamma {
+                type Ref<'a> = GammaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
                 #[allow(
@@ -2279,6 +2309,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
                     <DeltaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Delta {
+                type Ref<'a> = DeltaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2782,6 +2815,9 @@ pub mod tests {
                     <EpsilonRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Epsilon {
+                type Ref<'a> = EpsilonRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
                 #[allow(
@@ -3112,6 +3148,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
                     <ZetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Zeta {
+                type Ref<'a> = ZetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -3515,6 +3554,9 @@ pub mod tests {
                     <TestTypeRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestType {
+                type Ref<'a> = TestTypeRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
                 #[allow(
@@ -3771,6 +3813,9 @@ pub mod tests {
                     <EtaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Eta {
+                type Ref<'a> = EtaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
                 #[allow(
@@ -4021,6 +4066,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
                     <ThetaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Theta {
+                type Ref<'a> = ThetaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -4791,6 +4839,9 @@ pub mod tests {
                     <IotaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Iota {
+                type Ref<'a> = IotaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
                 #[allow(
@@ -5050,6 +5101,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
                     <KappaRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Kappa {
+                type Ref<'a> = KappaRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -5356,6 +5410,9 @@ pub mod tests {
                     <LambdaRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Lambda {
+                type Ref<'a> = LambdaRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
                 #[allow(
@@ -5546,6 +5603,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
                     <MuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Mu {
+                type Ref<'a> = MuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5895,6 +5955,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
                     <NuRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Nu {
+                type Ref<'a> = NuRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_explicit_nested.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasOptionUnion {
                     match self.selector() {
                         0u8 => {
@@ -91,6 +95,32 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasOptionUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -111,6 +141,9 @@ pub mod tests {
             for AliasOptionUnionRef<'a> {
                 fn to_owned(&self) -> AliasOptionUnion {
                     <AliasOptionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+                    <AliasOptionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -212,6 +245,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> FirstUnion {
                     match self.selector() {
                         0u8 => {
@@ -226,6 +263,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                            1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -245,6 +301,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
                 fn to_owned(&self) -> FirstUnion {
                     <FirstUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+                    <FirstUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -362,6 +421,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -381,6 +444,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Selector0
+                            }
+                            1u8 => TestUnion::Selector1(self.as_selector1()?),
+                            2u8 => TestUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -399,6 +485,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -523,6 +612,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionA {
                     match self.selector() {
                         0u8 => {
@@ -543,6 +636,26 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionA::Selector0(self.as_selector0()?),
+                            1u8 => UnionA::Selector1(self.as_selector1()?),
+                            2u8 => UnionA::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -561,6 +674,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
                 fn to_owned(&self) -> UnionA {
                     <UnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+                    <UnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -710,6 +826,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionB {
                     match self.selector() {
                         0u8 => {
@@ -737,6 +857,37 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionB::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                UnionB::UnionA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => UnionB::Selector2(self.as_selector2()?),
+                            3u8 => {
+                                UnionB::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -755,6 +906,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
                 fn to_owned(&self) -> UnionB {
                     <UnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+                    <UnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -876,6 +1030,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionC {
                     match self.selector() {
                         0u8 => {
@@ -890,6 +1048,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -909,6 +1086,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
                 fn to_owned(&self) -> UnionC {
                     <UnionCRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+                    <UnionCRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -1010,6 +1190,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionD {
                     match self.selector() {
                         0u8 => {
@@ -1024,6 +1208,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                            1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -1043,6 +1246,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
                 fn to_owned(&self) -> UnionD {
                     <UnionDRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+                    <UnionDRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1311,6 +1517,9 @@ pub mod tests {
                 fn to_owned(&self) -> Alpha {
                     <AlphaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    <AlphaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AlphaRef<'a> {
@@ -1319,13 +1528,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Alpha {
-                    Alpha {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: ssz_types::FixedBytes(
-                            self.c().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+                    Ok(Alpha {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: ssz_types::FixedBytes(self.c()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -1546,6 +1760,9 @@ pub mod tests {
                 fn to_owned(&self) -> Beta {
                     <BetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    <BetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BetaRef<'a> {
@@ -1554,14 +1771,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Beta {
-                    Beta {
-                        d: ssz_types::VariableList::new(
-                                self.d().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        e: self.e().expect("valid view"),
-                        f: self.f().expect("valid view"),
-                    }
+                    <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+                    Ok(Beta {
+                        d: ssz_types::VariableList::new(self.d()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        e: self.e()?,
+                        f: self.f()?,
+                    })
                 }
             }
             #[derive(
@@ -1854,6 +2078,9 @@ pub mod tests {
                 fn to_owned(&self) -> Gamma {
                     <GammaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    <GammaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> GammaRef<'a> {
@@ -1862,17 +2089,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Gamma {
-                    Gamma {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+                    Ok(Gamma {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -2042,6 +2276,9 @@ pub mod tests {
                 fn to_owned(&self) -> Delta {
                     <DeltaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    <DeltaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DeltaRef<'a> {
@@ -2050,10 +2287,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Delta {
-                    Delta {
-                        z: self.z().expect("valid view"),
-                        w: self.w().expect("valid view"),
-                    }
+                    <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+                    Ok(Delta {
+                        z: self.z()?,
+                        w: self.w()?,
+                    })
                 }
             }
             #[derive(
@@ -2534,6 +2778,9 @@ pub mod tests {
                 fn to_owned(&self) -> Epsilon {
                     <EpsilonRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    <EpsilonRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EpsilonRef<'a> {
@@ -2542,19 +2789,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Epsilon {
-                    Epsilon {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+                    Ok(Epsilon {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                    }
+                        i: self.i()?,
+                        j: self.j()?,
+                    })
                 }
             }
             #[derive(
@@ -2855,6 +3109,9 @@ pub mod tests {
                 fn to_owned(&self) -> Zeta {
                     <ZetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    <ZetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ZetaRef<'a> {
@@ -2863,24 +3120,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Zeta {
-                    Zeta {
-                        u: match self.u().expect("valid view") {
+                    <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+                    Ok(Zeta {
+                        u: match self.u()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        v: match self.v().expect("valid view") {
+                        v: match self.v()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3247,6 +3511,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestType {
                     <TestTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    <TestTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestTypeRef<'a> {
@@ -3255,24 +3522,32 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestType {
-                    TestType {
-                        ccc: self.ccc().expect("valid view"),
-                        ddd: self.ddd().expect("valid view"),
+                    <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+                    Ok(TestType {
+                        ccc: self.ccc()?,
+                        ddd: self.ddd()?,
                         eee: {
-                            let view = self.eee().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.eee()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        large_int_128: self.large_int_128().expect("valid view"),
-                        large_int_256: self.large_int_256().expect("valid view"),
-                    }
+                        large_int_128: self.large_int_128()?,
+                        large_int_256: self.large_int_256()?,
+                    })
                 }
             }
             #[derive(
@@ -3492,6 +3767,9 @@ pub mod tests {
                 fn to_owned(&self) -> Eta {
                     <EtaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    <EtaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EtaRef<'a> {
@@ -3500,20 +3778,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Eta {
-                    Eta {
+                    <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+                    Ok(Eta {
                         l: {
-                            let view = self.l().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.l()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         m: {
-                            let view = self.m().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.m()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         n: {
-                            let view = self.n().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.n()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             #[derive(
@@ -3733,6 +4018,9 @@ pub mod tests {
                 fn to_owned(&self) -> Theta {
                     <ThetaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    <ThetaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ThetaRef<'a> {
@@ -3741,19 +4029,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Theta {
-                    Theta {
+                    <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+                    Ok(Theta {
                         o: {
-                            let view = self.o().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.o()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         p: {
-                            let view = self.p().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.p()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        q: ssz_types::FixedBytes(
-                            self.q().expect("valid view").to_owned(),
-                        ),
-                    }
+                        q: ssz_types::FixedBytes(self.q()?.to_owned()),
+                    })
                 }
             }
             #[derive(
@@ -4494,6 +4787,9 @@ pub mod tests {
                 fn to_owned(&self) -> Iota {
                     <IotaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    <IotaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> IotaRef<'a> {
@@ -4502,28 +4798,35 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Iota {
-                    Iota {
-                        g: self.g().expect("valid view"),
-                        h: match self.h().expect("valid view") {
+                    <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+                    Ok(Iota {
+                        g: self.g()?,
+                        h: match self.h()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        i: self.i().expect("valid view"),
-                        j: self.j().expect("valid view"),
-                        r: match self.r().expect("valid view") {
+                        i: self.i()?,
+                        j: self.j()?,
+                        r: match self.r()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                        s: self.s().expect("valid view"),
-                    }
+                        s: self.s()?,
+                    })
                 }
             }
             #[derive(
@@ -4744,6 +5047,9 @@ pub mod tests {
                 fn to_owned(&self) -> Kappa {
                     <KappaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    <KappaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> KappaRef<'a> {
@@ -4752,17 +5058,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Kappa {
-                    Kappa {
+                    <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+                    Ok(Kappa {
                         t: {
-                            let view = self.t().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.t()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         u: {
-                            let view = self.u().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.u()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        v: self.v().expect("valid view").to_owned(),
-                    }
+                        v: self.v()?.to_owned(),
+                    })
                 }
             }
             #[derive(
@@ -5039,6 +5352,9 @@ pub mod tests {
                 fn to_owned(&self) -> Lambda {
                     <LambdaRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    <LambdaRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> LambdaRef<'a> {
@@ -5047,10 +5363,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Lambda {
-                    Lambda {
-                        w: self.w().expect("valid view"),
-                        x: self.x().expect("valid view"),
-                    }
+                    <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+                    Ok(Lambda {
+                        w: self.w()?,
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -5220,6 +5543,9 @@ pub mod tests {
                 fn to_owned(&self) -> Mu {
                     <MuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    <MuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MuRef<'a> {
@@ -5228,16 +5554,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Mu {
-                    Mu {
+                    <MuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+                    Ok(Mu {
                         y: {
-                            let view = self.y().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.y()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         z: {
-                            let view = self.z().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.z()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             pub type AliasMu = Mu;
@@ -5559,6 +5892,9 @@ pub mod tests {
                 fn to_owned(&self) -> Nu {
                     <NuRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    <NuRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NuRef<'a> {
@@ -5567,22 +5903,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Nu {
-                    Nu {
+                    <NuRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+                    Ok(Nu {
                         zz: {
-                            let view = self.zz().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.zz()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        aaa: self
-                            .aaa()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        bbb: self.bbb().expect("valid view").to_owned(),
-                        test: self
-                            .test()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        aaa: self.aaa()?.try_to_owned()?,
+                        bbb: self.bbb()?.to_owned(),
+                        test: match self.test()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_external.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external.rs
@@ -529,7 +529,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ExternalContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_external.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external.rs
@@ -174,6 +174,9 @@ pub mod tests {
                     <ExternalUnionARef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ExternalUnionA {
+                type Ref<'a> = ExternalUnionARef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for ExternalUnionARef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -375,6 +378,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ExternalUnionB, ssz::DecodeError> {
                     <ExternalUnionBRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ExternalUnionB {
+                type Ref<'a> = ExternalUnionBRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for ExternalUnionBRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -598,6 +604,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ExternalContainer, ssz::DecodeError> {
                     <ExternalContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ExternalContainer {
+                type Ref<'a> = ExternalContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExternalContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_external.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external.rs
@@ -92,6 +92,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> ExternalUnionA {
                     match self.selector() {
                         0u8 => {
@@ -113,6 +117,39 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ExternalUnionA, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                ExternalUnionA::Selector0
+                            }
+                            1u8 => {
+                                ExternalUnionA::A({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => {
+                                ExternalUnionA::B({
+                                    let view = self.as_selector2()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalUnionARef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -132,6 +169,9 @@ pub mod tests {
             for ExternalUnionARef<'a> {
                 fn to_owned(&self) -> ExternalUnionA {
                     <ExternalUnionARef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<ExternalUnionA, ssz::DecodeError> {
+                    <ExternalUnionARef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for ExternalUnionARef<'a> {
@@ -254,6 +294,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> ExternalUnionB {
                     match self.selector() {
                         0u8 => {
@@ -275,6 +319,39 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ExternalUnionB, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                ExternalUnionB::Selector0
+                            }
+                            1u8 => {
+                                ExternalUnionB::TestA({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => {
+                                ExternalUnionB::TestB({
+                                    let view = self.as_selector2()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalUnionBRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -294,6 +371,9 @@ pub mod tests {
             for ExternalUnionBRef<'a> {
                 fn to_owned(&self) -> ExternalUnionB {
                     <ExternalUnionBRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<ExternalUnionB, ssz::DecodeError> {
+                    <ExternalUnionBRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for ExternalUnionBRef<'a> {
@@ -515,6 +595,9 @@ pub mod tests {
                 fn to_owned(&self) -> ExternalContainer {
                     <ExternalContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ExternalContainer, ssz::DecodeError> {
+                    <ExternalContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExternalContainerRef<'a> {
@@ -523,16 +606,25 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ExternalContainer {
-                    ExternalContainer {
+                    <ExternalContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ExternalContainer, ssz::DecodeError> {
+                    Ok(ExternalContainer {
                         field_a: {
-                            let view = self.field_a().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.field_a()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         field_b: {
-                            let view = self.field_b().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.field_b()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container.rs
@@ -189,6 +189,9 @@ pub mod tests {
                     <BlockCommitmentRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BlockCommitment {
+                type Ref<'a> = BlockCommitmentRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 #[allow(
@@ -403,6 +406,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<BlockRange, ssz::DecodeError> {
                     <BlockRangeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for BlockRange {
+                type Ref<'a> = BlockRangeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockRangeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_external_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container.rs
@@ -113,7 +113,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -330,7 +330,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BlockRangeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_external_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container.rs
@@ -185,6 +185,9 @@ pub mod tests {
                 fn to_owned(&self) -> BlockCommitment {
                     <BlockCommitmentRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    <BlockCommitmentRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
@@ -193,12 +196,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BlockCommitment {
-                    BlockCommitment {
-                        height: self.height().expect("valid view"),
-                        block_hash: ssz_types::FixedBytes(
-                            self.block_hash().expect("valid view").to_owned(),
-                        ),
-                    }
+                    <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    Ok(BlockCommitment {
+                        height: self.height()?,
+                        block_hash: ssz_types::FixedBytes(self.block_hash()?.to_owned()),
+                    })
                 }
             }
         }
@@ -392,6 +400,9 @@ pub mod tests {
                 fn to_owned(&self) -> BlockRange {
                     <BlockRangeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BlockRange, ssz::DecodeError> {
+                    <BlockRangeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockRangeRef<'a> {
@@ -400,16 +411,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BlockRange {
-                    BlockRange {
+                    <BlockRangeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BlockRange, ssz::DecodeError> {
+                    Ok(BlockRange {
                         start: {
-                            let view = self.start().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.start()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         end: {
-                            let view = self.end().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.end()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -60,6 +60,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> PendingInputEntry {
                     match self.selector() {
                         0u8 => {
@@ -70,6 +74,31 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<PendingInputEntry, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                PendingInputEntry::Deposit({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for PendingInputEntryRef<'a> {
@@ -90,6 +119,9 @@ pub mod tests {
             for PendingInputEntryRef<'a> {
                 fn to_owned(&self) -> PendingInputEntry {
                     <PendingInputEntryRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<PendingInputEntry, ssz::DecodeError> {
+                    <PendingInputEntryRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for PendingInputEntryRef<'a> {
@@ -274,6 +306,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestContainer {
                     <TestContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    <TestContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {
@@ -282,20 +317,28 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestContainer {
-                    TestContainer {
+                    <TestContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    Ok(TestContainer {
                         pending_inputs: {
-                            let view = self.pending_inputs().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.pending_inputs()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -238,7 +238,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_container_union.rs
@@ -124,6 +124,9 @@ pub mod tests {
                     <PendingInputEntryRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for PendingInputEntry {
+                type Ref<'a> = PendingInputEntryRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for PendingInputEntryRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -309,6 +312,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
                     <TestContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestContainer {
+                type Ref<'a> = TestContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -364,7 +364,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ExternalPragmaTestRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -523,6 +523,9 @@ pub mod tests {
                     <ExternalPragmaTestRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ExternalPragmaTest {
+                type Ref<'a> = ExternalPragmaTestRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExternalPragmaTestRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_pragma.rs
@@ -519,6 +519,9 @@ pub mod tests {
                 fn to_owned(&self) -> ExternalPragmaTest {
                     <ExternalPragmaTestRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ExternalPragmaTest, ssz::DecodeError> {
+                    <ExternalPragmaTestRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExternalPragmaTestRef<'a> {
@@ -527,45 +530,52 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ExternalPragmaTest {
-                    ExternalPragmaTest {
+                    <ExternalPragmaTestRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ExternalPragmaTest, ssz::DecodeError> {
+                    Ok(ExternalPragmaTest {
                         state: {
-                            let view = self.state().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.state()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         balance: {
-                            let view = self.balance().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.balance()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        headers: self
-                            .headers()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
+                        headers: self.headers()?.try_to_owned()?,
                         transactions: {
-                            let view = self.transactions().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.transactions()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
                         account_ids: {
-                            let view = self.account_ids().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.account_ids()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -285,6 +285,9 @@ pub mod tests {
                     <ContainerWithExternalRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ContainerWithExternal {
+                type Ref<'a> = ContainerWithExternalRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithExternalRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -178,7 +178,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerWithExternalRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_external_ref_variants.rs
@@ -279,6 +279,11 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerWithExternal {
                     <ContainerWithExternalRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithExternal, ssz::DecodeError> {
+                    <ContainerWithExternalRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithExternalRef<'a> {
@@ -287,28 +292,39 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerWithExternal {
-                    ContainerWithExternal {
+                    <ContainerWithExternalRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithExternal, ssz::DecodeError> {
+                    Ok(ContainerWithExternal {
                         payload: {
-                            let view = self.payload().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.payload()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         account_id: {
-                            let view = self.account_id().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.account_id()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         messages: {
-                            let view = self.messages().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.messages()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -66,6 +66,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> AliasOptionUnion {
             match self.selector() {
                 0u8 => {
@@ -81,6 +82,27 @@ pub mod test_1 {
                 }
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                    1u8 => {
+                        AliasOptionUnion::Selector1({
+                            let view = self.as_selector1()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                        })
+                    }
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -100,6 +122,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'a> {
         fn to_owned(&self) -> AliasOptionUnion {
             <AliasOptionUnionRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+            <AliasOptionUnionRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -191,6 +216,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> FirstUnion {
             match self.selector() {
                 0u8 => {
@@ -201,6 +227,22 @@ pub mod test_1 {
                 }
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                    1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -220,6 +262,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
         fn to_owned(&self) -> FirstUnion {
             <FirstUnionRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+            <FirstUnionRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -327,6 +372,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> TestUnion {
             match self.selector() {
                 0u8 => {
@@ -337,6 +383,26 @@ pub mod test_1 {
                 2u8 => TestUnion::Selector2(self.as_selector2().expect("valid selector")),
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => {
+                        self.as_selector0()?;
+                        TestUnion::Selector0
+                    }
+                    1u8 => TestUnion::Selector1(self.as_selector1()?),
+                    2u8 => TestUnion::Selector2(self.as_selector2()?),
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -356,6 +422,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
         fn to_owned(&self) -> TestUnion {
             <TestUnionRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+            <TestUnionRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -468,6 +537,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> UnionA {
             match self.selector() {
                 0u8 => UnionA::Selector0(self.as_selector0().expect("valid selector")),
@@ -475,6 +545,23 @@ pub mod test_1 {
                 2u8 => UnionA::Selector2(self.as_selector2().expect("valid selector")),
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => UnionA::Selector0(self.as_selector0()?),
+                    1u8 => UnionA::Selector1(self.as_selector1()?),
+                    2u8 => UnionA::Selector2(self.as_selector2()?),
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
@@ -494,6 +581,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
         fn to_owned(&self) -> UnionA {
             <UnionARef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+            <UnionARef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -624,6 +714,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> UnionB {
             match self.selector() {
                 0u8 => UnionB::Selector0(self.as_selector0().expect("valid selector")),
@@ -643,6 +734,34 @@ pub mod test_1 {
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => UnionB::Selector0(self.as_selector0()?),
+                    1u8 => {
+                        UnionB::UnionA({
+                            let view = self.as_selector1()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                        })
+                    }
+                    2u8 => UnionB::Selector2(self.as_selector2()?),
+                    3u8 => {
+                        UnionB::Selector3({
+                            let view = self.as_selector3()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                        })
+                    }
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
+        }
     }
     impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
         fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -661,6 +780,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
         fn to_owned(&self) -> UnionB {
             <UnionBRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+            <UnionBRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -766,6 +888,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> UnionC {
             match self.selector() {
                 0u8 => {
@@ -776,6 +899,22 @@ pub mod test_1 {
                 }
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                    1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -795,6 +934,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
         fn to_owned(&self) -> UnionC {
             <UnionCRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+            <UnionCRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -886,6 +1028,7 @@ pub mod test_1 {
             }
             ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
         }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> UnionD {
             match self.selector() {
                 0u8 => {
@@ -896,6 +1039,22 @@ pub mod test_1 {
                 }
                 _ => panic!("Invalid union selector: {}", self.selector()),
             }
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+            Ok(
+                match self.selector() {
+                    0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                    1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                    other => {
+                        return Err(
+                            ssz::DecodeError::BytesInvalid(
+                                format!("Invalid union selector: {}", other),
+                            ),
+                        );
+                    }
+                },
+            )
         }
     }
     impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -915,6 +1074,9 @@ pub mod test_1 {
     impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
         fn to_owned(&self) -> UnionD {
             <UnionDRef<'a>>::to_owned(self)
+        }
+        fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+            <UnionDRef<'a>>::try_to_owned(self)
         }
     }
     impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1162,16 +1324,23 @@ pub mod test_1 {
         fn to_owned(&self) -> Alpha {
             <AlphaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+            <AlphaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> AlphaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Alpha {
-            Alpha {
-                a: self.a().expect("valid view"),
-                b: self.b().expect("valid view"),
-                c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
-            }
+            <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+            Ok(Alpha {
+                a: self.a()?,
+                b: self.b()?,
+                c: ssz_types::FixedBytes(self.c()?.to_owned()),
+            })
         }
     }
     #[derive(
@@ -1376,17 +1545,24 @@ pub mod test_1 {
         fn to_owned(&self) -> Beta {
             <BetaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+            <BetaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BetaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Beta {
-            Beta {
-                d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
-                    .expect("valid view"),
-                e: self.e().expect("valid view"),
-                f: self.f().expect("valid view"),
-            }
+            <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+            Ok(Beta {
+                d: ssz_types::VariableList::new(self.d()?.to_owned())
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+                e: self.e()?,
+                f: self.f()?,
+            })
         }
     }
     #[derive(
@@ -1648,22 +1824,29 @@ pub mod test_1 {
         fn to_owned(&self) -> Gamma {
             <GammaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+            <GammaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> GammaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Gamma {
-            Gamma {
-                g: self.g().expect("valid view"),
-                h: match self.h().expect("valid view") {
+            <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+            Ok(Gamma {
+                g: self.g()?,
+                h: match self.h()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-            }
+            })
         }
     }
     #[derive(
@@ -1822,15 +2005,22 @@ pub mod test_1 {
         fn to_owned(&self) -> Delta {
             <DeltaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+            <DeltaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> DeltaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Delta {
-            Delta {
-                z: self.z().expect("valid view"),
-                w: self.w().expect("valid view"),
-            }
+            <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+            Ok(Delta {
+                z: self.z()?,
+                w: self.w()?,
+            })
         }
     }
     #[derive(
@@ -2256,24 +2446,31 @@ pub mod test_1 {
         fn to_owned(&self) -> Epsilon {
             <EpsilonRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+            <EpsilonRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EpsilonRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Epsilon {
-            Epsilon {
-                g: self.g().expect("valid view"),
-                h: match self.h().expect("valid view") {
+            <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+            Ok(Epsilon {
+                g: self.g()?,
+                h: match self.h()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-                i: self.i().expect("valid view"),
-                j: self.j().expect("valid view"),
-            }
+                i: self.i()?,
+                j: self.j()?,
+            })
         }
     }
     #[derive(
@@ -2527,29 +2724,36 @@ pub mod test_1 {
         fn to_owned(&self) -> Zeta {
             <ZetaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+            <ZetaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> ZetaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Zeta {
-            Zeta {
-                u: match self.u().expect("valid view") {
+            <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+            Ok(Zeta {
+                u: match self.u()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-                v: match self.v().expect("valid view") {
+                v: match self.v()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-            }
+            })
         }
     }
     #[derive(
@@ -2883,29 +3087,35 @@ pub mod test_1 {
         fn to_owned(&self) -> TestType {
             <TestTypeRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+            <TestTypeRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> TestTypeRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> TestType {
-            TestType {
-                ccc: self.ccc().expect("valid view"),
-                ddd: self.ddd().expect("valid view"),
+            <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+            Ok(TestType {
+                ccc: self.ccc()?,
+                ddd: self.ddd()?,
                 eee: {
-                    let view = self.eee().expect("valid view");
-                    let items: Result<Vec<_>, _> = view
+                    let view = self.eee()?;
+                    let items = view
                         .iter()
                         .map(|item_result| {
-                            item_result
-                                .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                         })
-                        .collect();
-                    let items = items.expect("valid view");
-                    ssz_types::VariableList::new(items).expect("valid view")
+                        .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                    ssz_types::VariableList::new(items)
+                        .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
                 },
-                large_int_128: self.large_int_128().expect("valid view"),
-                large_int_256: self.large_int_256().expect("valid view"),
-            }
+                large_int_128: self.large_int_128()?,
+                large_int_256: self.large_int_256()?,
+            })
         }
     }
     #[derive(
@@ -3110,25 +3320,32 @@ pub mod test_1 {
         fn to_owned(&self) -> Eta {
             <EtaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+            <EtaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EtaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Eta {
-            Eta {
+            <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+            Ok(Eta {
                 l: {
-                    let view = self.l().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.l()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
                 m: {
-                    let view = self.m().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.m()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
                 n: {
-                    let view = self.n().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.n()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-            }
+            })
         }
     }
     #[derive(
@@ -3333,22 +3550,29 @@ pub mod test_1 {
         fn to_owned(&self) -> Theta {
             <ThetaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+            <ThetaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> ThetaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Theta {
-            Theta {
+            <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+            Ok(Theta {
                 o: {
-                    let view = self.o().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.o()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
                 p: {
-                    let view = self.p().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.p()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-                q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
-            }
+                q: ssz_types::FixedBytes(self.q()?.to_owned()),
+            })
         }
     }
     #[derive(
@@ -4010,33 +4234,40 @@ pub mod test_1 {
         fn to_owned(&self) -> Iota {
             <IotaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+            <IotaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> IotaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Iota {
-            Iota {
-                g: self.g().expect("valid view"),
-                h: match self.h().expect("valid view") {
+            <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+            Ok(Iota {
+                g: self.g()?,
+                h: match self.h()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-                i: self.i().expect("valid view"),
-                j: self.j().expect("valid view"),
-                r: match self.r().expect("valid view") {
+                i: self.i()?,
+                j: self.j()?,
+                r: match self.r()? {
                     ssz_types::Optional::Some(inner) => {
                         ssz_types::Optional::Some(
-                            ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                         )
                     }
                     ssz_types::Optional::None => ssz_types::Optional::None,
                 },
-                s: self.s().expect("valid view"),
-            }
+                s: self.s()?,
+            })
         }
     }
     #[derive(
@@ -4242,22 +4473,29 @@ pub mod test_1 {
         fn to_owned(&self) -> Kappa {
             <KappaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+            <KappaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> KappaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Kappa {
-            Kappa {
+            <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+            Ok(Kappa {
                 t: {
-                    let view = self.t().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.t()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
                 u: {
-                    let view = self.u().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.u()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-                v: self.v().expect("valid view").to_owned(),
-            }
+                v: self.v()?.to_owned(),
+            })
         }
     }
     #[derive(
@@ -4503,15 +4741,22 @@ pub mod test_1 {
         fn to_owned(&self) -> Lambda {
             <LambdaRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+            <LambdaRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> LambdaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Lambda {
-            Lambda {
-                w: self.w().expect("valid view"),
-                x: self.x().expect("valid view"),
-            }
+            <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+            Ok(Lambda {
+                w: self.w()?,
+                x: self.x()?,
+            })
         }
     }
     #[derive(
@@ -4670,21 +4915,28 @@ pub mod test_1 {
         fn to_owned(&self) -> Mu {
             <MuRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+            <MuRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> MuRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Mu {
-            Mu {
+            <MuRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+            Ok(Mu {
                 y: {
-                    let view = self.y().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.y()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
                 z: {
-                    let view = self.z().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.z()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-            }
+            })
         }
     }
     pub type AliasMu = Mu;
@@ -4975,23 +5227,32 @@ pub mod test_1 {
         fn to_owned(&self) -> Nu {
             <NuRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+            <NuRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> NuRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> Nu {
-            Nu {
+            <NuRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+            Ok(Nu {
                 zz: {
-                    let view = self.zz().expect("valid view");
-                    ssz_types::view::ToOwnedSsz::to_owned(&view)
+                    let view = self.zz()?;
+                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                 },
-                aaa: self.aaa().expect("valid view").to_owned().expect("valid view"),
-                bbb: self.bbb().expect("valid view").to_owned(),
-                test: self
-                    .test()
-                    .expect("valid view")
-                    .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-            }
+                aaa: self.aaa()?.try_to_owned()?,
+                bbb: self.bbb()?.to_owned(),
+                test: match self.test()? {
+                    Some(inner) => {
+                        Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                    }
+                    None => None,
+                },
+            })
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -127,6 +127,9 @@ pub mod test_1 {
             <AliasOptionUnionRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for AliasOptionUnion {
+        type Ref<'a> = AliasOptionUnionRef<'a>;
+    }
     impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
             tree_hash::TreeHashType::Vector
@@ -266,6 +269,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
             <FirstUnionRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for FirstUnion {
+        type Ref<'a> = FirstUnionRef<'a>;
     }
     impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -427,6 +433,9 @@ pub mod test_1 {
             <TestUnionRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for TestUnion {
+        type Ref<'a> = TestUnionRef<'a>;
+    }
     impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
             tree_hash::TreeHashType::Vector
@@ -585,6 +594,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
             <UnionARef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for UnionA {
+        type Ref<'a> = UnionARef<'a>;
     }
     impl<'a> tree_hash::TreeHash for UnionARef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -785,6 +797,9 @@ pub mod test_1 {
             <UnionBRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for UnionB {
+        type Ref<'a> = UnionBRef<'a>;
+    }
     impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
             tree_hash::TreeHashType::Vector
@@ -939,6 +954,9 @@ pub mod test_1 {
             <UnionCRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for UnionC {
+        type Ref<'a> = UnionCRef<'a>;
+    }
     impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
             tree_hash::TreeHashType::Vector
@@ -1078,6 +1096,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
             <UnionDRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for UnionD {
+        type Ref<'a> = UnionDRef<'a>;
     }
     impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1328,6 +1349,9 @@ pub mod test_1 {
             <AlphaRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Alpha {
+        type Ref<'a> = AlphaRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> AlphaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1548,6 +1572,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
             <BetaRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Beta {
+        type Ref<'a> = BetaRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BetaRef<'a> {
@@ -1828,6 +1855,9 @@ pub mod test_1 {
             <GammaRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Gamma {
+        type Ref<'a> = GammaRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> GammaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -2008,6 +2038,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
             <DeltaRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Delta {
+        type Ref<'a> = DeltaRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> DeltaRef<'a> {
@@ -2450,6 +2483,9 @@ pub mod test_1 {
             <EpsilonRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Epsilon {
+        type Ref<'a> = EpsilonRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EpsilonRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -2727,6 +2763,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
             <ZetaRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Zeta {
+        type Ref<'a> = ZetaRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> ZetaRef<'a> {
@@ -3091,6 +3130,9 @@ pub mod test_1 {
             <TestTypeRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for TestType {
+        type Ref<'a> = TestTypeRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> TestTypeRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3324,6 +3366,9 @@ pub mod test_1 {
             <EtaRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Eta {
+        type Ref<'a> = EtaRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> EtaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3553,6 +3598,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
             <ThetaRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Theta {
+        type Ref<'a> = ThetaRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> ThetaRef<'a> {
@@ -4238,6 +4286,9 @@ pub mod test_1 {
             <IotaRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Iota {
+        type Ref<'a> = IotaRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> IotaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4476,6 +4527,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
             <KappaRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Kappa {
+        type Ref<'a> = KappaRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> KappaRef<'a> {
@@ -4745,6 +4799,9 @@ pub mod test_1 {
             <LambdaRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for Lambda {
+        type Ref<'a> = LambdaRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> LambdaRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4918,6 +4975,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
             <MuRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Mu {
+        type Ref<'a> = MuRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> MuRef<'a> {
@@ -5230,6 +5290,9 @@ pub mod test_1 {
         fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
             <NuRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for Nu {
+        type Ref<'a> = NuRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_flat_modules.rs
@@ -1266,7 +1266,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -1490,7 +1490,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for BetaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -1969,7 +1969,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -3020,7 +3020,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -3283,7 +3283,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for EtaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -3516,7 +3516,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -4444,7 +4444,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for KappaRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -4906,7 +4906,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for MuRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -5194,7 +5194,7 @@ pub mod test_1 {
     }
     impl<'a> tree_hash::TreeHash for NuRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_import.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_import.rs
@@ -1131,7 +1131,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ProfileInehritanceRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::Container
+                    tree_hash::TreeHashType::StableContainer
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Profile should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_import.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_import.rs
@@ -74,6 +74,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasUnionUnion {
                     match self.selector() {
                         0u8 => {
@@ -89,6 +93,30 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AliasUnionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AliasUnionUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                AliasUnionUnion::AliasUnion({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasUnionUnionRef<'a> {
@@ -109,6 +137,9 @@ pub mod tests {
             for AliasUnionUnionRef<'a> {
                 fn to_owned(&self) -> AliasUnionUnion {
                     <AliasUnionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasUnionUnion, ssz::DecodeError> {
+                    <AliasUnionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasUnionUnionRef<'a> {
@@ -427,6 +458,11 @@ pub mod tests {
                 fn to_owned(&self) -> StableContainerClass {
                     <StableContainerClassRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<StableContainerClass, ssz::DecodeError> {
+                    <StableContainerClassRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
@@ -435,17 +471,27 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> StableContainerClass {
-                    StableContainerClass {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <StableContainerClassRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<StableContainerClass, ssz::DecodeError> {
+                    Ok(StableContainerClass {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
         }
@@ -537,6 +583,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AliasUnionUnion {
                     match self.selector() {
                         0u8 => {
@@ -557,6 +607,34 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AliasUnionUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                AliasUnionUnion::Selector0
+                            }
+                            1u8 => AliasUnionUnion::AliasUint8(self.as_selector1()?),
+                            2u8 => {
+                                AliasUnionUnion::AliasUnion({
+                                    let view = self.as_selector2()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for AliasUnionUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -576,6 +654,9 @@ pub mod tests {
             for AliasUnionUnionRef<'a> {
                 fn to_owned(&self) -> AliasUnionUnion {
                     <AliasUnionUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AliasUnionUnion, ssz::DecodeError> {
+                    <AliasUnionUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AliasUnionUnionRef<'a> {
@@ -845,6 +926,11 @@ pub mod tests {
                 fn to_owned(&self) -> StableContainerClass {
                     <StableContainerClassRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<StableContainerClass, ssz::DecodeError> {
+                    <StableContainerClassRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
@@ -853,9 +939,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> StableContainerClass {
-                    StableContainerClass {
-                        a: self.a().expect("valid view"),
-                    }
+                    <StableContainerClassRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<StableContainerClass, ssz::DecodeError> {
+                    Ok(StableContainerClass {
+                        a: self.a()?,
+                    })
                 }
             }
         }
@@ -1118,6 +1214,9 @@ pub mod tests {
                 fn to_owned(&self) -> ProfileInehritance {
                     <ProfileInehritanceRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ProfileInehritance, ssz::DecodeError> {
+                    <ProfileInehritanceRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileInehritanceRef<'a> {
@@ -1126,17 +1225,26 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ProfileInehritance {
-                    ProfileInehritance {
-                        a: self.a().expect("valid view"),
-                        b: match self.b().expect("valid view") {
+                    <ProfileInehritanceRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ProfileInehritance, ssz::DecodeError> {
+                    Ok(ProfileInehritance {
+                        a: self.a()?,
+                        b: match self.b()? {
                             ssz_types::Optional::Some(inner) => {
                                 ssz_types::Optional::Some(
-                                    ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                                 )
                             }
                             ssz_types::Optional::None => ssz_types::Optional::None,
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_import.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_import.rs
@@ -142,6 +142,9 @@ pub mod tests {
                     <AliasUnionUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AliasUnionUnion {
+                type Ref<'a> = AliasUnionUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AliasUnionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -464,6 +467,9 @@ pub mod tests {
                     <StableContainerClassRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for StableContainerClass {
+                type Ref<'a> = StableContainerClassRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
                 #[allow(
@@ -658,6 +664,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<AliasUnionUnion, ssz::DecodeError> {
                     <AliasUnionUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for AliasUnionUnion {
+                type Ref<'a> = AliasUnionUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for AliasUnionUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -931,6 +940,9 @@ pub mod tests {
                 ) -> Result<StableContainerClass, ssz::DecodeError> {
                     <StableContainerClassRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for StableContainerClass {
+                type Ref<'a> = StableContainerClassRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> StableContainerClassRef<'a> {
@@ -1217,6 +1229,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ProfileInehritance, ssz::DecodeError> {
                     <ProfileInehritanceRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ProfileInehritance {
+                type Ref<'a> = ProfileInehritanceRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ProfileInehritanceRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
@@ -931,7 +931,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerWithBigUnionsRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
@@ -231,6 +231,9 @@ pub mod tests {
                     <BigUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BigUnion {
+                type Ref<'a> = BigUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for BigUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -503,6 +506,9 @@ pub mod tests {
                     <MixedUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for MixedUnion {
+                type Ref<'a> = MixedUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for MixedUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -731,6 +737,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<SameTypeUnion, ssz::DecodeError> {
                     <SameTypeUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for SameTypeUnion {
+                type Ref<'a> = SameTypeUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for SameTypeUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1012,6 +1021,9 @@ pub mod tests {
                 ) -> Result<ContainerWithBigUnions, ssz::DecodeError> {
                     <ContainerWithBigUnionsRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerWithBigUnions {
+                type Ref<'a> = ContainerWithBigUnionsRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithBigUnionsRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_large_unions.rs
@@ -146,6 +146,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> BigUnion {
                     match self.selector() {
                         0u8 => {
@@ -181,6 +185,29 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BigUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => BigUnion::Selector0(self.as_selector0()?),
+                            1u8 => BigUnion::Selector1(self.as_selector1()?),
+                            2u8 => BigUnion::Selector2(self.as_selector2()?),
+                            3u8 => BigUnion::Selector3(self.as_selector3()?),
+                            4u8 => BigUnion::Selector4(self.as_selector4()?),
+                            5u8 => BigUnion::Selector5(self.as_selector5()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for BigUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -199,6 +226,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<BigUnion> for BigUnionRef<'a> {
                 fn to_owned(&self) -> BigUnion {
                     <BigUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<BigUnion, ssz::DecodeError> {
+                    <BigUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for BigUnionRef<'a> {
@@ -382,6 +412,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> MixedUnion {
                     match self.selector() {
                         0u8 => {
@@ -410,6 +444,42 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<MixedUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => MixedUnion::Selector0(self.as_selector0()?),
+                            1u8 => {
+                                MixedUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => {
+                                MixedUnion::Selector2({
+                                    let view = self.as_selector2()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            3u8 => {
+                                MixedUnion::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for MixedUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -428,6 +498,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<MixedUnion> for MixedUnionRef<'a> {
                 fn to_owned(&self) -> MixedUnion {
                     <MixedUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<MixedUnion, ssz::DecodeError> {
+                    <MixedUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for MixedUnionRef<'a> {
@@ -585,6 +658,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> SameTypeUnion {
                     match self.selector() {
                         0u8 => {
@@ -610,6 +687,27 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<SameTypeUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => SameTypeUnion::Selector0(self.as_selector0()?),
+                            1u8 => SameTypeUnion::Selector1(self.as_selector1()?),
+                            2u8 => SameTypeUnion::Selector2(self.as_selector2()?),
+                            3u8 => SameTypeUnion::Selector3(self.as_selector3()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for SameTypeUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -629,6 +727,9 @@ pub mod tests {
             for SameTypeUnionRef<'a> {
                 fn to_owned(&self) -> SameTypeUnion {
                     <SameTypeUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<SameTypeUnion, ssz::DecodeError> {
+                    <SameTypeUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for SameTypeUnionRef<'a> {
@@ -906,6 +1007,11 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerWithBigUnions {
                     <ContainerWithBigUnionsRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithBigUnions, ssz::DecodeError> {
+                    <ContainerWithBigUnionsRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithBigUnionsRef<'a> {
@@ -914,20 +1020,30 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerWithBigUnions {
-                    ContainerWithBigUnions {
+                    <ContainerWithBigUnionsRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithBigUnions, ssz::DecodeError> {
+                    Ok(ContainerWithBigUnions {
                         big: {
-                            let view = self.big().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.big()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         same: {
-                            let view = self.same().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.same()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         mixed: {
-                            let view = self.mixed().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.mixed()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -215,7 +215,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for NestedAliasContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -311,6 +311,11 @@ pub mod tests {
                 fn to_owned(&self) -> NestedAliasContainer {
                     <NestedAliasContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<NestedAliasContainer, ssz::DecodeError> {
+                    <NestedAliasContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NestedAliasContainerRef<'a> {
@@ -319,26 +324,28 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> NestedAliasContainer {
-                    NestedAliasContainer {
-                        field1: ssz_types::VariableList::new(
-                                self.field1().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        field2: self
-                            .field2()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                        field3: ssz_types::VariableList::new(
-                                self.field3().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        field4: self
-                            .field4()
-                            .expect("valid view")
-                            .to_owned()
-                            .expect("valid view"),
-                    }
+                    <NestedAliasContainerRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<NestedAliasContainer, ssz::DecodeError> {
+                    Ok(NestedAliasContainer {
+                        field1: ssz_types::VariableList::new(self.field1()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        field2: self.field2()?.try_to_owned()?,
+                        field3: ssz_types::VariableList::new(self.field3()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        field4: self.field4()?.try_to_owned()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_aliases.rs
@@ -317,6 +317,9 @@ pub mod tests {
                     <NestedAliasContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for NestedAliasContainer {
+                type Ref<'a> = NestedAliasContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> NestedAliasContainerRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -144,6 +144,9 @@ pub mod tests {
                     <FixedInnerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for FixedInner {
+                type Ref<'a> = FixedInnerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedInnerRef<'a> {
                 #[allow(
@@ -332,6 +335,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<FixedPair, ssz::DecodeError> {
                     <FixedPairRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for FixedPair {
+                type Ref<'a> = FixedPairRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedPairRef<'a> {
@@ -651,6 +657,9 @@ pub mod tests {
                     <MixedOuterRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for MixedOuter {
+                type Ref<'a> = MixedOuterRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MixedOuterRef<'a> {
                 #[allow(
@@ -855,6 +864,9 @@ pub mod tests {
                     <FixedOuterRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for FixedOuter {
+                type Ref<'a> = FixedOuterRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedOuterRef<'a> {
                 #[allow(
@@ -1053,6 +1065,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<BasicPair, ssz::DecodeError> {
                     <BasicPairRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for BasicPair {
+                type Ref<'a> = BasicPairRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicPairRef<'a> {
@@ -1260,6 +1275,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<VarThenFixed, ssz::DecodeError> {
                     <VarThenFixedRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for VarThenFixed {
+                type Ref<'a> = VarThenFixedRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> VarThenFixedRef<'a> {
@@ -1534,6 +1552,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Interleaved, ssz::DecodeError> {
                     <InterleavedRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Interleaved {
+                type Ref<'a> = InterleavedRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InterleavedRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -140,6 +140,9 @@ pub mod tests {
                 fn to_owned(&self) -> FixedInner {
                     <FixedInnerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<FixedInner, ssz::DecodeError> {
+                    <FixedInnerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedInnerRef<'a> {
@@ -148,9 +151,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> FixedInner {
-                    FixedInner {
-                        tag: self.tag().expect("valid view"),
-                    }
+                    <FixedInnerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FixedInner, ssz::DecodeError> {
+                    Ok(FixedInner { tag: self.tag()? })
                 }
             }
             /// A larger fixed-size inner container (8 bytes).
@@ -321,6 +329,9 @@ pub mod tests {
                 fn to_owned(&self) -> FixedPair {
                     <FixedPairRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<FixedPair, ssz::DecodeError> {
+                    <FixedPairRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedPairRef<'a> {
@@ -329,10 +340,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> FixedPair {
-                    FixedPair {
-                        x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view"),
-                    }
+                    <FixedPairRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FixedPair, ssz::DecodeError> {
+                    Ok(FixedPair {
+                        x: self.x()?,
+                        y: self.y()?,
+                    })
                 }
             }
             /// Mixed container: fixed containers inline, one variable tail.
@@ -629,6 +647,9 @@ pub mod tests {
                 fn to_owned(&self) -> MixedOuter {
                     <MixedOuterRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<MixedOuter, ssz::DecodeError> {
+                    <MixedOuterRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MixedOuterRef<'a> {
@@ -637,21 +658,28 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> MixedOuter {
-                    MixedOuter {
+                    <MixedOuterRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<MixedOuter, ssz::DecodeError> {
+                    Ok(MixedOuter {
                         inner: {
-                            let view = self.inner().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.inner()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        count: self.count().expect("valid view"),
+                        count: self.count()?,
                         pair: {
-                            let view = self.pair().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.pair()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        tail: ssz_types::VariableList::new(
-                                self.tail().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                    }
+                        tail: ssz_types::VariableList::new(self.tail()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                    })
                 }
             }
             /// Fully fixed container nesting fixed containers.
@@ -823,6 +851,9 @@ pub mod tests {
                 fn to_owned(&self) -> FixedOuter {
                     <FixedOuterRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<FixedOuter, ssz::DecodeError> {
+                    <FixedOuterRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FixedOuterRef<'a> {
@@ -831,16 +862,23 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> FixedOuter {
-                    FixedOuter {
+                    <FixedOuterRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<FixedOuter, ssz::DecodeError> {
+                    Ok(FixedOuter {
                         inner: {
-                            let view = self.inner().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.inner()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         pair: {
-                            let view = self.pair().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.pair()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
             /// Basic-fields-only container: decodes fine either way, but exercises the view
@@ -1012,6 +1050,9 @@ pub mod tests {
                 fn to_owned(&self) -> BasicPair {
                     <BasicPairRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BasicPair, ssz::DecodeError> {
+                    <BasicPairRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicPairRef<'a> {
@@ -1020,10 +1061,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BasicPair {
-                    BasicPair {
-                        tag: self.tag().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                    }
+                    <BasicPairRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BasicPair, ssz::DecodeError> {
+                    Ok(BasicPair {
+                        tag: self.tag()?,
+                        b: self.b()?,
+                    })
                 }
             }
             /// Variable-size field before a fixed-size one: the offset entry sits at the
@@ -1209,6 +1257,9 @@ pub mod tests {
                 fn to_owned(&self) -> VarThenFixed {
                     <VarThenFixedRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<VarThenFixed, ssz::DecodeError> {
+                    <VarThenFixedRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> VarThenFixedRef<'a> {
@@ -1217,13 +1268,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> VarThenFixed {
-                    VarThenFixed {
-                        entries: ssz_types::VariableList::new(
-                                self.entries().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        name: self.name().expect("valid view"),
-                    }
+                    <VarThenFixedRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<VarThenFixed, ssz::DecodeError> {
+                    Ok(VarThenFixed {
+                        entries: ssz_types::VariableList::new(self.entries()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        name: self.name()?,
+                    })
                 }
             }
             /// Variable fields interleaved with fixed fields.
@@ -1473,6 +1531,9 @@ pub mod tests {
                 fn to_owned(&self) -> Interleaved {
                     <InterleavedRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Interleaved, ssz::DecodeError> {
+                    <InterleavedRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> InterleavedRef<'a> {
@@ -1481,17 +1542,24 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Interleaved {
-                    Interleaved {
-                        head: ssz_types::VariableList::new(
-                                self.head().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                        mid: self.mid().expect("valid view"),
-                        tail: ssz_types::VariableList::new(
-                                self.tail().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
-                    }
+                    <InterleavedRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Interleaved, ssz::DecodeError> {
+                    Ok(Interleaved {
+                        head: ssz_types::VariableList::new(self.head()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                        mid: self.mid()?,
+                        tail: ssz_types::VariableList::new(self.tail()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_nested_fixed_container.rs
@@ -84,7 +84,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for FixedInnerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -263,7 +263,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for FixedPairRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -550,7 +550,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MixedOuterRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -790,7 +790,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for FixedOuterRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -993,7 +993,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BasicPairRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1199,7 +1199,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for VarThenFixedRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1455,7 +1455,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for InterleavedRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -100,7 +100,7 @@ impl<'a> StateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for StateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -321,7 +321,7 @@ impl<'a> UpdateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -170,6 +170,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
         <StateRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for State {
+    type Ref<'a> = StateRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -403,6 +406,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
         <UpdateRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Update {
+    type Ref<'a> = UpdateRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_order_1.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_1.rs
@@ -166,15 +166,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
     fn to_owned(&self) -> State {
         <StateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        <StateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> State {
-        State {
-            data: ssz_types::FixedBytes(self.data().expect("valid view").to_owned()),
-            counter: self.counter().expect("valid view"),
-        }
+        <StateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        Ok(State {
+            data: ssz_types::FixedBytes(self.data()?.to_owned()),
+            counter: self.counter()?,
+        })
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -393,21 +400,26 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn to_owned(&self) -> Update {
         <UpdateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        <UpdateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Update {
-        Update {
+        <UpdateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        Ok(Update {
             state: {
-                let view = self.state().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.state()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            timestamp: self.timestamp().expect("valid view"),
-            updates: ssz_types::VariableList::new(
-                    self.updates().expect("valid view").to_owned(),
-                )
-                .expect("valid view"),
-        }
+            timestamp: self.timestamp()?,
+            updates: ssz_types::VariableList::new(self.updates()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -100,7 +100,7 @@ impl<'a> StateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for StateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -321,7 +321,7 @@ impl<'a> UpdateRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for UpdateRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -170,6 +170,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
         <StateRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for State {
+    type Ref<'a> = StateRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -403,6 +406,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
         <UpdateRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Update {
+    type Ref<'a> = UpdateRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_order_2.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_order_2.rs
@@ -166,15 +166,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<State> for StateRef<'a> {
     fn to_owned(&self) -> State {
         <StateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        <StateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> StateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> State {
-        State {
-            data: ssz_types::FixedBytes(self.data().expect("valid view").to_owned()),
-            counter: self.counter().expect("valid view"),
-        }
+        <StateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<State, ssz::DecodeError> {
+        Ok(State {
+            data: ssz_types::FixedBytes(self.data()?.to_owned()),
+            counter: self.counter()?,
+        })
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -393,21 +400,26 @@ impl<'a> ssz_types::view::ToOwnedSsz<Update> for UpdateRef<'a> {
     fn to_owned(&self) -> Update {
         <UpdateRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        <UpdateRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> UpdateRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Update {
-        Update {
+        <UpdateRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Update, ssz::DecodeError> {
+        Ok(Update {
             state: {
-                let view = self.state().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.state()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            timestamp: self.timestamp().expect("valid view"),
-            updates: ssz_types::VariableList::new(
-                    self.updates().expect("valid view").to_owned(),
-                )
-                .expect("valid view"),
-        }
+            timestamp: self.timestamp()?,
+            updates: ssz_types::VariableList::new(self.updates()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
@@ -84,7 +84,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BasicContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
@@ -145,6 +145,9 @@ pub mod tests {
                     <BasicContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BasicContainer {
+                type Ref<'a> = BasicContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicContainerRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_basic.rs
@@ -141,6 +141,9 @@ pub mod tests {
                 fn to_owned(&self) -> BasicContainer {
                     <BasicContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BasicContainer, ssz::DecodeError> {
+                    <BasicContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BasicContainerRef<'a> {
@@ -149,9 +152,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BasicContainer {
-                    BasicContainer {
-                        a: self.a().expect("valid view"),
-                    }
+                    <BasicContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BasicContainer, ssz::DecodeError> {
+                    Ok(BasicContainer { a: self.a()? })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
@@ -82,7 +82,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EmptyPragmaContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -240,7 +240,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for EmptyValueContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
@@ -145,6 +145,9 @@ pub mod tests {
                     <EmptyPragmaContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for EmptyPragmaContainer {
+                type Ref<'a> = EmptyPragmaContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyPragmaContainerRef<'a> {
                 #[allow(
@@ -297,6 +300,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<EmptyValueContainer, ssz::DecodeError> {
                     <EmptyValueContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for EmptyValueContainer {
+                type Ref<'a> = EmptyValueContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyValueContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_empty.rs
@@ -139,6 +139,11 @@ pub mod tests {
                 fn to_owned(&self) -> EmptyPragmaContainer {
                     <EmptyPragmaContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<EmptyPragmaContainer, ssz::DecodeError> {
+                    <EmptyPragmaContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyPragmaContainerRef<'a> {
@@ -147,9 +152,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> EmptyPragmaContainer {
-                    EmptyPragmaContainer {
-                        x: self.x().expect("valid view"),
-                    }
+                    <EmptyPragmaContainerRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<EmptyPragmaContainer, ssz::DecodeError> {
+                    Ok(EmptyPragmaContainer {
+                        x: self.x()?,
+                    })
                 }
             }
             #[derive(
@@ -279,6 +294,9 @@ pub mod tests {
                 fn to_owned(&self) -> EmptyValueContainer {
                     <EmptyValueContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<EmptyValueContainer, ssz::DecodeError> {
+                    <EmptyValueContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> EmptyValueContainerRef<'a> {
@@ -287,9 +305,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> EmptyValueContainer {
-                    EmptyValueContainer {
-                        y: self.y().expect("valid view"),
-                    }
+                    <EmptyValueContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<EmptyValueContainer, ssz::DecodeError> {
+                    Ok(EmptyValueContainer {
+                        y: self.y()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
@@ -154,7 +154,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for FieldPragmaContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
@@ -239,6 +239,11 @@ pub mod tests {
                 fn to_owned(&self) -> FieldPragmaContainer {
                     <FieldPragmaContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<FieldPragmaContainer, ssz::DecodeError> {
+                    <FieldPragmaContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FieldPragmaContainerRef<'a> {
@@ -247,13 +252,21 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> FieldPragmaContainer {
-                    FieldPragmaContainer {
-                        normal_field: self.normal_field().expect("valid view"),
-                        pragma_field: self.pragma_field().expect("valid view"),
-                        multi_pragma_field: self
-                            .multi_pragma_field()
-                            .expect("valid view"),
-                    }
+                    <FieldPragmaContainerRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<FieldPragmaContainer, ssz::DecodeError> {
+                    Ok(FieldPragmaContainer {
+                        normal_field: self.normal_field()?,
+                        pragma_field: self.pragma_field()?,
+                        multi_pragma_field: self.multi_pragma_field()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_field.rs
@@ -245,6 +245,9 @@ pub mod tests {
                     <FieldPragmaContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for FieldPragmaContainer {
+                type Ref<'a> = FieldPragmaContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> FieldPragmaContainerRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
@@ -288,6 +288,9 @@ pub mod tests {
                 fn to_owned(&self) -> Parent {
                     <ParentRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Parent, ssz::DecodeError> {
+                    <ParentRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ParentRef<'a> {
@@ -296,10 +299,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Parent {
-                    Parent {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                    }
+                    <ParentRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Parent, ssz::DecodeError> {
+                    Ok(Parent {
+                        a: self.a()?,
+                        b: self.b()?,
+                    })
                 }
             }
             #[derive(
@@ -664,6 +674,9 @@ pub mod tests {
                 fn to_owned(&self) -> Child {
                     <ChildRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<Child, ssz::DecodeError> {
+                    <ChildRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ChildRef<'a> {
@@ -672,11 +685,18 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> Child {
-                    Child {
-                        a: self.a().expect("valid view"),
-                        b: self.b().expect("valid view"),
-                        c: self.c().expect("valid view"),
-                    }
+                    <ChildRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<Child, ssz::DecodeError> {
+                    Ok(Child {
+                        a: self.a()?,
+                        b: self.b()?,
+                        c: self.c()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_inheritance.rs
@@ -292,6 +292,9 @@ pub mod tests {
                     <ParentRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for Parent {
+                type Ref<'a> = ParentRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ParentRef<'a> {
                 #[allow(
@@ -677,6 +680,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<Child, ssz::DecodeError> {
                     <ChildRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for Child {
+                type Ref<'a> = ChildRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ChildRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
@@ -191,6 +191,9 @@ pub mod tests {
                     <MultiPragmaContainerRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for MultiPragmaContainer {
+                type Ref<'a> = MultiPragmaContainerRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MultiPragmaContainerRef<'a> {
                 #[allow(

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
@@ -185,6 +185,11 @@ pub mod tests {
                 fn to_owned(&self) -> MultiPragmaContainer {
                     <MultiPragmaContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<MultiPragmaContainer, ssz::DecodeError> {
+                    <MultiPragmaContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> MultiPragmaContainerRef<'a> {
@@ -193,10 +198,20 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> MultiPragmaContainer {
-                    MultiPragmaContainer {
-                        x: self.x().expect("valid view"),
-                        y: self.y().expect("valid view"),
-                    }
+                    <MultiPragmaContainerRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<MultiPragmaContainer, ssz::DecodeError> {
+                    Ok(MultiPragmaContainer {
+                        x: self.x()?,
+                        y: self.y()?,
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_pragmas_multiple.rs
@@ -115,7 +115,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for MultiPragmaContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
@@ -197,6 +197,9 @@ pub mod tests {
                     <BlockCommitmentRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BlockCommitment {
+                type Ref<'a> = BlockCommitmentRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 #[allow(
@@ -346,6 +349,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
                     <OtherTypeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for OtherType {
+                type Ref<'a> = OtherTypeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
@@ -193,6 +193,9 @@ pub mod tests {
                 fn to_owned(&self) -> BlockCommitment {
                     <BlockCommitmentRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    <BlockCommitmentRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
@@ -201,10 +204,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BlockCommitment {
-                    BlockCommitment {
-                        slot: self.slot().expect("valid view"),
-                        blkid: self.blkid().expect("valid view"),
-                    }
+                    <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    Ok(BlockCommitment {
+                        slot: self.slot()?,
+                        blkid: self.blkid()?,
+                    })
                 }
             }
             #[derive(
@@ -333,6 +343,9 @@ pub mod tests {
                 fn to_owned(&self) -> OtherType {
                     <OtherTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+                    <OtherTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {
@@ -341,9 +354,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> OtherType {
-                    OtherType {
-                        value: self.value().expect("valid view"),
-                    }
+                    <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+                    Ok(OtherType { value: self.value()? })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives.rs
@@ -123,7 +123,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -290,7 +290,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
@@ -115,7 +115,7 @@ pub mod test_rkyv_derives {
     }
     impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -269,7 +269,7 @@ pub mod test_rkyv_derives {
     }
     impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
@@ -181,15 +181,22 @@ pub mod test_rkyv_derives {
         fn to_owned(&self) -> BlockCommitment {
             <BlockCommitmentRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+            <BlockCommitmentRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> BlockCommitment {
-            BlockCommitment {
-                slot: self.slot().expect("valid view"),
-                blkid: self.blkid().expect("valid view"),
-            }
+            <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+            Ok(BlockCommitment {
+                slot: self.slot()?,
+                blkid: self.blkid()?,
+            })
         }
     }
     #[derive(
@@ -312,14 +319,19 @@ pub mod test_rkyv_derives {
         fn to_owned(&self) -> OtherType {
             <OtherTypeRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+            <OtherTypeRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> OtherType {
-            OtherType {
-                value: self.value().expect("valid view"),
-            }
+            <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+            Ok(OtherType { value: self.value()? })
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_flat.rs
@@ -185,6 +185,9 @@ pub mod test_rkyv_derives {
             <BlockCommitmentRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for BlockCommitment {
+        type Ref<'a> = BlockCommitmentRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -322,6 +325,9 @@ pub mod test_rkyv_derives {
         fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
             <OtherTypeRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for OtherType {
+        type Ref<'a> = OtherTypeRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
@@ -110,7 +110,7 @@ impl<'a> BlockCommitmentRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -262,7 +262,7 @@ impl<'a> OtherTypeRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
@@ -176,15 +176,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<BlockCommitment> for BlockCommitmentRef<'a>
     fn to_owned(&self) -> BlockCommitment {
         <BlockCommitmentRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+        <BlockCommitmentRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> BlockCommitment {
-        BlockCommitment {
-            slot: self.slot().expect("valid view"),
-            blkid: self.blkid().expect("valid view"),
-        }
+        <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+        Ok(BlockCommitment {
+            slot: self.slot()?,
+            blkid: self.blkid()?,
+        })
     }
 }
 #[derive(
@@ -305,13 +312,18 @@ impl<'a> ssz_types::view::ToOwnedSsz<OtherType> for OtherTypeRef<'a> {
     fn to_owned(&self) -> OtherType {
         <OtherTypeRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+        <OtherTypeRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> OtherType {
-        OtherType {
-            value: self.value().expect("valid view"),
-        }
+        <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+        Ok(OtherType { value: self.value()? })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_rkyv_derives_single.rs
@@ -180,6 +180,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<BlockCommitment> for BlockCommitmentRef<'a>
         <BlockCommitmentRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for BlockCommitment {
+    type Ref<'a> = BlockCommitmentRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -315,6 +318,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<OtherType> for OtherTypeRef<'a> {
     fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
         <OtherTypeRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for OtherType {
+    type Ref<'a> = OtherTypeRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
@@ -195,6 +195,9 @@ pub mod tests {
                     <BlockCommitmentRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for BlockCommitment {
+                type Ref<'a> = BlockCommitmentRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
                 #[allow(
@@ -344,6 +347,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
                     <OtherTypeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for OtherType {
+                type Ref<'a> = OtherTypeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
@@ -121,7 +121,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -288,7 +288,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives.rs
@@ -191,6 +191,9 @@ pub mod tests {
                 fn to_owned(&self) -> BlockCommitment {
                     <BlockCommitmentRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    <BlockCommitmentRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> BlockCommitmentRef<'a> {
@@ -199,10 +202,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> BlockCommitment {
-                    BlockCommitment {
-                        slot: self.slot().expect("valid view"),
-                        blkid: self.blkid().expect("valid view"),
-                    }
+                    <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+                    Ok(BlockCommitment {
+                        slot: self.slot()?,
+                        blkid: self.blkid()?,
+                    })
                 }
             }
             #[derive(
@@ -331,6 +341,9 @@ pub mod tests {
                 fn to_owned(&self) -> OtherType {
                     <OtherTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+                    <OtherTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> OtherTypeRef<'a> {
@@ -339,9 +352,14 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> OtherType {
-                    OtherType {
-                        value: self.value().expect("valid view"),
-                    }
+                    <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+                    Ok(OtherType { value: self.value()? })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
@@ -183,6 +183,9 @@ pub mod test_serde_derives {
             <BlockCommitmentRef<'a>>::try_to_owned(self)
         }
     }
+    impl ssz_types::view::SszHasView for BlockCommitment {
+        type Ref<'a> = BlockCommitmentRef<'a>;
+    }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -320,6 +323,9 @@ pub mod test_serde_derives {
         fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
             <OtherTypeRef<'a>>::try_to_owned(self)
         }
+    }
+    impl ssz_types::view::SszHasView for OtherType {
+        type Ref<'a> = OtherTypeRef<'a>;
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
@@ -113,7 +113,7 @@ pub mod test_serde_derives {
     }
     impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")
@@ -267,7 +267,7 @@ pub mod test_serde_derives {
     }
     impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
         fn tree_hash_type() -> tree_hash::TreeHashType {
-            tree_hash::TreeHashType::StableContainer
+            tree_hash::TreeHashType::Container
         }
         fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
             unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_flat.rs
@@ -179,15 +179,22 @@ pub mod test_serde_derives {
         fn to_owned(&self) -> BlockCommitment {
             <BlockCommitmentRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+            <BlockCommitmentRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> BlockCommitmentRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> BlockCommitment {
-            BlockCommitment {
-                slot: self.slot().expect("valid view"),
-                blkid: self.blkid().expect("valid view"),
-            }
+            <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+            Ok(BlockCommitment {
+                slot: self.slot()?,
+                blkid: self.blkid()?,
+            })
         }
     }
     #[derive(
@@ -310,14 +317,19 @@ pub mod test_serde_derives {
         fn to_owned(&self) -> OtherType {
             <OtherTypeRef<'a>>::to_owned(self)
         }
+        fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+            <OtherTypeRef<'a>>::try_to_owned(self)
+        }
     }
     #[allow(dead_code, reason = "generated code using ssz-gen")]
     impl<'a> OtherTypeRef<'a> {
         #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
         pub fn to_owned(&self) -> OtherType {
-            OtherType {
-                value: self.value().expect("valid view"),
-            }
+            <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+        }
+        #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+        pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+            Ok(OtherType { value: self.value()? })
         }
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
@@ -178,6 +178,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<BlockCommitment> for BlockCommitmentRef<'a>
         <BlockCommitmentRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for BlockCommitment {
+    type Ref<'a> = BlockCommitmentRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -313,6 +316,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<OtherType> for OtherTypeRef<'a> {
     fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
         <OtherTypeRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for OtherType {
+    type Ref<'a> = OtherTypeRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
@@ -108,7 +108,7 @@ impl<'a> BlockCommitmentRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for BlockCommitmentRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -260,7 +260,7 @@ impl<'a> OtherTypeRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for OtherTypeRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_serde_derives_single.rs
@@ -174,15 +174,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<BlockCommitment> for BlockCommitmentRef<'a>
     fn to_owned(&self) -> BlockCommitment {
         <BlockCommitmentRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+        <BlockCommitmentRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BlockCommitmentRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> BlockCommitment {
-        BlockCommitment {
-            slot: self.slot().expect("valid view"),
-            blkid: self.blkid().expect("valid view"),
-        }
+        <BlockCommitmentRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<BlockCommitment, ssz::DecodeError> {
+        Ok(BlockCommitment {
+            slot: self.slot()?,
+            blkid: self.blkid()?,
+        })
     }
 }
 #[derive(
@@ -303,13 +310,18 @@ impl<'a> ssz_types::view::ToOwnedSsz<OtherType> for OtherTypeRef<'a> {
     fn to_owned(&self) -> OtherType {
         <OtherTypeRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+        <OtherTypeRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> OtherTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> OtherType {
-        OtherType {
-            value: self.value().expect("valid view"),
-        }
+        <OtherTypeRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<OtherType, ssz::DecodeError> {
+        Ok(OtherType { value: self.value()? })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -65,6 +65,7 @@ impl<'a> AliasOptionUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> AliasOptionUnion {
         match self.selector() {
             0u8 => {
@@ -78,6 +79,27 @@ impl<'a> AliasOptionUnionRef<'a> {
             }
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => AliasOptionUnion::Selector0(self.as_selector0()?),
+                1u8 => {
+                    AliasOptionUnion::Selector1({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for AliasOptionUnionRef<'a> {
@@ -97,6 +119,9 @@ impl<'a> ssz::view::SszTypeInfo for AliasOptionUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'a> {
     fn to_owned(&self) -> AliasOptionUnion {
         <AliasOptionUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<AliasOptionUnion, ssz::DecodeError> {
+        <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
@@ -188,12 +213,29 @@ impl<'a> FirstUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> FirstUnion {
         match self.selector() {
             0u8 => FirstUnion::Selector0(self.as_selector0().expect("valid selector")),
             1u8 => FirstUnion::Selector1(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => FirstUnion::Selector0(self.as_selector0()?),
+                1u8 => FirstUnion::Selector1(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for FirstUnionRef<'a> {
@@ -213,6 +255,9 @@ impl<'a> ssz::view::SszTypeInfo for FirstUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn to_owned(&self) -> FirstUnion {
         <FirstUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
+        <FirstUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
@@ -320,6 +365,7 @@ impl<'a> TestUnionRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestUnion {
         match self.selector() {
             0u8 => {
@@ -330,6 +376,26 @@ impl<'a> TestUnionRef<'a> {
             2u8 => TestUnion::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => {
+                    self.as_selector0()?;
+                    TestUnion::Selector0
+                }
+                1u8 => TestUnion::Selector1(self.as_selector1()?),
+                2u8 => TestUnion::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -349,6 +415,9 @@ impl<'a> ssz::view::SszTypeInfo for TestUnionRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
     fn to_owned(&self) -> TestUnion {
         <TestUnionRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+        <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -461,6 +530,7 @@ impl<'a> UnionARef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionA {
         match self.selector() {
             0u8 => UnionA::Selector0(self.as_selector0().expect("valid selector")),
@@ -468,6 +538,23 @@ impl<'a> UnionARef<'a> {
             2u8 => UnionA::Selector2(self.as_selector2().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionA::Selector0(self.as_selector0()?),
+                1u8 => UnionA::Selector1(self.as_selector1()?),
+                2u8 => UnionA::Selector2(self.as_selector2()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionARef<'a> {
@@ -487,6 +574,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionARef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn to_owned(&self) -> UnionA {
         <UnionARef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
+        <UnionARef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
@@ -617,6 +707,7 @@ impl<'a> UnionBRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionB {
         match self.selector() {
             0u8 => UnionB::Selector0(self.as_selector0().expect("valid selector")),
@@ -636,6 +727,34 @@ impl<'a> UnionBRef<'a> {
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionB::Selector0(self.as_selector0()?),
+                1u8 => {
+                    UnionB::UnionA({
+                        let view = self.as_selector1()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                2u8 => UnionB::Selector2(self.as_selector2()?),
+                3u8 => {
+                    UnionB::Selector3({
+                        let view = self.as_selector3()?;
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                    })
+                }
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
+    }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionBRef<'a> {
     fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -654,6 +773,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionBRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
     fn to_owned(&self) -> UnionB {
         <UnionBRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionB, ssz::DecodeError> {
+        <UnionBRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
@@ -759,12 +881,29 @@ impl<'a> UnionCRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionC {
         match self.selector() {
             0u8 => UnionC::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionC::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionC::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionC::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionCRef<'a> {
@@ -784,6 +923,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionCRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
     fn to_owned(&self) -> UnionC {
         <UnionCRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionC, ssz::DecodeError> {
+        <UnionCRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
@@ -875,12 +1017,29 @@ impl<'a> UnionDRef<'a> {
         }
         ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
     }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> UnionD {
         match self.selector() {
             0u8 => UnionD::AliasUintAlias(self.as_selector0().expect("valid selector")),
             1u8 => UnionD::AliasUintAlias(self.as_selector1().expect("valid selector")),
             _ => panic!("Invalid union selector: {}", self.selector()),
         }
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        Ok(
+            match self.selector() {
+                0u8 => UnionD::AliasUintAlias(self.as_selector0()?),
+                1u8 => UnionD::AliasUintAlias(self.as_selector1()?),
+                other => {
+                    return Err(
+                        ssz::DecodeError::BytesInvalid(
+                            format!("Invalid union selector: {}", other),
+                        ),
+                    );
+                }
+            },
+        )
     }
 }
 impl<'a> ssz::view::DecodeView<'a> for UnionDRef<'a> {
@@ -900,6 +1059,9 @@ impl<'a> ssz::view::SszTypeInfo for UnionDRef<'a> {
 impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn to_owned(&self) -> UnionD {
         <UnionDRef<'a>>::to_owned(self)
+    }
+    fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
+        <UnionDRef<'a>>::try_to_owned(self)
     }
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
@@ -1146,16 +1308,23 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
     fn to_owned(&self) -> Alpha {
         <AlphaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        <AlphaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Alpha {
-        Alpha {
-            a: self.a().expect("valid view"),
-            b: self.b().expect("valid view"),
-            c: ssz_types::FixedBytes(self.c().expect("valid view").to_owned()),
-        }
+        <AlphaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Alpha, ssz::DecodeError> {
+        Ok(Alpha {
+            a: self.a()?,
+            b: self.b()?,
+            c: ssz_types::FixedBytes(self.c()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -1360,17 +1529,24 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn to_owned(&self) -> Beta {
         <BetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        <BetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Beta {
-        Beta {
-            d: ssz_types::VariableList::new(self.d().expect("valid view").to_owned())
-                .expect("valid view"),
-            e: self.e().expect("valid view"),
-            f: self.f().expect("valid view"),
-        }
+        <BetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
+        Ok(Beta {
+            d: ssz_types::VariableList::new(self.d()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
+            e: self.e()?,
+            f: self.f()?,
+        })
     }
 }
 #[derive(
@@ -1628,22 +1804,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
     fn to_owned(&self) -> Gamma {
         <GammaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        <GammaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Gamma {
-        Gamma {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <GammaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Gamma, ssz::DecodeError> {
+        Ok(Gamma {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -1801,15 +1984,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn to_owned(&self) -> Delta {
         <DeltaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        <DeltaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Delta {
-        Delta {
-            z: self.z().expect("valid view"),
-            w: self.w().expect("valid view"),
-        }
+        <DeltaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
+        Ok(Delta {
+            z: self.z()?,
+            w: self.w()?,
+        })
     }
 }
 #[derive(
@@ -2231,24 +2421,31 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
     fn to_owned(&self) -> Epsilon {
         <EpsilonRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        <EpsilonRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Epsilon {
-        Epsilon {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <EpsilonRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Epsilon, ssz::DecodeError> {
+        Ok(Epsilon {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-        }
+            i: self.i()?,
+            j: self.j()?,
+        })
     }
 }
 #[derive(
@@ -2496,29 +2693,36 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn to_owned(&self) -> Zeta {
         <ZetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        <ZetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Zeta {
-        Zeta {
-            u: match self.u().expect("valid view") {
+        <ZetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
+        Ok(Zeta {
+            u: match self.u()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            v: match self.v().expect("valid view") {
+            v: match self.v()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-        }
+        })
     }
 }
 #[derive(
@@ -2845,29 +3049,35 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
     fn to_owned(&self) -> TestType {
         <TestTypeRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        <TestTypeRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> TestType {
-        TestType {
-            ccc: self.ccc().expect("valid view"),
-            ddd: self.ddd().expect("valid view"),
+        <TestTypeRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<TestType, ssz::DecodeError> {
+        Ok(TestType {
+            ccc: self.ccc()?,
+            ddd: self.ddd()?,
             eee: {
-                let view = self.eee().expect("valid view");
-                let items: Result<Vec<_>, _> = view
+                let view = self.eee()?;
+                let items = view
                     .iter()
                     .map(|item_result| {
-                        item_result
-                            .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                     })
-                    .collect();
-                let items = items.expect("valid view");
-                ssz_types::VariableList::new(items).expect("valid view")
+                    .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                ssz_types::VariableList::new(items)
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
             },
-            large_int_128: self.large_int_128().expect("valid view"),
-            large_int_256: self.large_int_256().expect("valid view"),
-        }
+            large_int_128: self.large_int_128()?,
+            large_int_256: self.large_int_256()?,
+        })
     }
 }
 #[derive(
@@ -3072,25 +3282,32 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
     fn to_owned(&self) -> Eta {
         <EtaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        <EtaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Eta {
-        Eta {
+        <EtaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Eta, ssz::DecodeError> {
+        Ok(Eta {
             l: {
-                let view = self.l().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.l()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             m: {
-                let view = self.m().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.m()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             n: {
-                let view = self.n().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.n()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 #[derive(
@@ -3295,22 +3512,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn to_owned(&self) -> Theta {
         <ThetaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        <ThetaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Theta {
-        Theta {
+        <ThetaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
+        Ok(Theta {
             o: {
-                let view = self.o().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.o()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             p: {
-                let view = self.p().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.p()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            q: ssz_types::FixedBytes(self.q().expect("valid view").to_owned()),
-        }
+            q: ssz_types::FixedBytes(self.q()?.to_owned()),
+        })
     }
 }
 #[derive(
@@ -3968,33 +4192,40 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
     fn to_owned(&self) -> Iota {
         <IotaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        <IotaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Iota {
-        Iota {
-            g: self.g().expect("valid view"),
-            h: match self.h().expect("valid view") {
+        <IotaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Iota, ssz::DecodeError> {
+        Ok(Iota {
+            g: self.g()?,
+            h: match self.h()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            i: self.i().expect("valid view"),
-            j: self.j().expect("valid view"),
-            r: match self.r().expect("valid view") {
+            i: self.i()?,
+            j: self.j()?,
+            r: match self.r()? {
                 ssz_types::Optional::Some(inner) => {
                     ssz_types::Optional::Some(
-                        ssz_types::view::ToOwnedSsz::to_owned(&inner),
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?,
                     )
                 }
                 ssz_types::Optional::None => ssz_types::Optional::None,
             },
-            s: self.s().expect("valid view"),
-        }
+            s: self.s()?,
+        })
     }
 }
 #[derive(
@@ -4199,22 +4430,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn to_owned(&self) -> Kappa {
         <KappaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        <KappaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Kappa {
-        Kappa {
+        <KappaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
+        Ok(Kappa {
             t: {
-                let view = self.t().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.t()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             u: {
-                let view = self.u().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.u()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            v: self.v().expect("valid view").to_owned(),
-        }
+            v: self.v()?.to_owned(),
+        })
     }
 }
 #[derive(
@@ -4450,15 +4688,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
     fn to_owned(&self) -> Lambda {
         <LambdaRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        <LambdaRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Lambda {
-        Lambda {
-            w: self.w().expect("valid view"),
-            x: self.x().expect("valid view"),
-        }
+        <LambdaRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Lambda, ssz::DecodeError> {
+        Ok(Lambda {
+            w: self.w()?,
+            x: self.x()?,
+        })
     }
 }
 #[derive(
@@ -4617,21 +4862,28 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn to_owned(&self) -> Mu {
         <MuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        <MuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Mu {
-        Mu {
+        <MuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
+        Ok(Mu {
             y: {
-                let view = self.y().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.y()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
             z: {
-                let view = self.z().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.z()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 pub type AliasMu = Mu;
@@ -4914,22 +5166,29 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn to_owned(&self) -> Nu {
         <NuRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        <NuRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> Nu {
-        Nu {
+        <NuRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
+        Ok(Nu {
             zz: {
-                let view = self.zz().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.zz()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-            aaa: self.aaa().expect("valid view").to_owned().expect("valid view"),
-            bbb: self.bbb().expect("valid view").to_owned(),
-            test: self
-                .test()
-                .expect("valid view")
-                .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-        }
+            aaa: self.aaa()?.try_to_owned()?,
+            bbb: self.bbb()?.to_owned(),
+            test: match self.test()? {
+                Some(inner) => Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?),
+                None => None,
+            },
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -124,6 +124,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<AliasOptionUnion> for AliasOptionUnionRef<'
         <AliasOptionUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for AliasOptionUnion {
+    type Ref<'a> = AliasOptionUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for AliasOptionUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -259,6 +262,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<FirstUnion> for FirstUnionRef<'a> {
     fn try_to_owned(&self) -> Result<FirstUnion, ssz::DecodeError> {
         <FirstUnionRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for FirstUnion {
+    type Ref<'a> = FirstUnionRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for FirstUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -420,6 +426,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
         <TestUnionRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestUnion {
+    type Ref<'a> = TestUnionRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -578,6 +587,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionA> for UnionARef<'a> {
     fn try_to_owned(&self) -> Result<UnionA, ssz::DecodeError> {
         <UnionARef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionA {
+    type Ref<'a> = UnionARef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionARef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -778,6 +790,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionB> for UnionBRef<'a> {
         <UnionBRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionB {
+    type Ref<'a> = UnionBRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionBRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -928,6 +943,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionC> for UnionCRef<'a> {
         <UnionCRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for UnionC {
+    type Ref<'a> = UnionCRef<'a>;
+}
 impl<'a> tree_hash::TreeHash for UnionCRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
         tree_hash::TreeHashType::Vector
@@ -1063,6 +1081,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<UnionD> for UnionDRef<'a> {
     fn try_to_owned(&self) -> Result<UnionD, ssz::DecodeError> {
         <UnionDRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for UnionD {
+    type Ref<'a> = UnionDRef<'a>;
 }
 impl<'a> tree_hash::TreeHash for UnionDRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1312,6 +1333,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Alpha> for AlphaRef<'a> {
         <AlphaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Alpha {
+    type Ref<'a> = AlphaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> AlphaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1532,6 +1556,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Beta> for BetaRef<'a> {
     fn try_to_owned(&self) -> Result<Beta, ssz::DecodeError> {
         <BetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Beta {
+    type Ref<'a> = BetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> BetaRef<'a> {
@@ -1808,6 +1835,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Gamma> for GammaRef<'a> {
         <GammaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Gamma {
+    type Ref<'a> = GammaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> GammaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -1987,6 +2017,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Delta> for DeltaRef<'a> {
     fn try_to_owned(&self) -> Result<Delta, ssz::DecodeError> {
         <DeltaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Delta {
+    type Ref<'a> = DeltaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> DeltaRef<'a> {
@@ -2425,6 +2458,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Epsilon> for EpsilonRef<'a> {
         <EpsilonRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Epsilon {
+    type Ref<'a> = EpsilonRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EpsilonRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -2696,6 +2732,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Zeta> for ZetaRef<'a> {
     fn try_to_owned(&self) -> Result<Zeta, ssz::DecodeError> {
         <ZetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Zeta {
+    type Ref<'a> = ZetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ZetaRef<'a> {
@@ -3053,6 +3092,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<TestType> for TestTypeRef<'a> {
         <TestTypeRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for TestType {
+    type Ref<'a> = TestTypeRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> TestTypeRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3286,6 +3328,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Eta> for EtaRef<'a> {
         <EtaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Eta {
+    type Ref<'a> = EtaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> EtaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -3515,6 +3560,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Theta> for ThetaRef<'a> {
     fn try_to_owned(&self) -> Result<Theta, ssz::DecodeError> {
         <ThetaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Theta {
+    type Ref<'a> = ThetaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ThetaRef<'a> {
@@ -4196,6 +4244,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Iota> for IotaRef<'a> {
         <IotaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Iota {
+    type Ref<'a> = IotaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> IotaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4433,6 +4484,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Kappa> for KappaRef<'a> {
     fn try_to_owned(&self) -> Result<Kappa, ssz::DecodeError> {
         <KappaRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Kappa {
+    type Ref<'a> = KappaRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> KappaRef<'a> {
@@ -4692,6 +4746,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Lambda> for LambdaRef<'a> {
         <LambdaRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for Lambda {
+    type Ref<'a> = LambdaRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> LambdaRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -4865,6 +4922,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Mu> for MuRef<'a> {
     fn try_to_owned(&self) -> Result<Mu, ssz::DecodeError> {
         <MuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Mu {
+    type Ref<'a> = MuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> MuRef<'a> {
@@ -5169,6 +5229,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<Nu> for NuRef<'a> {
     fn try_to_owned(&self) -> Result<Nu, ssz::DecodeError> {
         <NuRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for Nu {
+    type Ref<'a> = NuRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> NuRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_single_module.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_single_module.rs
@@ -1251,7 +1251,7 @@ impl<'a> AlphaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for AlphaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1474,7 +1474,7 @@ impl<'a> BetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for BetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -1949,7 +1949,7 @@ impl<'a> DeltaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for DeltaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -2983,7 +2983,7 @@ impl<'a> TestTypeRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for TestTypeRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3245,7 +3245,7 @@ impl<'a> EtaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for EtaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -3478,7 +3478,7 @@ impl<'a> ThetaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ThetaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4402,7 +4402,7 @@ impl<'a> KappaRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for KappaRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -4853,7 +4853,7 @@ impl<'a> MuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for MuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -5133,7 +5133,7 @@ impl<'a> NuRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for NuRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -171,18 +171,25 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerA> for ContainerARef<'a> {
     fn to_owned(&self) -> ContainerA {
         <ContainerARef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ContainerA, ssz::DecodeError> {
+        <ContainerARef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerARef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ContainerA {
-        ContainerA {
-            value: self.value().expect("valid view"),
+        <ContainerARef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ContainerA, ssz::DecodeError> {
+        Ok(ContainerA {
+            value: self.value()?,
             b_ref: {
-                let view = self.b_ref().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.b_ref()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -350,18 +357,25 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerB> for ContainerBRef<'a> {
     fn to_owned(&self) -> ContainerB {
         <ContainerBRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ContainerB, ssz::DecodeError> {
+        <ContainerBRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerBRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ContainerB {
-        ContainerB {
-            value: self.value().expect("valid view"),
+        <ContainerBRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ContainerB, ssz::DecodeError> {
+        Ok(ContainerB {
+            value: self.value()?,
             c_ref: {
-                let view = self.c_ref().expect("valid view");
-                ssz_types::view::ToOwnedSsz::to_owned(&view)
+                let view = self.c_ref()?;
+                ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
             },
-        }
+        })
     }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
@@ -484,13 +498,18 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerC> for ContainerCRef<'a> {
     fn to_owned(&self) -> ContainerC {
         <ContainerCRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ContainerC, ssz::DecodeError> {
+        <ContainerCRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerCRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ContainerC {
-        ContainerC {
-            value: self.value().expect("valid view"),
-        }
+        <ContainerCRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ContainerC, ssz::DecodeError> {
+        Ok(ContainerC { value: self.value()? })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -175,6 +175,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerA> for ContainerARef<'a> {
         <ContainerARef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for ContainerA {
+    type Ref<'a> = ContainerARef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerARef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -361,6 +364,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerB> for ContainerBRef<'a> {
         <ContainerBRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for ContainerB {
+    type Ref<'a> = ContainerBRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerBRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -501,6 +507,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ContainerC> for ContainerCRef<'a> {
     fn try_to_owned(&self) -> Result<ContainerC, ssz::DecodeError> {
         <ContainerCRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for ContainerC {
+    type Ref<'a> = ContainerCRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ContainerCRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_three_way.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_three_way.rs
@@ -103,7 +103,7 @@ impl<'a> ContainerARef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ContainerARef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -292,7 +292,7 @@ impl<'a> ContainerBRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ContainerBRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -451,7 +451,7 @@ impl<'a> ContainerCRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ContainerCRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
@@ -1380,7 +1380,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for UnionEdgeCasesRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1719,7 +1719,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for AllUnionsRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
@@ -136,6 +136,9 @@ pub mod tests {
                     <AnotherSimpleRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for AnotherSimple {
+                type Ref<'a> = AnotherSimpleRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for AnotherSimpleRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -376,6 +379,9 @@ pub mod tests {
                     <ComplexUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ComplexUnion {
+                type Ref<'a> = ComplexUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for ComplexUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -580,6 +586,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<MixedOptional, ssz::DecodeError> {
                     <MixedOptionalRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for MixedOptional {
+                type Ref<'a> = MixedOptionalRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for MixedOptionalRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -786,6 +795,9 @@ pub mod tests {
                     <NestedUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for NestedUnion {
+                type Ref<'a> = NestedUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for NestedUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -955,6 +967,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<SimpleUnion, ssz::DecodeError> {
                     <SimpleUnionRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for SimpleUnion {
+                type Ref<'a> = SimpleUnionRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for SimpleUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -1497,6 +1512,9 @@ pub mod tests {
                     <UnionEdgeCasesRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionEdgeCases {
+                type Ref<'a> = UnionEdgeCasesRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionEdgeCasesRef<'a> {
                 #[allow(
@@ -1788,6 +1806,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<AllUnions, ssz::DecodeError> {
                     <AllUnionsRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for AllUnions {
+                type Ref<'a> = AllUnionsRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AllUnionsRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_edge_cases.rs
@@ -74,6 +74,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> AnotherSimple {
                     match self.selector() {
                         0u8 => {
@@ -88,6 +92,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AnotherSimple, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => AnotherSimple::Selector0(self.as_selector0()?),
+                            1u8 => AnotherSimple::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for AnotherSimpleRef<'a> {
@@ -108,6 +131,9 @@ pub mod tests {
             for AnotherSimpleRef<'a> {
                 fn to_owned(&self) -> AnotherSimple {
                     <AnotherSimpleRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<AnotherSimple, ssz::DecodeError> {
+                    <AnotherSimpleRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for AnotherSimpleRef<'a> {
@@ -253,6 +279,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> ComplexUnion {
                     match self.selector() {
                         0u8 => {
@@ -282,6 +312,47 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ComplexUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                ComplexUnion::Selector0({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            1u8 => {
+                                ComplexUnion::Selector1({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => {
+                                ComplexUnion::SimpleUnion({
+                                    let view = self.as_selector2()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            3u8 => {
+                                ComplexUnion::Selector3({
+                                    let view = self.as_selector3()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for ComplexUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -300,6 +371,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<ComplexUnion> for ComplexUnionRef<'a> {
                 fn to_owned(&self) -> ComplexUnion {
                     <ComplexUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<ComplexUnion, ssz::DecodeError> {
+                    <ComplexUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for ComplexUnionRef<'a> {
@@ -437,6 +511,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> MixedOptional {
                     match self.selector() {
                         0u8 => {
@@ -455,6 +533,29 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<MixedOptional, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                MixedOptional::Selector0
+                            }
+                            1u8 => MixedOptional::Selector1(self.as_selector1()?),
+                            2u8 => MixedOptional::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for MixedOptionalRef<'a> {
@@ -475,6 +576,9 @@ pub mod tests {
             for MixedOptionalRef<'a> {
                 fn to_owned(&self) -> MixedOptional {
                     <MixedOptionalRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<MixedOptional, ssz::DecodeError> {
+                    <MixedOptionalRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for MixedOptionalRef<'a> {
@@ -603,6 +707,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> NestedUnion {
                     match self.selector() {
                         0u8 => {
@@ -625,6 +733,36 @@ pub mod tests {
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<NestedUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                NestedUnion::SimpleUnion({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            1u8 => {
+                                NestedUnion::AnotherSimple({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            2u8 => NestedUnion::Selector2(self.as_selector2()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
+                }
             }
             impl<'a> ssz::view::DecodeView<'a> for NestedUnionRef<'a> {
                 fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ssz::DecodeError> {
@@ -643,6 +781,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<NestedUnion> for NestedUnionRef<'a> {
                 fn to_owned(&self) -> NestedUnion {
                     <NestedUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<NestedUnion, ssz::DecodeError> {
+                    <NestedUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for NestedUnionRef<'a> {
@@ -754,6 +895,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> SimpleUnion {
                     match self.selector() {
                         0u8 => {
@@ -768,6 +913,25 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<SimpleUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => SimpleUnion::Selector0(self.as_selector0()?),
+                            1u8 => SimpleUnion::Selector1(self.as_selector1()?),
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for SimpleUnionRef<'a> {
@@ -787,6 +951,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<SimpleUnion> for SimpleUnionRef<'a> {
                 fn to_owned(&self) -> SimpleUnion {
                     <SimpleUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<SimpleUnion, ssz::DecodeError> {
+                    <SimpleUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for SimpleUnionRef<'a> {
@@ -1326,6 +1493,9 @@ pub mod tests {
                 fn to_owned(&self) -> UnionEdgeCases {
                     <UnionEdgeCasesRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<UnionEdgeCases, ssz::DecodeError> {
+                    <UnionEdgeCasesRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionEdgeCasesRef<'a> {
@@ -1334,32 +1504,45 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> UnionEdgeCases {
-                    UnionEdgeCases {
+                    <UnionEdgeCasesRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionEdgeCases, ssz::DecodeError> {
+                    Ok(UnionEdgeCases {
                         simple: {
-                            let view = self.simple().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.simple()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         nested: {
-                            let view = self.nested().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.nested()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         complex: {
-                            let view = self.complex().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.complex()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        opt_simple: self
-                            .opt_simple()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                        opt_complex: self
-                            .opt_complex()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                        opt_union: self
-                            .opt_union()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        opt_simple: match self.opt_simple()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                        opt_complex: match self.opt_complex()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                        opt_union: match self.opt_union()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
             #[derive(
@@ -1602,6 +1785,9 @@ pub mod tests {
                 fn to_owned(&self) -> AllUnions {
                     <AllUnionsRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<AllUnions, ssz::DecodeError> {
+                    <AllUnionsRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> AllUnionsRef<'a> {
@@ -1610,20 +1796,29 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> AllUnions {
-                    AllUnions {
+                    <AllUnionsRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<AllUnions, ssz::DecodeError> {
+                    Ok(AllUnions {
                         union1: {
-                            let view = self.union1().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.union1()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
                         union2: {
-                            let view = self.union2().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.union2()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                        union3: self
-                            .union3()
-                            .expect("valid view")
-                            .map(|inner| ssz_types::view::ToOwnedSsz::to_owned(&inner)),
-                    }
+                        union3: match self.union3()? {
+                            Some(inner) => {
+                                Some(ssz_types::view::ToOwnedSsz::try_to_owned(&inner)?)
+                            }
+                            None => None,
+                        },
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -76,6 +76,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -90,6 +94,33 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                self.as_selector0()?;
+                                TestUnion::Empty
+                            }
+                            1u8 => {
+                                TestUnion::Data({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -109,6 +140,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -271,6 +305,9 @@ pub mod tests {
                 fn to_owned(&self) -> DataVariant {
                     <DataVariantRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<DataVariant, ssz::DecodeError> {
+                    <DataVariantRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DataVariantRef<'a> {
@@ -279,9 +316,16 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> DataVariant {
-                    DataVariant {
-                        value: self.value().expect("valid view"),
-                    }
+                    <DataVariantRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<DataVariant, ssz::DecodeError> {
+                    Ok(DataVariant {
+                        value: self.value()?,
+                    })
                 }
             }
             /// Container using the union
@@ -412,6 +456,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestContainer {
                     <TestContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    <TestContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {
@@ -420,12 +467,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestContainer {
-                    TestContainer {
+                    <TestContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    Ok(TestContainer {
                         state: {
-                            let view = self.state().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.state()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -145,6 +145,9 @@ pub mod tests {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -309,6 +312,9 @@ pub mod tests {
                     <DataVariantRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for DataVariant {
+                type Ref<'a> = DataVariantRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> DataVariantRef<'a> {
                 #[allow(
@@ -459,6 +465,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
                     <TestContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestContainer {
+                type Ref<'a> = TestContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_empty_variant.rs
@@ -252,7 +252,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for DataVariantRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -405,7 +405,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
@@ -78,6 +78,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> ExternalUnion {
                     match self.selector() {
                         0u8 => {
@@ -94,6 +98,35 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ExternalUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                ExternalUnion::Type1({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            1u8 => {
+                                ExternalUnion::Type2({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for ExternalUnionRef<'a> {
@@ -114,6 +147,9 @@ pub mod tests {
             for ExternalUnionRef<'a> {
                 fn to_owned(&self) -> ExternalUnion {
                     <ExternalUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<ExternalUnion, ssz::DecodeError> {
+                    <ExternalUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for ExternalUnionRef<'a> {
@@ -283,6 +319,9 @@ pub mod tests {
                 fn to_owned(&self) -> TestContainer {
                     <TestContainerRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    <TestContainerRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {
@@ -291,12 +330,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> TestContainer {
-                    TestContainer {
+                    <TestContainerRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
+                    Ok(TestContainer {
                         union_field: {
-                            let view = self.union_field().expect("valid view");
-                            ssz_types::view::ToOwnedSsz::to_owned(&view)
+                            let view = self.union_field()?;
+                            ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
@@ -152,6 +152,9 @@ pub mod tests {
                     <ExternalUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ExternalUnion {
+                type Ref<'a> = ExternalUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for ExternalUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -322,6 +325,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<TestContainer, ssz::DecodeError> {
                     <TestContainerRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for TestContainer {
+                type Ref<'a> = TestContainerRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> TestContainerRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_external_alias.rs
@@ -265,7 +265,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for TestContainerRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -79,6 +79,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionClass {
                     match self.selector() {
                         0u8 => {
@@ -95,6 +99,35 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionClass, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                UnionClass::Variant1({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            1u8 => {
+                                UnionClass::Variant2({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionClassRef<'a> {
@@ -114,6 +147,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<UnionClass> for UnionClassRef<'a> {
                 fn to_owned(&self) -> UnionClass {
                     <UnionClassRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionClass, ssz::DecodeError> {
+                    <UnionClassRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionClassRef<'a> {
@@ -201,6 +237,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionClassWithExternal {
                     match self.selector() {
                         0u8 => {
@@ -211,6 +251,31 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<UnionClassWithExternal, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                UnionClassWithExternal::Deposit({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionClassWithExternalRef<'a> {
@@ -231,6 +296,11 @@ pub mod tests {
             for UnionClassWithExternalRef<'a> {
                 fn to_owned(&self) -> UnionClassWithExternal {
                     <UnionClassWithExternalRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<UnionClassWithExternal, ssz::DecodeError> {
+                    <UnionClassWithExternalRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionClassWithExternalRef<'a> {
@@ -328,6 +398,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> UnionTypeAlias {
                     match self.selector() {
                         0u8 => {
@@ -344,6 +418,35 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnionTypeAlias, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                UnionTypeAlias::TypeAliasVariant1({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            1u8 => {
+                                UnionTypeAlias::TypeAliasVariant2({
+                                    let view = self.as_selector1()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for UnionTypeAliasRef<'a> {
@@ -364,6 +467,9 @@ pub mod tests {
             for UnionTypeAliasRef<'a> {
                 fn to_owned(&self) -> UnionTypeAlias {
                     <UnionTypeAliasRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<UnionTypeAlias, ssz::DecodeError> {
+                    <UnionTypeAliasRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for UnionTypeAliasRef<'a> {
@@ -532,6 +638,11 @@ pub mod tests {
                 fn to_owned(&self) -> UnionTypeAliasVariant1 {
                     <UnionTypeAliasVariant1Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<UnionTypeAliasVariant1, ssz::DecodeError> {
+                    <UnionTypeAliasVariant1Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant1Ref<'a> {
@@ -540,9 +651,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> UnionTypeAliasVariant1 {
-                    UnionTypeAliasVariant1 {
-                        value: self.value().expect("valid view"),
-                    }
+                    <UnionTypeAliasVariant1Ref<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<UnionTypeAliasVariant1, ssz::DecodeError> {
+                    Ok(UnionTypeAliasVariant1 {
+                        value: self.value()?,
+                    })
                 }
             }
             #[derive(
@@ -672,6 +793,11 @@ pub mod tests {
                 fn to_owned(&self) -> UnionTypeAliasVariant2 {
                     <UnionTypeAliasVariant2Ref<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<UnionTypeAliasVariant2, ssz::DecodeError> {
+                    <UnionTypeAliasVariant2Ref<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant2Ref<'a> {
@@ -680,9 +806,19 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> UnionTypeAliasVariant2 {
-                    UnionTypeAliasVariant2 {
-                        value: self.value().expect("valid view"),
-                    }
+                    <UnionTypeAliasVariant2Ref<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<UnionTypeAliasVariant2, ssz::DecodeError> {
+                    Ok(UnionTypeAliasVariant2 {
+                        value: self.value()?,
+                    })
                 }
             }
             /// Container using class Name(Union): syntax in a List
@@ -838,6 +974,11 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerWithUnionClass {
                     <ContainerWithUnionClassRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionClass, ssz::DecodeError> {
+                    <ContainerWithUnionClassRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionClassRef<'a> {
@@ -846,20 +987,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerWithUnionClass {
-                    ContainerWithUnionClass {
+                    <ContainerWithUnionClassRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionClass, ssz::DecodeError> {
+                    Ok(ContainerWithUnionClass {
                         items: {
-                            let view = self.items().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.items()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
             /// Container using class Name(Union): syntax with external in a List
@@ -1016,6 +1168,11 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerWithUnionClassExternal {
                     <ContainerWithUnionClassExternalRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionClassExternal, ssz::DecodeError> {
+                    <ContainerWithUnionClassExternalRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionClassExternalRef<'a> {
@@ -1024,20 +1181,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerWithUnionClassExternal {
-                    ContainerWithUnionClassExternal {
+                    <ContainerWithUnionClassExternalRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionClassExternal, ssz::DecodeError> {
+                    Ok(ContainerWithUnionClassExternal {
                         items: {
-                            let view = self.items().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.items()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
             pub type TypeAliasVariant1 = UnionTypeAliasVariant1;
@@ -1195,6 +1363,11 @@ pub mod tests {
                 fn to_owned(&self) -> ContainerWithUnionTypeAlias {
                     <ContainerWithUnionTypeAliasRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionTypeAlias, ssz::DecodeError> {
+                    <ContainerWithUnionTypeAliasRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionTypeAliasRef<'a> {
@@ -1203,20 +1376,31 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ContainerWithUnionTypeAlias {
-                    ContainerWithUnionTypeAlias {
+                    <ContainerWithUnionTypeAliasRef<'a>>::try_to_owned(self)
+                        .expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(
+                    &self,
+                ) -> Result<ContainerWithUnionTypeAlias, ssz::DecodeError> {
+                    Ok(ContainerWithUnionTypeAlias {
                         items: {
-                            let view = self.items().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.items()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                    }
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -590,7 +590,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for UnionTypeAliasVariant1Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -748,7 +748,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for UnionTypeAliasVariant2Ref<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -918,7 +918,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerWithUnionClassRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1114,7 +1114,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerWithUnionClassExternalRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -1313,7 +1313,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ContainerWithUnionTypeAliasRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_in_list.rs
@@ -152,6 +152,9 @@ pub mod tests {
                     <UnionClassRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionClass {
+                type Ref<'a> = UnionClassRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for UnionClassRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -302,6 +305,9 @@ pub mod tests {
                 ) -> Result<UnionClassWithExternal, ssz::DecodeError> {
                     <UnionClassWithExternalRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionClassWithExternal {
+                type Ref<'a> = UnionClassWithExternalRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionClassWithExternalRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -471,6 +477,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnionTypeAlias, ssz::DecodeError> {
                     <UnionTypeAliasRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionTypeAlias {
+                type Ref<'a> = UnionTypeAliasRef<'a>;
             }
             impl<'a> tree_hash::TreeHash for UnionTypeAliasRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
@@ -644,6 +653,9 @@ pub mod tests {
                     <UnionTypeAliasVariant1Ref<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for UnionTypeAliasVariant1 {
+                type Ref<'a> = UnionTypeAliasVariant1Ref<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant1Ref<'a> {
                 #[allow(
@@ -798,6 +810,9 @@ pub mod tests {
                 ) -> Result<UnionTypeAliasVariant2, ssz::DecodeError> {
                     <UnionTypeAliasVariant2Ref<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnionTypeAliasVariant2 {
+                type Ref<'a> = UnionTypeAliasVariant2Ref<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnionTypeAliasVariant2Ref<'a> {
@@ -979,6 +994,9 @@ pub mod tests {
                 ) -> Result<ContainerWithUnionClass, ssz::DecodeError> {
                     <ContainerWithUnionClassRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerWithUnionClass {
+                type Ref<'a> = ContainerWithUnionClassRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionClassRef<'a> {
@@ -1174,6 +1192,9 @@ pub mod tests {
                     <ContainerWithUnionClassExternalRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ContainerWithUnionClassExternal {
+                type Ref<'a> = ContainerWithUnionClassExternalRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionClassExternalRef<'a> {
                 #[allow(
@@ -1368,6 +1389,9 @@ pub mod tests {
                 ) -> Result<ContainerWithUnionTypeAlias, ssz::DecodeError> {
                     <ContainerWithUnionTypeAliasRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ContainerWithUnionTypeAlias {
+                type Ref<'a> = ContainerWithUnionTypeAliasRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ContainerWithUnionTypeAliasRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -220,7 +220,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for UnderlyingTypeRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -59,6 +59,10 @@ pub mod tests {
                     }
                     ssz::view::DecodeView::from_ssz_bytes(&self.bytes[1..])
                 }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
                 pub fn to_owned(&self) -> TestUnion {
                     match self.selector() {
                         0u8 => {
@@ -69,6 +73,29 @@ pub mod tests {
                         }
                         _ => panic!("Invalid union selector: {}", self.selector()),
                     }
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    Ok(
+                        match self.selector() {
+                            0u8 => {
+                                TestUnion::TypeAlias({
+                                    let view = self.as_selector0()?;
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&view)?
+                                })
+                            }
+                            other => {
+                                return Err(
+                                    ssz::DecodeError::BytesInvalid(
+                                        format!("Invalid union selector: {}", other),
+                                    ),
+                                );
+                            }
+                        },
+                    )
                 }
             }
             impl<'a> ssz::view::DecodeView<'a> for TestUnionRef<'a> {
@@ -88,6 +115,9 @@ pub mod tests {
             impl<'a> ssz_types::view::ToOwnedSsz<TestUnion> for TestUnionRef<'a> {
                 fn to_owned(&self) -> TestUnion {
                     <TestUnionRef<'a>>::to_owned(self)
+                }
+                fn try_to_owned(&self) -> Result<TestUnion, ssz::DecodeError> {
+                    <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
@@ -244,6 +274,9 @@ pub mod tests {
                 fn to_owned(&self) -> UnderlyingType {
                     <UnderlyingTypeRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<UnderlyingType, ssz::DecodeError> {
+                    <UnderlyingTypeRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnderlyingTypeRef<'a> {
@@ -252,9 +285,16 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> UnderlyingType {
-                    UnderlyingType {
-                        value: self.value().expect("valid view"),
-                    }
+                    <UnderlyingTypeRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<UnderlyingType, ssz::DecodeError> {
+                    Ok(UnderlyingType {
+                        value: self.value()?,
+                    })
                 }
             }
             pub type TypeAlias = UnderlyingType;

--- a/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_union_type_alias.rs
@@ -120,6 +120,9 @@ pub mod tests {
                     <TestUnionRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for TestUnion {
+                type Ref<'a> = TestUnionRef<'a>;
+            }
             impl<'a> tree_hash::TreeHash for TestUnionRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
                     tree_hash::TreeHashType::Vector
@@ -277,6 +280,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<UnderlyingType, ssz::DecodeError> {
                     <UnderlyingTypeRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for UnderlyingType {
+                type Ref<'a> = UnderlyingTypeRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> UnderlyingTypeRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -161,15 +161,22 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportEntry> for ExportEntryRef<'a> {
     fn to_owned(&self) -> ExportEntry {
         <ExportEntryRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+        <ExportEntryRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ExportEntry {
-        ExportEntry {
-            key: self.key().expect("valid view"),
-            value: self.value().expect("valid view"),
-        }
+        <ExportEntryRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+        Ok(ExportEntry {
+            key: self.key()?,
+            value: self.value()?,
+        })
     }
 }
 #[derive(
@@ -394,29 +401,33 @@ impl<'a> ssz_types::view::ToOwnedSsz<ViewTypeTest> for ViewTypeTestRef<'a> {
     fn to_owned(&self) -> ViewTypeTest {
         <ViewTypeTestRef<'a>>::to_owned(self)
     }
+    fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
+        <ViewTypeTestRef<'a>>::try_to_owned(self)
+    }
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ViewTypeTestRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
     pub fn to_owned(&self) -> ViewTypeTest {
-        ViewTypeTest {
-            payload: ssz_types::VariableList::new(
-                    self.payload().expect("valid view").to_owned(),
-                )
-                .expect("valid view"),
+        <ViewTypeTestRef<'a>>::try_to_owned(self).expect("valid view")
+    }
+    #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
+    pub fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
+        Ok(ViewTypeTest {
+            payload: ssz_types::VariableList::new(self.payload()?.to_owned())
+                .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?,
             entries: {
-                let view = self.entries().expect("valid view");
-                let items: Result<Vec<_>, _> = view
+                let view = self.entries()?;
+                let items = view
                     .iter()
                     .map(|item_result| {
-                        item_result
-                            .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                        ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                     })
-                    .collect();
-                let items = items.expect("valid view");
-                ssz_types::VariableList::new(items).expect("valid view")
+                    .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                ssz_types::VariableList::new(items)
+                    .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?
             },
-            hash: ssz_types::FixedBytes(self.hash().expect("valid view").to_owned()),
-        }
+            hash: ssz_types::FixedBytes(self.hash()?.to_owned()),
+        })
     }
 }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -96,7 +96,7 @@ impl<'a> ExportEntryRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")
@@ -320,7 +320,7 @@ impl<'a> ViewTypeTestRef<'a> {
 }
 impl<'a> tree_hash::TreeHash for ViewTypeTestRef<'a> {
     fn tree_hash_type() -> tree_hash::TreeHashType {
-        tree_hash::TreeHashType::StableContainer
+        tree_hash::TreeHashType::Container
     }
     fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
         unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/expected_output/test_view_types.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types.rs
@@ -165,6 +165,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ExportEntry> for ExportEntryRef<'a> {
         <ExportEntryRef<'a>>::try_to_owned(self)
     }
 }
+impl ssz_types::view::SszHasView for ExportEntry {
+    type Ref<'a> = ExportEntryRef<'a>;
+}
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ExportEntryRef<'a> {
     #[allow(clippy::wrong_self_convention, reason = "API convention for view types")]
@@ -404,6 +407,9 @@ impl<'a> ssz_types::view::ToOwnedSsz<ViewTypeTest> for ViewTypeTestRef<'a> {
     fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
         <ViewTypeTestRef<'a>>::try_to_owned(self)
     }
+}
+impl ssz_types::view::SszHasView for ViewTypeTest {
+    type Ref<'a> = ViewTypeTestRef<'a>;
 }
 #[allow(dead_code, reason = "generated code using ssz-gen")]
 impl<'a> ViewTypeTestRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -182,6 +182,9 @@ pub mod tests {
                     <ExportEntryRef<'a>>::try_to_owned(self)
                 }
             }
+            impl ssz_types::view::SszHasView for ExportEntry {
+                type Ref<'a> = ExportEntryRef<'a>;
+            }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExportEntryRef<'a> {
                 #[allow(
@@ -494,6 +497,9 @@ pub mod tests {
                 fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
                     <ViewTypeTestRef<'a>>::try_to_owned(self)
                 }
+            }
+            impl ssz_types::view::SszHasView for ViewTypeTest {
+                type Ref<'a> = ViewTypeTestRef<'a>;
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ViewTypeTestRef<'a> {

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -178,6 +178,9 @@ pub mod tests {
                 fn to_owned(&self) -> ExportEntry {
                     <ExportEntryRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+                    <ExportEntryRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ExportEntryRef<'a> {
@@ -186,10 +189,17 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ExportEntry {
-                    ExportEntry {
-                        key: self.key().expect("valid view"),
-                        value: self.value().expect("valid view"),
-                    }
+                    <ExportEntryRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ExportEntry, ssz::DecodeError> {
+                    Ok(ExportEntry {
+                        key: self.key()?,
+                        value: self.value()?,
+                    })
                 }
             }
             #[derive(
@@ -481,6 +491,9 @@ pub mod tests {
                 fn to_owned(&self) -> ViewTypeTest {
                     <ViewTypeTestRef<'a>>::to_owned(self)
                 }
+                fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
+                    <ViewTypeTestRef<'a>>::try_to_owned(self)
+                }
             }
             #[allow(dead_code, reason = "generated code using ssz-gen")]
             impl<'a> ViewTypeTestRef<'a> {
@@ -489,27 +502,33 @@ pub mod tests {
                     reason = "API convention for view types"
                 )]
                 pub fn to_owned(&self) -> ViewTypeTest {
-                    ViewTypeTest {
-                        payload: ssz_types::VariableList::new(
-                                self.payload().expect("valid view").to_owned(),
-                            )
-                            .expect("valid view"),
+                    <ViewTypeTestRef<'a>>::try_to_owned(self).expect("valid view")
+                }
+                #[allow(
+                    clippy::wrong_self_convention,
+                    reason = "API convention for view types"
+                )]
+                pub fn try_to_owned(&self) -> Result<ViewTypeTest, ssz::DecodeError> {
+                    Ok(ViewTypeTest {
+                        payload: ssz_types::VariableList::new(self.payload()?.to_owned())
+                            .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                format!("{e:?}"),
+                            ))?,
                         entries: {
-                            let view = self.entries().expect("valid view");
-                            let items: Result<Vec<_>, _> = view
+                            let view = self.entries()?;
+                            let items = view
                                 .iter()
                                 .map(|item_result| {
-                                    item_result
-                                        .map(|item| ssz_types::view::ToOwnedSsz::to_owned(&item))
+                                    ssz_types::view::ToOwnedSsz::try_to_owned(&item_result?)
                                 })
-                                .collect();
-                            let items = items.expect("valid view");
-                            ssz_types::VariableList::new(items).expect("valid view")
+                                .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+                            ssz_types::VariableList::new(items)
+                                .map_err(|e| ssz::DecodeError::BytesInvalid(
+                                    format!("{e:?}"),
+                                ))?
                         },
-                        hash: ssz_types::FixedBytes(
-                            self.hash().expect("valid view").to_owned(),
-                        ),
-                    }
+                        hash: ssz_types::FixedBytes(self.hash()?.to_owned()),
+                    })
                 }
             }
         }

--- a/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
+++ b/crates/ssz_codegen/tests/expected_output/test_view_types_check.rs
@@ -109,7 +109,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ExportEntryRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")
@@ -388,7 +388,7 @@ pub mod tests {
             }
             impl<'a> tree_hash::TreeHash for ViewTypeTestRef<'a> {
                 fn tree_hash_type() -> tree_hash::TreeHashType {
-                    tree_hash::TreeHashType::StableContainer
+                    tree_hash::TreeHashType::Container
                 }
                 fn tree_hash_packed_encoding(&self) -> tree_hash::PackedEncoding {
                     unreachable!("Container should never be packed")

--- a/crates/ssz_codegen/tests/tests.rs
+++ b/crates/ssz_codegen/tests/tests.rs
@@ -1088,15 +1088,20 @@ fn test_view_types_imports_and_to_owned() {
         "List<T, N> fields should use ListRef in view types"
     );
 
-    // Verify that list to_owned conversion builds VariableList from items
+    // Verify that list try_to_owned conversion builds VariableList from items,
+    // reporting a bound violation rather than panicking on it.
     assert!(
-        generated.contains("VariableList::new(items).expect(\"valid view\")"),
-        "ListRef to_owned conversion should build VariableList"
+        generated.contains("ssz_types::VariableList::new(items)"),
+        "ListRef try_to_owned conversion should build VariableList"
+    );
+    assert!(
+        !generated.contains("VariableList::new(items).expect(\"valid view\")"),
+        "ListRef conversion should report a bound violation, not panic"
     );
 
     // Verify that Vector[byte, N] uses FixedBytes conversion
     assert!(
-        generated.contains("FixedBytes(self.hash().expect(\"valid view\").to_owned())"),
+        generated.contains("FixedBytes(self.hash()?.to_owned())"),
         "Vector[byte, N] should convert via FixedBytes"
     );
 
@@ -2150,8 +2155,8 @@ fn test_external_container_to_owned_ssz() {
     // Verify that the generated code uses ToOwnedSsz trait method for complex types
     // This is the key change that enables custom type resolution
     assert!(
-        generated.contains("ssz_types::view::ToOwnedSsz::to_owned(&view)"),
-        "Generated to_owned() should use ToOwnedSsz trait method for complex types. Generated:\n{}",
+        generated.contains("ssz_types::view::ToOwnedSsz::try_to_owned(&view)?"),
+        "Generated try_to_owned() should use ToOwnedSsz trait method for complex types. Generated:\n{}",
         generated
     );
 
@@ -2167,8 +2172,8 @@ fn test_external_container_to_owned_ssz() {
     // and have the BlockRange conversion automatically use their custom type
     assert!(
         generated.contains("start: {")
-            && generated.contains("ssz_types::view::ToOwnedSsz::to_owned(&view)"),
-        "BlockRange.start should use trait-based to_owned for type resolution"
+            && generated.contains("ssz_types::view::ToOwnedSsz::try_to_owned(&view)?"),
+        "BlockRange.start should use trait-based try_to_owned for type resolution"
     );
 
     // Verify generated output matches expected output

--- a/crates/ssz_codegen/tests/union_view_materialization.rs
+++ b/crates/ssz_codegen/tests/union_view_materialization.rs
@@ -1,0 +1,67 @@
+//! Regression tests: union views materialize every variant shape.
+//!
+//! `test_union_edge_cases` only compares generated text against a golden, so it
+//! cannot catch a variant whose emitted conversion does not compile — which is
+//! how a `Vector[T, N]` variant went unnoticed: the generated arm materializes
+//! through `ToOwnedSsz`, which `FixedVectorRef` did not implement.
+//!
+//! These tests compile the generated fixture and exercise the variants through
+//! `try_to_owned`, which must report a malformed payload rather than panic.
+
+#![allow(dead_code)]
+#![allow(unused_crate_dependencies)]
+#![allow(missing_docs)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use ssz::{Encode, view::DecodeView};
+use ssz_derive as _;
+use ssz_primitives as _;
+use ssz_types::{FixedVector, VariableList, view::ToOwnedSsz};
+use tree_hash_derive as _;
+
+include!("expected_output/test_union_edge_cases.rs");
+
+use tests::input::test_union_edge_cases::{ComplexUnion, ComplexUnionRef};
+
+/// A `Vector[uint16, 5]` variant materializes through the trait.
+#[test]
+fn vector_variant_materializes() {
+    let owned = ComplexUnion::Selector1(
+        FixedVector::new(vec![1u16, 2, 3, 4, 5]).expect("exactly five elements"),
+    );
+    let bytes = owned.as_ssz_bytes();
+
+    let view = ComplexUnionRef::from_ssz_bytes(&bytes).expect("view borrows");
+
+    assert_eq!(
+        ToOwnedSsz::<ComplexUnion>::try_to_owned(&view).expect("materializes"),
+        owned
+    );
+}
+
+/// A `List[uint8, 10]` variant materializes through the trait.
+#[test]
+fn list_variant_materializes() {
+    let owned =
+        ComplexUnion::Selector0(VariableList::new(vec![9u8, 8, 7]).expect("within the bound"));
+    let bytes = owned.as_ssz_bytes();
+
+    let view = ComplexUnionRef::from_ssz_bytes(&bytes).expect("view borrows");
+
+    assert_eq!(
+        ToOwnedSsz::<ComplexUnion>::try_to_owned(&view).expect("materializes"),
+        owned
+    );
+}
+
+/// An out-of-range selector is reported rather than panicking.
+#[test]
+fn out_of_range_selector_is_reported() {
+    // ComplexUnion has four arms; 9 is not one of them.
+    let bytes = [9u8, 0u8];
+
+    let view = ComplexUnionRef::from_ssz_bytes(&bytes).expect("view borrows");
+
+    assert!(ToOwnedSsz::<ComplexUnion>::try_to_owned(&view).is_err());
+}

--- a/crates/ssz_types/src/view.rs
+++ b/crates/ssz_types/src/view.rs
@@ -29,7 +29,7 @@ use ssz::{
     DecodeError,
     view::{DecodeView, ListRef, SszTypeInfo, VectorRef},
 };
-use ssz_primitives::FixedBytes;
+use ssz_primitives::{FixedBytes, U128, U256};
 use tree_hash::{PackedEncoding, TreeHash, TreeHashDigest, TreeHashType};
 
 use crate::{Error, FixedVector, VariableList};
@@ -214,6 +214,76 @@ impl<'a, const N: usize> ToOwnedSsz<FixedBytes<N>> for ssz::view::FixedBytesRef<
         FixedBytes(*self.as_bytes())
     }
 }
+
+/// Lets a `Vector[byte, N]` be materialized as a plain array, which is
+/// wire-identical to [`FixedBytes<N>`] but is what hand-written types hold.
+impl<'a, const N: usize> ToOwnedSsz<[u8; N]> for ssz::view::FixedBytesRef<'a, N> {
+    fn to_owned(&self) -> [u8; N] {
+        *self.as_bytes()
+    }
+}
+
+/// Associates an owned SSZ type with its canonical borrowed view.
+///
+/// This lets generic code name the correct view type from the owned type.
+///
+/// Implemented for generated containers/unions and non-generic SSZ shapes that
+/// can appear as whole encodings: fixed-width primitives, `[u8; N]`,
+/// [`FixedBytes<N>`], `VariableList<u8, N>`, and [`BitVector<N>`](crate::BitVector).
+///
+/// Generic `VariableList<T, N>` and `FixedVector<T, N>` are omitted because byte
+/// vectors use `BytesRef`/`FixedBytesRef` while other element types use
+/// `ListRef`/`FixedVectorRef`; expressing both would need specialization.
+pub trait SszHasView: Sized {
+    /// Borrowed view for this type's SSZ encoding.
+    ///
+    /// The bounds match what generated container views require for field views.
+    type Ref<'a>: ssz::view::DecodeView<'a>
+        + ssz::view::SszTypeInfo
+        + tree_hash::TreeHash
+        + ToOwnedSsz<Self>;
+}
+
+macro_rules! impl_ssz_has_view_for_primitive {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl SszHasView for $ty {
+                type Ref<'a> = $ty;
+            }
+        )*
+    };
+}
+
+// Primitives are their own view: `DecodeView` reads them directly and the
+// `Copy` blanket supplies `ToOwnedSsz`.
+//
+// `usize` is omitted because its `Encode`/`Decode` width is target-dependent
+// while its `DecodeView`/`TreeHash` width is fixed at 8.
+impl_ssz_has_view_for_primitive!(u8, u16, u32, u64, bool, U128, U256);
+
+impl<const N: usize> SszHasView for [u8; N] {
+    type Ref<'a> = ssz::view::FixedBytesRef<'a, N>;
+}
+
+impl<const N: usize> SszHasView for FixedBytes<N> {
+    type Ref<'a> = ssz::view::FixedBytesRef<'a, N>;
+}
+
+// `List[byte, N]` views as `BytesRef` rather than `ListRef<u8>`, matching what
+// generated container getters return.
+impl<const N: usize> SszHasView for VariableList<u8, N> {
+    type Ref<'a> = ssz::view::BytesRef<'a, N>;
+}
+
+impl<const N: usize> SszHasView for crate::BitVector<N>
+where
+    [(); ssz::view::bytes_for_bits(N)]:,
+{
+    type Ref<'a> = ssz::view::BitVectorRef<'a, N>;
+}
+
+// `BitList<N>` is omitted: `BitListRef` has no `SszTypeInfo` implementation, so
+// it cannot describe its own layout to an enclosing view.
 
 impl<'a, const N: usize> ToOwnedSsz<VariableList<u8, N>> for ssz::view::BytesRef<'a, N> {
     fn to_owned(&self) -> VariableList<u8, N> {

--- a/crates/ssz_types/src/view.rs
+++ b/crates/ssz_types/src/view.rs
@@ -129,6 +129,19 @@ where
 
         VariableList::new(items)
     }
+
+    /// Converts this view to an owned list, reporting element and length-bound failures.
+    pub fn try_to_owned<T>(&self) -> Result<VariableList<T, N>, ssz::DecodeError>
+    where
+        TRef: ToOwnedSsz<T>,
+    {
+        let items = self
+            .iter()
+            .map(|item_result| ToOwnedSsz::try_to_owned(&item_result?))
+            .collect::<Result<Vec<T>, ssz::DecodeError>>()?;
+
+        VariableList::new(items).map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))
+    }
 }
 
 /// Convert a view type to its owned equivalent.
@@ -168,7 +181,20 @@ where
 ///   need a `Ref` variant.
 pub trait ToOwnedSsz<T> {
     /// Converts this view to an owned value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if materialization fails after view decoding. Prefer
+    /// [`ToOwnedSsz::try_to_owned`].
     fn to_owned(&self) -> T;
+
+    /// Fallible owned conversion.
+    ///
+    /// The default delegates to [`ToOwnedSsz::to_owned`]; override this when
+    /// materialization can fail after view decoding.
+    fn try_to_owned(&self) -> Result<T, ssz::DecodeError> {
+        Ok(self.to_owned())
+    }
 }
 
 /// Blanket implementation for all [`Copy`] types.
@@ -192,6 +218,11 @@ impl<'a, const N: usize> ToOwnedSsz<FixedBytes<N>> for ssz::view::FixedBytesRef<
 impl<'a, const N: usize> ToOwnedSsz<VariableList<u8, N>> for ssz::view::BytesRef<'a, N> {
     fn to_owned(&self) -> VariableList<u8, N> {
         VariableList::new(self.to_owned()).expect("valid view")
+    }
+
+    fn try_to_owned(&self) -> Result<VariableList<u8, N>, ssz::DecodeError> {
+        VariableList::new(self.to_owned())
+            .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))
     }
 }
 
@@ -223,6 +254,39 @@ where
             })
             .collect();
         VariableList::new(items).expect("valid view")
+    }
+
+    fn try_to_owned(&self) -> Result<VariableList<T, N>, ssz::DecodeError> {
+        let items = self
+            .iter()
+            .map(|item_result| ToOwnedSsz::try_to_owned(&item_result?))
+            .collect::<Result<Vec<T>, ssz::DecodeError>>()?;
+        VariableList::new(items).map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))
+    }
+}
+
+/// Allows generated conversions to materialize `Vector[T, N]` through `ToOwnedSsz`.
+impl<'a, TRef, T, const N: usize> ToOwnedSsz<FixedVector<T, N>> for FixedVectorRef<'a, TRef, N>
+where
+    TRef: DecodeView<'a> + SszTypeInfo + ToOwnedSsz<T>,
+{
+    fn to_owned(&self) -> FixedVector<T, N> {
+        let items: Vec<T> = self
+            .iter()
+            .map(|item_result| {
+                let item = item_result.expect("valid view");
+                ToOwnedSsz::to_owned(&item)
+            })
+            .collect();
+        FixedVector::new(items).expect("valid view")
+    }
+
+    fn try_to_owned(&self) -> Result<FixedVector<T, N>, ssz::DecodeError> {
+        let items = self
+            .iter()
+            .map(|item_result| ToOwnedSsz::try_to_owned(&item_result?))
+            .collect::<Result<Vec<T>, ssz::DecodeError>>()?;
+        FixedVector::new(items).map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))
     }
 }
 
@@ -330,6 +394,19 @@ where
         let items = items.map_err(|_| Error::OutOfBounds { i: 0, len: N })?;
 
         FixedVector::new(items)
+    }
+
+    /// Converts this view to an owned vector, reporting element and length-bound failures.
+    pub fn try_to_owned<T>(&self) -> Result<FixedVector<T, N>, ssz::DecodeError>
+    where
+        TRef: ToOwnedSsz<T>,
+    {
+        let items = self
+            .iter()
+            .map(|item_result| ToOwnedSsz::try_to_owned(&item_result?))
+            .collect::<Result<Vec<T>, ssz::DecodeError>>()?;
+
+        FixedVector::new(items).map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))
     }
 }
 


### PR DESCRIPTION
## Description

Improves generated SSZ view support and fixes view metadata:

- Makes generated view materialization fallible via `try_to_owned`, so getter, element decode, and owned-conversion failures are returned instead of panicking.
- Adds `SszHasView`, linking owned SSZ types to their canonical borrowed views, and emits those impls for generated containers and unions.
- Corrects generated view `TreeHashType` tags so container views report `Container` and profile views report `StableContainer`.

It also adds the supporting `ToOwnedSsz` impls.

This PR is created with help from Claude and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This should make [`strata-common#152`](https://github.com/alpenlabs/strata-common/pull/152) cleaner.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
