### PR TITLE
chore(cargo): enforce 14-day min-publish-age for crates.io deps

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,9 @@ min-publish-age = true
 
 [registry]
 global-min-publish-age = "14 days"
+
+# Reject too-new versions even when a user-level cargo config sets "allow".
+# The CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE environment variable still
+# overrides this for one-off updates.
+[resolver]
+incompatible-publish-age = "deny"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Cooldown for crates.io dependencies (RFC 3923, `min-publish-age`).
+# Versions published less than 14 days ago are not selected by the resolver
+# unless they are already in `Cargo.lock`. Matches the Dependabot cooldown.
+# Urgent override for a single resolve:
+#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update -p <crate>
+
+# Stable cargo ignores this table. Nightly cargo needs it until the feature
+# is stable (Rust 1.100, 2026-11-12); remove it once the toolchain has it.
+[unstable]
+min-publish-age = true
+
+[registry]
+global-min-publish-age = "14 days"


### PR DESCRIPTION
## Description

Adds a 14-day cooldown for crates.io dependencies through Cargo's new `min-publish-age` setting (RFC 3923), in a root `.cargo/config.toml`:

```toml
[unstable]
min-publish-age = true

[registry]
global-min-publish-age = "14 days"
```

Dependabot already waits 14 days before proposing a bump. This makes plain `cargo add`, `cargo update`, and hand-edited version requirements follow the same rule, so a freshly published (and possibly compromised) release can't slip in through a developer's PR. Versions already in `Cargo.lock` are left alone. For an urgent fix there is a one-off escape hatch:

```
CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update -p <crate>
```

This repo pins a nightly that already has the feature, so the cooldown is active right away for anyone building with the repo toolchain.

Tracking: STR-3852.

Update: a follow-up commit also sets `[resolver] incompatible-publish-age = "deny"`. That is cargo's default, but spelling it out in the repo config means a developer with `allow` in their user-level `~/.cargo/config.toml` no longer switches the cooldown off here. The `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` escape hatch still works, since environment variables take precedence over both. Robin's suggestion from the Slack thread.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

One gap worth knowing about: versions already in `Cargo.lock` are exempt by design, so a lockfile produced with the override still passes `cargo build --locked` in CI. If we want CI to catch that, `cargo update --dry-run` prints a `Downgrading` line for every locked version that violates the policy and can be turned into a check. That is out of scope for this PR.

The `[unstable]` table is temporary. Stable cargo ignores it, and nightly cargo needs it until the feature reaches stable in Rust 1.100 (2026-11-12). After that it can be dropped.

Verified locally with `cargo update --dry-run --workspace`:

```
Locking 0 packages to latest compatible versions
note: pass `--verbose` to see 59 unchanged dependencies behind latest
warning: not updating lockfile due to dry run
- No `Downgrading` lines.
```

AI disclosure: the change and this PR body were produced with Claude Code and Codex, then reviewed and tested by me.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://rust-lang.github.io/rfcs/3923-cargo-min-publish-age.html
- https://github.com/rust-lang/cargo/pull/17335

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3852

